### PR TITLE
Improve error handling and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+
+All notable changes to Easy-EO are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the project is pre-1.0, breaking changes may occur in minor releases and
+are called out under a **Breaking** heading.
+
+## [Unreleased]
+
+### Breaking
+
+- **Default values corrected to conventional choices.**
+  - `normalize_percentile` now defaults to `lower_percentile=2`,
+    `upper_percentile=98` (previously `0.0` / `1.0`). Callers relying on the
+    old defaults will get different output; pass the values explicitly to
+    reproduce the previous behaviour.
+  - `resample` now defaults to `resampling_method="nearest"` (previously
+    `"bilinear"`), matching `reproject_raster` and avoiding blending of
+    categorical values and nodata edges. Pass `resampling_method="bilinear"`
+    to restore the old default.
+- **Operations now raise the Easy-EO exception hierarchy** instead of bare
+  built-ins. Most raises keep a built-in base for backward compatibility, so
+  `except ValueError` (validation, CRS, alignment) and `except RuntimeError`
+  (`BackendError`) keep working. The exceptions are a few conditions that
+  previously raised `TypeError` and now raise a hierarchy member that is *not*
+  a `TypeError`:
+  - Backend guards (a rasterio-only op on a NumPy-backed dataset) now raise
+    `BackendError` (a `RuntimeError`) instead of `TypeError`.
+  - Invalid-type inputs — a non-array to `load_array`, an invalid `target_crs`
+    type to `reproject_raster`, an invalid `vector_file` to
+    `clip_raster_with_vector`, an invalid resampling method — now raise
+    `ValidationError` (a `ValueError`) instead of `TypeError`.
+
+### Added
+
+- **Custom exception hierarchy** in `eeo.core.exceptions`, exported from the
+  top-level package: `EEOError` (base), `ValidationError`, `CRSMismatchError`,
+  `AlignmentError`, and `BackendError`. Catch `EEOError` to handle any
+  Easy-EO-specific failure. Actionable error messages now state the expected
+  versus received value.
+- `eeo.show_versions()` — prints an environment report (Easy-EO, Python,
+  rasterio, GDAL, numpy, geopandas, matplotlib, and installed extras) for bug
+  reports.
+- PEP 561 typing support: a `py.typed` marker and a generated
+  `eeo/core/core.pyi` that exposes the dynamically-bound operation methods to
+  type checkers, both shipped in the wheel.
+- A `dev` optional-dependencies extra (`pip install easy-eo[dev]`) bundling
+  pytest, pytest-cov, ruff, mypy, and pre-commit.
+
+### Changed
+
+- **Loosened runtime dependency bounds** to library-appropriate ranges:
+  `rasterio>=1.4,<2`, `geopandas>=1.1,<2`, `numpy>=1.26,<3`, `matplotlib>=3.8`
+  (previously over-tight caps such as a single matplotlib minor).
+- Public docstrings rewritten to a single NumPy-style template, enforced in CI
+  via ruff pydocstyle rules and numpydoc validation.
+- Consolidated per-module `.pyi` stubs into inline annotations plus the single
+  generated `core.pyi`.
+
+### Removed
+
+- Per-module `.pyi` stub files, superseded by inline type annotations and the
+  `py.typed` marker.
+
+### Fixed
+
+- **Backend detection for chained operations.** `clip_raster_with_bbox`,
+  `clip_raster_with_vector`, `mosaic`, `stack`, and `reproject_raster` no
+  longer reject genuinely rasterio-backed datasets produced by a previous
+  operation (e.g. `ds.add(1).clip_raster_with_bbox(...)`).
+- `mosaic(..., save_path=...)` via the bound method now returns `None` as
+  documented when writing to disk, instead of returning the source dataset.
+- `mosaic(..., auto_reproject=True)` across rasters in different CRSs now
+  works; it previously raised `TypeError` and the feature never functioned.
+- `resample` now surfaces an invalid `resampling_method` as `ValidationError`
+  rather than masking it inside a backend failure.
+- `clip_raster_with_bbox` raises a clear `ValidationError` when the bounding
+  box does not intersect the raster, instead of a cryptic rasterio
+  "0x0 dataset" error.
+- rasterio 1.4 compatibility: `extract_value_at_coordinate` coerces the
+  `index()` row/col to `int` before indexing.
+- Documentation: fixed invalid multi-line chained examples (missing
+  parentheses), normalized branding to Easy-EO / easy-eo / eeo, and resolved
+  signature/stub/docs mismatches across the API.
+
+## [0.1.0b1] - 2025-12-24
+
+Initial public beta release.
+
+### Added
+
+- `EEORasterDataset`, the chainable raster dataset, with rasterio- and
+  NumPy-backed adapters behind a common backend interface.
+- Loaders: `load_raster` (from a file) and `load_array` (from a NumPy array).
+- Raster algebra: `add`, `subtract`, `multiply`, `divide`, `power`, `sqrt`,
+  `log`, `absolute`, with operator overloading.
+- Analysis: `normalized_difference` (NDVI/NDWI-family) and per-pixel
+  statistics (`get_maximum_pixel`, `get_minimum_pixel`, `get_mean_pixel`,
+  `get_percentile_pixel`, `extract_value_at_coordinate`).
+- Preprocessing: `clip_raster_with_bbox`, `clip_raster_with_vector`,
+  `resample`, `reproject_raster`, `normalize_min_max`, `normalize_percentile`,
+  `standardize`.
+- Merging: `mosaic` and `stack`.
+- Visualization: `plot_raster`, `plot_composite`,
+  `plot_raster_with_histogram`, `plot_band_array`.
+
+[Unreleased]: https://github.com/Tommy-Burns/easy-eo/compare/v0.1.0b1...HEAD
+[0.1.0b1]: https://github.com/Tommy-Burns/easy-eo/releases/tag/v0.1.0b1

--- a/docs/source/modules/core.rst
+++ b/docs/source/modules/core.rst
@@ -5,8 +5,43 @@ Core Module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: EEOError, ValidationError, CRSMismatchError, AlignmentError, BackendError
 
 Utilities
 ---------
 
 .. autofunction:: eeo.show_versions
+
+Exceptions
+----------
+
+Easy-EO raises a small hierarchy of exceptions so you can catch precisely what
+you need. Every library-specific error derives from :class:`~eeo.EEOError`, so a
+single ``except`` clause handles any of them while letting unrelated errors
+propagate:
+
+.. code-block:: python
+
+    import eeo
+
+    try:
+        ds = eeo.load_raster("scene.tif")
+        result = ds.normalized_difference(other, auto_align=False)
+    except eeo.AlignmentError as err:
+        # rasters were not on the same grid
+        print(err)
+    except eeo.EEOError as err:
+        # any other Easy-EO failure
+        print(err)
+
+For backward compatibility, each subclass also derives from the built-in
+exception it historically replaced: :class:`~eeo.ValidationError`,
+:class:`~eeo.CRSMismatchError`, and :class:`~eeo.AlignmentError` are
+``ValueError``\ s, and :class:`~eeo.BackendError` is a ``RuntimeError``. Two
+failure modes intentionally keep their standard-library exceptions rather than
+joining the hierarchy: a missing raster file raises ``FileNotFoundError``, and
+an out-of-range band index raises ``IndexError``.
+
+.. automodule:: eeo.core.exceptions
+    :members:
+    :show-inheritance:

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -6,7 +6,15 @@ visualization built on rasterio, NumPy, GeoPandas, and matplotlib.
 
 from ._show_versions import show_versions
 from .analysis import *
-from .core import load_array, load_raster
+from .core import (
+    AlignmentError,
+    BackendError,
+    CRSMismatchError,
+    EEOError,
+    ValidationError,
+    load_array,
+    load_raster,
+)
 from .core.adapters import *
 from .ops import *
 from .preprocessing import *
@@ -16,6 +24,11 @@ __all__ = [
     "load_raster",
     "load_array",
     "show_versions",
+    "EEOError",
+    "ValidationError",
+    "CRSMismatchError",
+    "AlignmentError",
+    "BackendError",
 ]
 
 __version__ = "0.1.0b1"

--- a/eeo/analysis/indices.py
+++ b/eeo/analysis/indices.py
@@ -11,6 +11,7 @@ import rasterio as rio
 from eeo.common import align_raster_to_target
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import AlignmentError
 
 
 @eeo_raster_op
@@ -37,7 +38,7 @@ def normalized_difference(
         Second operand (e.g. Red for NDVI).
     auto_align : bool, default True
         If True, resample ``other`` onto ``ds``'s grid when their shape or
-        transform differ. If False, a mismatch raises ``ValueError``.
+        transform differ. If False, a mismatch raises ``AlignmentError``.
     method : str, default "bilinear"
         Resampling method used when ``auto_align`` triggers alignment; one of
         rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
@@ -55,7 +56,7 @@ def normalized_difference(
 
     Raises
     ------
-    ValueError
+    AlignmentError
         If the two rasters are on different grids and ``auto_align`` is False.
 
     Notes
@@ -77,7 +78,11 @@ def normalized_difference(
         if auto_align:
             other = align_raster_to_target(other, ds, method=method)
         else:
-            raise ValueError("Rasters must have the same shape and alignment")
+            raise AlignmentError(
+                "rasters must share the same grid for this operation; "
+                f"got shape {other.get_shape()} vs {ds.get_shape()}. "
+                "Pass auto_align=True to resample the other raster onto this grid."
+            )
 
     a = ds.read().astype(rio.float32)
     b = other.read().astype(rio.float32)

--- a/eeo/analysis/stats.py
+++ b/eeo/analysis/stats.py
@@ -6,6 +6,7 @@ import rasterio as rio
 from eeo.common import mask_nodata
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import ValidationError
 
 Coordinate = tuple[float, float] | list[float]
 
@@ -35,7 +36,7 @@ def extract_value_at_coordinate(
 
     Raises
     ------
-    ValueError
+    ValidationError
         If ``coordinates`` does not contain exactly two values.
 
     Notes
@@ -48,7 +49,9 @@ def extract_value_at_coordinate(
     >>> value = ds.extract_value_at_coordinate((500000.0, 4200000.0))
     """
     if len(coordinates) != 2:
-        raise ValueError(f"Expected 2 coordinates, got {len(coordinates)}")
+        raise ValidationError(
+            f"coordinates must contain exactly 2 values (x, y); got {len(coordinates)}"
+        )
 
     backend = ds._adapter.backend
     if not isinstance(backend, rio.DatasetReader):

--- a/eeo/common.py
+++ b/eeo/common.py
@@ -43,6 +43,9 @@ def is_rasterio_backed(ds: EEORasterDataset) -> bool:
 
 def normalize_resampling_method(value):
     """Normalize a resampling method to a ``rasterio.enums.Resampling`` value."""
+
+    from eeo.core.exceptions import ValidationError
+
     if isinstance(value, Resampling):
         return value
     if isinstance(value, str):
@@ -51,8 +54,12 @@ def normalize_resampling_method(value):
             return Resampling[name]
         except KeyError as e:
             valid = ", ".join([r.name for r in Resampling])
-            raise ValueError(f"Invalid resampling method {value}. Valid values are: {valid}") from e
-    raise TypeError("resampling method must be one from rasterio.enums.Resampling or a string")
+            raise ValidationError(
+                f"invalid resampling method {value!r}; expected one of: {valid}"
+            ) from e
+    raise ValidationError(
+        f"resampling method must be a str or rasterio.enums.Resampling; got {type(value).__name__}"
+    )
 
 
 # Helper function for raster auto-alignment

--- a/eeo/common.py
+++ b/eeo/common.py
@@ -43,7 +43,6 @@ def is_rasterio_backed(ds: EEORasterDataset) -> bool:
 
 def normalize_resampling_method(value):
     """Normalize a resampling method to a ``rasterio.enums.Resampling`` value."""
-
     from eeo.core.exceptions import ValidationError
 
     if isinstance(value, Resampling):

--- a/eeo/core/__init__.py
+++ b/eeo/core/__init__.py
@@ -1,6 +1,13 @@
 """Core dataset class, loaders, decorators, and backend adapters."""
 
 from .core import EEORasterDataset
+from .exceptions import (
+    AlignmentError,
+    BackendError,
+    CRSMismatchError,
+    EEOError,
+    ValidationError,
+)
 from .loader import load_array, load_raster
 from .plugins import load_ops
 
@@ -10,4 +17,9 @@ __all__ = [
     "EEORasterDataset",
     "load_raster",
     "load_array",
+    "EEOError",
+    "ValidationError",
+    "CRSMismatchError",
+    "AlignmentError",
+    "BackendError",
 ]

--- a/eeo/core/adapters/numpy.py
+++ b/eeo/core/adapters/numpy.py
@@ -78,7 +78,10 @@ class NumpyRasterioAdapter(BaseRasterAdapter):
 
     def read_band(self, idx: int) -> np.ndarray:
         if idx < 1 or idx > self.get_count():
-            raise IndexError(f"Band index {idx} out of range")
+            raise IndexError(
+                f"band index {idx} out of range; dataset has {self.get_count()} "
+                f"band(s) (valid 1..{self.get_count()})"
+            )
         return self._array[idx - 1]
 
     # ========================

--- a/eeo/core/adapters/rasterio.py
+++ b/eeo/core/adapters/rasterio.py
@@ -6,6 +6,8 @@ import numpy as np
 import rasterio as rio
 from rasterio.io import DatasetReader, MemoryFile
 
+from eeo.core.exceptions import BackendError
+
 from .base import BaseRasterAdapter
 
 
@@ -29,7 +31,7 @@ class RasterioAdapter(BaseRasterAdapter):
         try:
             dataset = rio.open(path)
         except Exception as e:
-            raise RuntimeError(f"Failed to open raster: {path}") from e
+            raise BackendError(f"failed to open raster: {path}") from e
         return cls(dataset)
 
     @classmethod
@@ -99,7 +101,10 @@ class RasterioAdapter(BaseRasterAdapter):
 
     def read_band(self, idx: int) -> np.ndarray:
         if idx < 1 or idx > self._ds.count:
-            raise IndexError(f"Band index {idx} out of range")
+            raise IndexError(
+                f"band index {idx} out of range; dataset has {self._ds.count} "
+                f"band(s) (valid 1..{self._ds.count})"
+            )
         return self._ds.read(idx)
 
     # ========================

--- a/eeo/core/exceptions.py
+++ b/eeo/core/exceptions.py
@@ -1,0 +1,53 @@
+"""Custom exception hierarchy for Easy-EO.
+
+Every error Easy-EO raises for its own failure modes derives from
+:class:`EEOError`, so callers can catch any library-specific problem with a
+single ``except EEOError`` while letting unrelated exceptions propagate. Each
+subclass additionally derives from the built-in exception it historically
+replaced (``ValueError`` or ``RuntimeError``), so existing
+``except ValueError`` / ``except RuntimeError`` handlers keep working.
+
+Two failure modes intentionally keep their standard-library exceptions rather
+than joining this hierarchy, because remapping them would break universal
+Python idioms: a missing raster file raises :class:`FileNotFoundError`, and an
+out-of-range band index raises :class:`IndexError`.
+"""
+
+
+class EEOError(Exception):
+    """Base class for every error raised by Easy-EO."""
+
+
+class ValidationError(EEOError, ValueError):
+    """Raised when a function receives invalid or malformed input.
+
+    Covers out-of-range parameters, wrong argument types, and malformed
+    arrays or coordinates. Subclasses :class:`ValueError` for backward
+    compatibility.
+    """
+
+
+class CRSMismatchError(EEOError, ValueError):
+    """Raised when rasters have incompatible coordinate reference systems.
+
+    Subclasses :class:`ValueError` for backward compatibility.
+    """
+
+
+class AlignmentError(EEOError, ValueError):
+    """Raised when rasters are not aligned on the same pixel grid.
+
+    Signals a mismatch in shape and/or affine transform between rasters that an
+    operation requires to share a grid. Subclasses :class:`ValueError` for
+    backward compatibility.
+    """
+
+
+class BackendError(EEOError, RuntimeError):
+    """Raised for backend problems: an unsupported op or a failed read/open.
+
+    Raised when an operation is not supported by the dataset's active backend
+    (for example, a rasterio-only op called on a NumPy-backed dataset), or when
+    a backend fails to open, read, or transform data. Subclasses
+    :class:`RuntimeError` for backward compatibility.
+    """

--- a/eeo/core/loader.py
+++ b/eeo/core/loader.py
@@ -9,6 +9,7 @@ from rasterio.crs import CRS
 from rasterio.transform import Affine
 
 from eeo.core.core import EEORasterDataset
+from eeo.core.exceptions import BackendError, ValidationError
 
 
 def load_raster(path: str) -> EEORasterDataset:
@@ -31,7 +32,7 @@ def load_raster(path: str) -> EEORasterDataset:
     ------
     FileNotFoundError
         If ``path`` does not exist.
-    RuntimeError
+    BackendError
         If the file exists but cannot be opened as a raster.
 
     Examples
@@ -39,11 +40,11 @@ def load_raster(path: str) -> EEORasterDataset:
     >>> ds = load_raster("scene.tif")
     """
     if not os.path.isfile(path):
-        raise FileNotFoundError(f'The file "{path}" does not exist')
+        raise FileNotFoundError(f'the file "{path}" does not exist')
     try:
         return EEORasterDataset.from_path(path)
     except Exception as e:
-        raise RuntimeError(f'File "{path}" could not be opened as a rasterio dataset') from e
+        raise BackendError(f'file "{path}" could not be opened as a rasterio dataset') from e
 
 
 def load_array(
@@ -78,10 +79,8 @@ def load_array(
 
     Raises
     ------
-    TypeError
-        If ``array`` is not a NumPy array.
-    ValueError
-        If ``array`` is neither 2D nor 3D.
+    ValidationError
+        If ``array`` is not a NumPy array, or is neither 2D nor 3D.
 
     Examples
     --------
@@ -89,9 +88,12 @@ def load_array(
     >>> ds = load_array(np.zeros((64, 64), dtype="float32"), crs=4326)
     """
     if not isinstance(array, np.ndarray):
-        raise TypeError("The array must be a numpy array")
+        raise ValidationError(f"array must be a NumPy ndarray; got {type(array).__name__}")
 
     if array.ndim not in (2, 3):
-        raise ValueError("The array must be 2D or 3D (bands, height, width)")
+        raise ValidationError(
+            "array must be 2D (height, width) or 3D (bands, height, width); "
+            f"got {array.ndim}D with shape {array.shape}"
+        )
 
     return EEORasterDataset.from_array(array=array, transform=transform, crs=crs, nodata=nodata)

--- a/eeo/ops/algebra.py
+++ b/eeo/ops/algebra.py
@@ -6,6 +6,7 @@ import rasterio as rio
 from eeo.common import align_raster_to_target
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import AlignmentError
 
 
 # ARITHMETIC AND ALGEBRA
@@ -32,7 +33,7 @@ def add(
         every pixel.
     auto_align : bool, default True
         If True, resample ``other`` onto ``ds``'s grid when their shape or
-        transform differ. If False, a mismatch raises ``ValueError``.
+        transform differ. If False, a mismatch raises ``AlignmentError``.
     method : str, default "bilinear"
         Resampling method used when ``auto_align`` triggers alignment; one of
         rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
@@ -47,7 +48,7 @@ def add(
 
     Raises
     ------
-    ValueError
+    AlignmentError
         If ``other`` is a dataset on a different grid and ``auto_align`` is
         False.
 
@@ -68,8 +69,10 @@ def add(
             if auto_align:
                 other = align_raster_to_target(other, ds, method=method)
             else:
-                raise ValueError(
-                    "Rasters must have the same shape and alignment for arithmetic operations"
+                raise AlignmentError(
+                    "rasters must share the same grid for arithmetic; "
+                    f"got shape {other.get_shape()} vs {ds.get_shape()}. "
+                    "Pass auto_align=True to resample the other raster onto this grid."
                 )
         data = ds.read() + other.read()
     else:
@@ -105,7 +108,7 @@ def subtract(
         a scalar is subtracted from every pixel.
     auto_align : bool, default True
         If True, resample ``other`` onto ``ds``'s grid when their shape or
-        transform differ. If False, a mismatch raises ``ValueError``.
+        transform differ. If False, a mismatch raises ``AlignmentError``.
     method : str, default "bilinear"
         Resampling method used when ``auto_align`` triggers alignment; one of
         rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
@@ -120,7 +123,7 @@ def subtract(
 
     Raises
     ------
-    ValueError
+    AlignmentError
         If ``other`` is a dataset on a different grid and ``auto_align`` is
         False.
 
@@ -140,8 +143,10 @@ def subtract(
             if auto_align:
                 other = align_raster_to_target(other, ds, method=method)
             else:
-                raise ValueError(
-                    "Rasters must have the same shape and alignment for arithmetic operations"
+                raise AlignmentError(
+                    "rasters must share the same grid for arithmetic; "
+                    f"got shape {other.get_shape()} vs {ds.get_shape()}. "
+                    "Pass auto_align=True to resample the other raster onto this grid."
                 )
         data = ds.read() - other.read()
     else:
@@ -176,7 +181,7 @@ def multiply(
         every pixel.
     auto_align : bool, default True
         If True, resample ``other`` onto ``ds``'s grid when their shape or
-        transform differ. If False, a mismatch raises ``ValueError``.
+        transform differ. If False, a mismatch raises ``AlignmentError``.
     method : str, default "bilinear"
         Resampling method used when ``auto_align`` triggers alignment; one of
         rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
@@ -191,7 +196,7 @@ def multiply(
 
     Raises
     ------
-    ValueError
+    AlignmentError
         If ``other`` is a dataset on a different grid and ``auto_align`` is
         False.
 
@@ -211,8 +216,10 @@ def multiply(
             if auto_align:
                 other = align_raster_to_target(other, ds, method=method)
             else:
-                raise ValueError(
-                    "Rasters must have the same shape and alignment for arithmetic operations"
+                raise AlignmentError(
+                    "rasters must share the same grid for arithmetic; "
+                    f"got shape {other.get_shape()} vs {ds.get_shape()}. "
+                    "Pass auto_align=True to resample the other raster onto this grid."
                 )
 
         data = ds.read() * other.read()
@@ -249,7 +256,7 @@ def divide(
         pixel.
     auto_align : bool, default True
         If True, resample ``other`` onto ``ds``'s grid when their shape or
-        transform differ. If False, a mismatch raises ``ValueError``.
+        transform differ. If False, a mismatch raises ``AlignmentError``.
     method : str, default "bilinear"
         Resampling method used when ``auto_align`` triggers alignment; one of
         rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
@@ -268,7 +275,7 @@ def divide(
 
     Raises
     ------
-    ValueError
+    AlignmentError
         If ``other`` is a dataset on a different grid and ``auto_align`` is
         False.
 
@@ -292,8 +299,10 @@ def divide(
             if auto_align:
                 other = align_raster_to_target(other, ds, method=method)
             else:
-                raise ValueError(
-                    "Rasters must have the same shape and alignment for arithmetic operations"
+                raise AlignmentError(
+                    "rasters must share the same grid for arithmetic; "
+                    f"got shape {other.get_shape()} vs {ds.get_shape()}. "
+                    "Pass auto_align=True to resample the other raster onto this grid."
                 )
         other_data: np.ndarray | float | int = other.read()
     else:

--- a/eeo/ops/merge.py
+++ b/eeo/ops/merge.py
@@ -9,6 +9,12 @@ from rasterio.merge import merge
 from eeo.common import is_rasterio_backed, normalize_resampling_method
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import (
+    AlignmentError,
+    BackendError,
+    CRSMismatchError,
+    ValidationError,
+)
 
 
 @eeo_raster_op(preserve_none=True)
@@ -38,7 +44,7 @@ def mosaic(
     auto_reproject : bool, default False
         If True, reproject any raster in ``others`` whose CRS differs from
         ``ds`` before mosaicking. If False, a CRS mismatch raises
-        ``ValueError``.
+        ``CRSMismatchError``.
     **kwargs
         Additional keyword arguments forwarded to ``rasterio.merge.merge``.
 
@@ -52,11 +58,12 @@ def mosaic(
 
     Raises
     ------
-    TypeError
+    BackendError
         If ``ds`` is not backed by rasterio.
-    ValueError
-        If ``others`` is empty, or a CRS mismatch is found and
-        ``auto_reproject=False``.
+    ValidationError
+        If ``others`` is empty.
+    CRSMismatchError
+        If a CRS mismatch is found and ``auto_reproject=False``.
 
     Notes
     -----
@@ -70,7 +77,10 @@ def mosaic(
     """
     # Ensure mosaic for only rasterio-backend datasets
     if not is_rasterio_backed(ds):
-        raise TypeError("Mosaicking is only allowed on rasterio backend rasters")
+        raise BackendError(
+            "mosaic requires a rasterio-backed dataset; this dataset uses the "
+            "NumPy backend. Call .to_rasterio() first."
+        )
 
     # normalize resampling
     resampling_method = normalize_resampling_method(resampling_method)
@@ -79,7 +89,7 @@ def mosaic(
     others = [others] if isinstance(others, EEORasterDataset) else list(others)
 
     if not others:
-        raise ValueError("At least one raster must be provided for mosaicking")
+        raise ValidationError("provide at least one raster to mosaic with; got an empty 'others'")
 
     # CRS validation
     src_datasets: list[EEORasterDataset] = [ds]
@@ -91,9 +101,10 @@ def mosaic(
                 # keyword-only target_crs as int/str/pyproj.CRS, so WKT is passed here rather.
                 obj = obj.reproject_raster(target_crs=target_crs.to_wkt())
             else:
-                raise ValueError(
-                    "All rasters must have the same CRS for mosaicking. "
-                    "Set auto_reproject=True to allow reprojection."
+                raise CRSMismatchError(
+                    "all rasters must share the CRS for mosaicking; "
+                    f"got {obj.get_crs()} vs {target_crs}. "
+                    "Set auto_reproject=True to reproject automatically."
                 )
 
         src_datasets.append(obj)
@@ -155,11 +166,14 @@ def stack(
 
     Raises
     ------
-    TypeError
+    BackendError
         If ``ds`` is not backed by rasterio.
-    ValueError
-        If ``others`` is empty, or any input's CRS, transform, or shape
-        differs from ``ds``.
+    ValidationError
+        If ``others`` is empty.
+    CRSMismatchError
+        If any input's CRS differs from ``ds``.
+    AlignmentError
+        If any input's transform or shape differs from ``ds``.
 
     Notes
     -----
@@ -173,22 +187,28 @@ def stack(
     """
     # Ensure stack for only rasterio-backend datasets
     if not is_rasterio_backed(ds):
-        raise TypeError("Stacking is only allowed on rasterio backend rasters")
+        raise BackendError(
+            "stack requires a rasterio-backed dataset; this dataset uses the "
+            "NumPy backend. Call .to_rasterio() first."
+        )
 
     # normalize inputs
     others = [others] if isinstance(others, EEORasterDataset) else list(others)
 
     if not others:
-        raise ValueError("At least one raster must be provided for stacking")
+        raise ValidationError("provide at least one raster to stack; got an empty 'others'")
 
     # alignment checks
     for item in others:
-        if (
-            item.get_crs() != ds.get_crs()
-            or item.get_transform() != ds.get_transform()
-            or item.get_shape() != ds.get_shape()
-        ):
-            raise ValueError("All rasters must have identical CRS, transform, and shape")
+        if item.get_crs() != ds.get_crs():
+            raise CRSMismatchError(
+                f"all rasters must share the CRS to stack; got {item.get_crs()} vs {ds.get_crs()}"
+            )
+        if item.get_transform() != ds.get_transform() or item.get_shape() != ds.get_shape():
+            raise AlignmentError(
+                "all rasters must share the transform and shape to stack; "
+                f"got shape {item.get_shape()} vs {ds.get_shape()}"
+            )
 
     # read data
     arrays = [ds.read()]

--- a/eeo/preprocessing/clip.py
+++ b/eeo/preprocessing/clip.py
@@ -10,6 +10,7 @@ from rasterio.windows import from_bounds
 from eeo.common import is_rasterio_backed
 from eeo.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import BackendError, ValidationError
 
 
 @eeo_raster_op
@@ -66,9 +67,10 @@ def clip_raster_with_vector(
 
     Raises
     ------
-    TypeError
-        If ``ds`` is not backed by rasterio, or ``vector_file`` is neither a
-        GeoDataFrame nor a valid file path.
+    BackendError
+        If ``ds`` is not backed by rasterio.
+    ValidationError
+        If ``vector_file`` is neither a GeoDataFrame nor a valid file path.
 
     Notes
     -----
@@ -82,7 +84,10 @@ def clip_raster_with_vector(
     """
     # Ensure clipping for only rasterio-backend datasets
     if not is_rasterio_backed(ds):
-        raise TypeError("Clipping is only allowed on rasterio backend rasters")
+        raise BackendError(
+            "clip requires a rasterio-backed dataset; this dataset uses the "
+            "NumPy backend. Call .to_rasterio() first."
+        )
 
     # Load vector data
     if isinstance(vector_file, gpd.GeoDataFrame):
@@ -90,7 +95,10 @@ def clip_raster_with_vector(
     elif isinstance(vector_file, str) and os.path.isfile(vector_file):
         gdf = gpd.read_file(vector_file)
     else:
-        raise TypeError("vector_file must be a GeoDataFrame or a valid file path")
+        raise ValidationError(
+            "vector_file must be a GeoDataFrame or a path to an existing vector "
+            f"file; got {vector_file!r}"
+        )
 
     # Reproject vector geometries if needed
     if gdf.crs != ds.get_crs():
@@ -160,9 +168,9 @@ def clip_raster_with_bbox(
 
     Raises
     ------
-    TypeError
+    BackendError
         If ``ds`` is not backed by rasterio.
-    ValueError
+    ValidationError
         If ``bbox`` is not four values, or does not intersect the raster.
 
     Notes
@@ -175,11 +183,14 @@ def clip_raster_with_bbox(
     """
     # Ensure rasterio backend
     if not is_rasterio_backed(ds):
-        raise TypeError("Clipping is only allowed on rasterio backend rasters")
+        raise BackendError(
+            "clip requires a rasterio-backed dataset; this dataset uses the "
+            "NumPy backend. Call .to_rasterio() first."
+        )
 
     # Validate bbox
     if not (isinstance(bbox, (tuple, list)) and len(bbox) == 4):
-        raise ValueError("bbox must be (minx, miny, maxx, maxy)")
+        raise ValidationError(f"bbox must be (minx, miny, maxx, maxy) — 4 values; got {bbox!r}")
 
     minx, miny, maxx, maxy = bbox
 
@@ -187,11 +198,19 @@ def clip_raster_with_bbox(
     window = from_bounds(minx, miny, maxx, maxy, ds.ds.transform)
     window = window.round_offsets().round_lengths()
 
-    # Ensure correct bbox
-    if window.width <= 0 or window.height <= 0:
-        raise ValueError(
-            "Bounding box does not intersect raster extent. "
-            f"Raster bounds: {ds.get_bounds()}, bbox: {bbox}"
+    # Ensure the bbox actually overlaps the raster. A degenerate box collapses
+    # to zero width/height here; a box that lies entirely outside keeps a
+    # positive size but does not intersect the raster window, and would
+    # otherwise fail later with a cryptic "0x0 dataset" read error.
+    raster_window = rio.windows.Window(0, 0, ds.ds.width, ds.ds.height)
+    if (
+        window.width <= 0
+        or window.height <= 0
+        or not rio.windows.intersect([window, raster_window])
+    ):
+        raise ValidationError(
+            "bounding box does not intersect raster extent; "
+            f"raster bounds: {ds.get_bounds()}, bbox: {bbox}"
         )
 
     transform = rio.windows.transform(window, ds.ds.transform)

--- a/eeo/preprocessing/reproject.py
+++ b/eeo/preprocessing/reproject.py
@@ -7,6 +7,7 @@ from rasterio.warp import Resampling, calculate_default_transform, reproject
 from eeo.common import is_rasterio_backed, normalize_resampling_method
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import BackendError, ValidationError
 
 
 @eeo_raster_op
@@ -38,9 +39,10 @@ def reproject_raster(
 
     Raises
     ------
-    TypeError
-        If ``ds`` is not backed by rasterio, or ``target_crs`` cannot be
-        interpreted as a CRS.
+    BackendError
+        If ``ds`` is not backed by rasterio.
+    ValidationError
+        If ``target_crs`` cannot be interpreted as a CRS.
 
     Notes
     -----
@@ -53,7 +55,10 @@ def reproject_raster(
     """
     # Ensure reprojection for only rasterio-backend datasets
     if not is_rasterio_backed(ds):
-        raise TypeError("Reprojection is only allowed on rasterio backend rasters")
+        raise BackendError(
+            "reproject requires a rasterio-backed dataset; this dataset uses "
+            "the NumPy backend. Call .to_rasterio() first."
+        )
 
     # Normalize resampling method
     resampling_method = normalize_resampling_method(resampling_method)
@@ -64,7 +69,9 @@ def reproject_raster(
         crs = target_crs
 
     if not isinstance(crs, pyproj.CRS):
-        raise TypeError("Invalid CRS. Must be int, str, or pyproj.CRS")
+        raise ValidationError(
+            f"target_crs must be an int, str, or pyproj.CRS; got {type(target_crs).__name__}"
+        )
 
     # Get dataset bounds
     left, bottom, right, top = ds.get_bounds()

--- a/eeo/preprocessing/resample.py
+++ b/eeo/preprocessing/resample.py
@@ -7,6 +7,7 @@ from rasterio.transform import Affine
 from eeo.common import normalize_resampling_method
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
+from eeo.core.exceptions import BackendError, ValidationError
 from eeo.core.types import ResamplingMethod
 
 
@@ -61,10 +62,10 @@ def resample(
 
     Raises
     ------
-    ValueError
+    ValidationError
         If zero or more than one of ``size``, ``scale_factor``, and
         ``resolution`` is given.
-    RuntimeError
+    BackendError
         If resampling fails for any other reason (wraps the underlying
         error).
 
@@ -87,7 +88,14 @@ def resample(
     """
     params = [size, scale_factor, resolution]
     if sum(p is not None for p in params) != 1:
-        raise ValueError("Provide exactly one of: size=, scale_factor=, resolution=")
+        raise ValidationError(
+            "provide exactly one of size=, scale_factor=, or resolution=; "
+            f"got {sum(p is not None for p in params)}"
+        )
+
+    # Validate the resampling method up front so a bad method surfaces as a
+    # ValidationError rather than being masked by the BackendError wrapper below.
+    resampling_enum = normalize_resampling_method(resampling_method)
 
     # Resampling needs rasterio's decimated reads; promote non-rasterio
     # backends (no-op if the backend is already rasterio)
@@ -112,8 +120,6 @@ def resample(
         new_width = int((bounds.right - bounds.left) / abs(xres))
         new_height = int((bounds.top - bounds.bottom) / abs(yres))
     try:
-        # Resampling using bilinear interpolation
-        resampling_enum = normalize_resampling_method(resampling_method)
         data = ds.read(
             out_shape=(ds.get_count(), new_height, new_width),
             resampling=resampling_enum,
@@ -145,4 +151,4 @@ def resample(
 
         return EEORasterDataset.from_rasterio(dataset)
     except Exception as e:
-        raise RuntimeError("Could not scale raster data") from e
+        raise BackendError("resampling failed in the rasterio backend") from e

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,6 +4,7 @@ from affine import Affine
 from rasterio.crs import CRS
 
 from eeo import load_array
+from eeo.core.exceptions import ValidationError
 
 
 # normalized difference
@@ -49,7 +50,7 @@ def test_extract_value_at_coordinate(raster_3x3):
 
 # invalid coordinate length
 def test_extract_value_invalid_coordinates(raster_3x3):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         raster_3x3.extract_value_at_coordinate((1,))
 
 

--- a/tests/test_error_model.py
+++ b/tests/test_error_model.py
@@ -1,0 +1,196 @@
+"""Failure-mode tests asserting the custom exception hierarchy is raised.
+
+Each operation's main failure modes must raise a specific Easy-EO exception
+(and, for backward compatibility, the built-in it derives from). The class
+relationships themselves are covered in ``test_exceptions.py``; here we drive
+real operations to the point of failure.
+"""
+
+import numpy as np
+import pytest
+
+from eeo.core.adapters.rasterio import RasterioAdapter
+from eeo.core.exceptions import (
+    AlignmentError,
+    BackendError,
+    CRSMismatchError,
+    EEOError,
+    ValidationError,
+)
+
+# ---------------------------------------------------------------------
+# BackendError: rasterio-only ops called on a NumPy-backed dataset
+# ---------------------------------------------------------------------
+
+
+def test_mosaic_on_numpy_backend_raises_backend_error(numpy_backed_dataset):
+    with pytest.raises(BackendError, match="rasterio-backed"):
+        numpy_backed_dataset.mosaic(numpy_backed_dataset)
+
+
+def test_stack_on_numpy_backend_raises_backend_error(numpy_backed_dataset):
+    with pytest.raises(BackendError, match="rasterio-backed"):
+        numpy_backed_dataset.stack(numpy_backed_dataset)
+
+
+def test_clip_bbox_on_numpy_backend_raises_backend_error(numpy_backed_dataset):
+    with pytest.raises(BackendError, match="rasterio-backed"):
+        numpy_backed_dataset.clip_raster_with_bbox((0, 0, 10, 10))
+
+
+def test_clip_vector_on_numpy_backend_raises_backend_error(numpy_backed_dataset):
+    # The backend guard fires before the vector file is ever read.
+    with pytest.raises(BackendError, match="rasterio-backed"):
+        numpy_backed_dataset.clip_raster_with_vector("does_not_matter.geojson")
+
+
+def test_reproject_on_numpy_backend_raises_backend_error(numpy_backed_dataset):
+    with pytest.raises(BackendError, match="rasterio-backed"):
+        numpy_backed_dataset.reproject_raster(target_crs=4326)
+
+
+def test_backend_error_is_runtime_error(numpy_backed_dataset):
+    # Backward compatibility: still catchable as RuntimeError.
+    with pytest.raises(RuntimeError):
+        numpy_backed_dataset.reproject_raster(target_crs=4326)
+
+
+def test_adapter_open_failure_raises_backend_error(tmp_path):
+    bad = tmp_path / "not_a_raster.txt"
+    bad.write_text("nope")
+    with pytest.raises(BackendError, match="failed to open raster"):
+        RasterioAdapter.from_path(str(bad))
+
+
+# ---------------------------------------------------------------------
+# AlignmentError: mismatched grids where alignment is required
+# ---------------------------------------------------------------------
+
+
+def test_add_misaligned_without_auto_align_raises(shape_mismatch_pair):
+    fine, coarse = shape_mismatch_pair
+    with pytest.raises(AlignmentError, match="share the same grid"):
+        fine.add(coarse, auto_align=False)
+
+
+def test_normalized_difference_misaligned_without_auto_align_raises(shape_mismatch_pair):
+    fine, coarse = shape_mismatch_pair
+    with pytest.raises(AlignmentError, match="share the same grid"):
+        fine.normalized_difference(coarse, auto_align=False)
+
+
+def test_stack_shape_mismatch_raises_alignment_error(shape_mismatch_pair):
+    # Same CRS, different transform/shape -> AlignmentError (not CRSMismatch).
+    fine, coarse = shape_mismatch_pair
+    with pytest.raises(AlignmentError, match="transform and shape"):
+        fine.stack(coarse)
+
+
+def test_alignment_error_is_value_error(shape_mismatch_pair):
+    fine, coarse = shape_mismatch_pair
+    with pytest.raises(ValueError):
+        fine.add(coarse, auto_align=False)
+
+
+# ---------------------------------------------------------------------
+# CRSMismatchError: incompatible CRS
+# ---------------------------------------------------------------------
+
+
+def test_stack_crs_mismatch_raises_crs_error(crs_mismatch_pair):
+    utm, geo = crs_mismatch_pair
+    with pytest.raises(CRSMismatchError, match="share the CRS"):
+        utm.stack(geo)
+
+
+def test_mosaic_crs_mismatch_raises_crs_error(crs_mismatch_pair):
+    utm, geo = crs_mismatch_pair
+    with pytest.raises(CRSMismatchError, match="share the CRS"):
+        utm.mosaic(geo)
+
+
+# ---------------------------------------------------------------------
+# ValidationError: malformed parameters
+# ---------------------------------------------------------------------
+
+
+def test_clip_bbox_wrong_length_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="4 values"):
+        single_band_float32.clip_raster_with_bbox((0, 0, 10))
+
+
+def test_clip_bbox_non_intersecting_raises_validation_error(single_band_float32):
+    # The UTM fixture sits near (500000, 4200000); a bbox at the origin misses.
+    with pytest.raises(ValidationError, match="does not intersect"):
+        single_band_float32.clip_raster_with_bbox((0, 0, 10, 10))
+
+
+def test_clip_vector_bad_type_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="GeoDataFrame"):
+        single_band_float32.clip_raster_with_vector(12345)
+
+
+def test_reproject_bad_crs_type_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="target_crs"):
+        single_band_float32.reproject_raster(target_crs=[1, 2, 3])
+
+
+def test_resample_invalid_method_raises_validation_error(single_band_float32):
+    # A bad method must surface as ValidationError, not the BackendError the
+    # rasterio read is wrapped in.
+    with pytest.raises(ValidationError, match="invalid resampling method"):
+        single_band_float32.resample(scale_factor=2.0, resampling_method="not_a_method")
+
+
+def test_resample_no_selector_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="exactly one"):
+        single_band_float32.resample()
+
+
+def test_empty_others_mosaic_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="at least one raster"):
+        single_band_float32.mosaic([])
+
+
+def test_empty_others_stack_raises_validation_error(single_band_float32):
+    with pytest.raises(ValidationError, match="at least one raster"):
+        single_band_float32.stack([])
+
+
+# ---------------------------------------------------------------------
+# Intentionally-kept standard-library exceptions
+# ---------------------------------------------------------------------
+
+
+def test_band_out_of_range_rasterio_backend_raises_index_error(single_band_float32):
+    with pytest.raises(IndexError, match="valid 1..1"):
+        single_band_float32.get_band(5)
+
+
+def test_band_out_of_range_numpy_backend_raises_index_error(numpy_backed_dataset):
+    with pytest.raises(IndexError, match="valid 1..1"):
+        numpy_backed_dataset.get_band(5)
+
+
+# ---------------------------------------------------------------------
+# Everything domain-specific is catchable as EEOError
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        lambda ds: ds.reproject_raster(target_crs=4326),  # BackendError on numpy backend
+        lambda ds: ds.resample(),  # ValidationError
+    ],
+)
+def test_domain_failures_catchable_as_eeoerror(numpy_backed_dataset, action):
+    with pytest.raises(EEOError):
+        action(numpy_backed_dataset)
+
+
+def test_load_array_validation_is_eeoerror():
+    from eeo import load_array
+
+    with pytest.raises(EEOError):
+        load_array(np.zeros((2, 2, 2, 2)))

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,64 @@
+"""Tests for the Easy-EO exception hierarchy.
+
+These cover only the class relationships: that every domain error derives from
+``EEOError``, keeps its historical built-in base for backward compatibility,
+and is exported at the top level. Tests asserting that operations raise the
+right types live alongside those operations' tests.
+"""
+
+import pytest
+
+import eeo
+from eeo.core.exceptions import (
+    AlignmentError,
+    BackendError,
+    CRSMismatchError,
+    EEOError,
+    ValidationError,
+)
+
+DOMAIN_ERRORS = [ValidationError, CRSMismatchError, AlignmentError, BackendError]
+VALUE_ERRORS = [ValidationError, CRSMismatchError, AlignmentError]
+
+
+def test_eeoerror_is_plain_exception():
+    assert issubclass(EEOError, Exception)
+    assert not issubclass(EEOError, (ValueError, RuntimeError))
+
+
+@pytest.mark.parametrize("exc", DOMAIN_ERRORS)
+def test_all_domain_errors_derive_from_eeoerror(exc):
+    assert issubclass(exc, EEOError)
+
+
+@pytest.mark.parametrize("exc", VALUE_ERRORS)
+def test_value_error_backward_compat(exc):
+    assert issubclass(exc, ValueError)
+    with pytest.raises(ValueError):
+        raise exc("boom")
+
+
+def test_backend_error_runtime_compat():
+    assert issubclass(BackendError, RuntimeError)
+    with pytest.raises(RuntimeError):
+        raise BackendError("boom")
+
+
+@pytest.mark.parametrize("exc", [*DOMAIN_ERRORS, EEOError])
+def test_every_error_catchable_as_eeoerror(exc):
+    with pytest.raises(EEOError):
+        raise exc("boom")
+
+
+def test_backend_error_is_not_value_error():
+    # BackendError must stay a RuntimeError, never a ValueError, so callers
+    # can distinguish "bad input" from "backend can't do this".
+    assert not issubclass(BackendError, ValueError)
+
+
+def test_exceptions_exposed_at_top_level():
+    assert eeo.EEOError is EEOError
+    assert eeo.ValidationError is ValidationError
+    assert eeo.CRSMismatchError is CRSMismatchError
+    assert eeo.AlignmentError is AlignmentError
+    assert eeo.BackendError is BackendError

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -6,6 +6,7 @@ from rasterio.crs import CRS
 
 from eeo import load_array, load_raster
 from eeo.core.core import EEORasterDataset
+from eeo.core.exceptions import BackendError, ValidationError
 
 
 # File does not exist
@@ -21,7 +22,7 @@ def test_load_raster_invalid_file(tmp_path):
     bad_file = tmp_path / "not_a_raster.txt"
     bad_file.write_text("this is not a raster")
 
-    with pytest.raises(RuntimeError, match="could not be opened"):
+    with pytest.raises(BackendError, match="could not be opened"):
         load_raster(str(bad_file))
 
 
@@ -56,7 +57,7 @@ def test_load_raster_success(tmp_path):
 
 # Load array non-empty input
 def test_load_array_rejects_non_numpy():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         load_array([[1, 2], [3, 4]])
 
 
@@ -65,7 +66,7 @@ def test_load_array_rejects_non_numpy():
 def test_invalid_array_dimensions(shape):
     array = np.zeros(shape)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         load_array(array)
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -5,6 +5,7 @@ from affine import Affine
 from rasterio.crs import CRS
 
 from eeo import load_raster
+from eeo.core.exceptions import CRSMismatchError
 from eeo.ops.merge import mosaic
 
 
@@ -70,9 +71,9 @@ def test_mosaic_auto_reproject_across_crs(single_band_float32):
 
 
 def test_mosaic_crs_mismatch_without_auto_reproject_raises(single_band_float32):
-    """A CRS mismatch still raises ValueError when auto_reproject is off."""
+    """A CRS mismatch raises CRSMismatchError when auto_reproject is off."""
     other = single_band_float32.reproject_raster(target_crs=4326)
-    with pytest.raises(ValueError, match="same CRS"):
+    with pytest.raises(CRSMismatchError, match="share the CRS"):
         single_band_float32.mosaic(other)
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from eeo.core.exceptions import ValidationError
 from eeo.preprocessing import (
     normalize_min_max,
     normalize_percentile,
@@ -79,7 +80,7 @@ def test_resample_with_scale_factor(single_band_float32):
 
 
 def test_resample_invalid_params(single_band_float32):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         resample(single_band_float32, size=(2, 2), scale_factor=2.0)
 
 

--- a/tests/test_resampling_utils.py
+++ b/tests/test_resampling_utils.py
@@ -6,6 +6,7 @@ from rasterio.enums import Resampling
 
 from eeo import load_array
 from eeo.common import align_raster_to_target, mask_nodata, normalize_resampling_method
+from eeo.core.exceptions import ValidationError
 
 
 # RESAMPLING NORMALIZATION
@@ -24,13 +25,13 @@ def test_normalize_resampling_string(value):
 
 # Rejects invalid string
 def test_normalize_resampling_invalid_string():
-    with pytest.raises(ValueError, match="Invalid resampling method"):
+    with pytest.raises(ValidationError, match="invalid resampling method"):
         normalize_resampling_method("invalid_method")
 
 
 # Rejects invalid type
 def test_normalize_resampling_invalid_type():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         normalize_resampling_method(123)
 
 


### PR DESCRIPTION
## Summary

Introduces a structured exception hierarchy and applies it consistently across the codebase, replacing generic exceptions with domain-specific ones while preserving backward compatibility where possible. Error messages have been rewritten to clearly communicate expected versus received values, improving usability and debugging. This PR also adds a Keep a Changelog–formatted `CHANGELOG.md` with retroactive release history and documents the new exception hierarchy in the user documentation.

## Related issues / tasks

- Completes **Error Model & Changelog**

## Type of change

- [x] Bug fix (non-breaking)
- [x] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] New feature (non-breaking)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behavior is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`) *(not applicable)*
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

- Added `eeo.core.exceptions` containing `EEOError`, `CRSMismatchError`,
  `AlignmentError`, `BackendError`, and `ValidationError`.
- Custom exceptions preserve historical built-in inheritance (`ValueError` or
  `RuntimeError`) to minimize backward compatibility impact for existing users.
- Standard library exceptions such as `FileNotFoundError` and `IndexError`
  remain unchanged where appropriate.
- Error messages have been standardized to an "expected …; got …" format and
  several validation paths were improved to surface more actionable errors
  (e.g. invalid resampling methods and non-intersecting bounding boxes).
- Added a Keep a Changelog–formatted `CHANGELOG.md` with an `Unreleased`
  section and a retroactive `0.1.0b1` entry documenting user-visible changes.
- Documented the exception hierarchy in the Sphinx documentation, including
  cross-referenced API documentation and usage examples.