### PR TITLE
Optimised Memory for Read/Write and Plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ are called out under a **Breaking** heading.
 
 ### Fixed
 
+- **Statistics pixel locators work on multi-band rasters.**
+  `get_maximum_pixel`, `get_minimum_pixel`, `get_mean_pixel`, and
+  `get_percentile_pixel` previously crashed with `ValueError` on any raster
+  with more than one band. All four now analyse the band selected by
+  `band_idx` (default 1 — a single-band raster's only band) and raise
+  `IndexError` for an out-of-range band. Single-band results are unchanged.
 - `to_rasterio()` no longer re-reads and copies datasets that are already
   rasterio-backed but were produced in memory by a previous operation
   (`DatasetWriter`-backed); it now returns the same dataset unchanged. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ are called out under a **Breaking** heading.
 
 ### Changed
 
+- **Plot functions read at display resolution.** `plot_raster`,
+  `plot_band_array`, `plot_raster_with_histogram`, and `plot_composite` now
+  read rasterio-backed rasters decimated to the figure's display budget
+  (via `out_shape`, served from GDAL overviews when present) instead of at
+  full resolution, making plotting of large scenes fast and memory-safe.
+  Small rasters and NumPy-backed datasets are still read in full;
+  `plot_raster_with_histogram`'s histogram is computed from the decimated
+  pixels for large rasters. `plot_histogram` is unchanged (exact counts).
 - **Loosened runtime dependency bounds** to library-appropriate ranges:
   `rasterio>=1.4,<2`, `geopandas>=1.1,<2`, `numpy>=1.26,<3`, `matplotlib>=3.8`
   (previously over-tight caps such as a single matplotlib minor).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ are called out under a **Breaking** heading.
 
 ### Fixed
 
+- `to_rasterio()` no longer re-reads and copies datasets that are already
+  rasterio-backed but were produced in memory by a previous operation
+  (`DatasetWriter`-backed); it now returns the same dataset unchanged. The
+  same needless re-promotion is fixed inside `normalized_difference` and
+  `extract_value_at_coordinate`.
 - **Backend detection for chained operations.** `clip_raster_with_bbox`,
   `clip_raster_with_vector`, `mosaic`, `stack`, and `reproject_raster` no
   longer reject genuinely rasterio-backed datasets produced by a previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ are called out under a **Breaking** heading.
   with more than one band. All four now analyse the band selected by
   `band_idx` (default 1 — a single-band raster's only band) and raise
   `IndexError` for an out-of-range band. Single-band results are unchanged.
+- `reproject_raster` computed the destination grid with the source raster's
+  **width passed as its height**, distorting the output resolution and shape
+  for non-square rasters (square rasters were unaffected). The destination
+  grid now matches rasterio's `calculate_default_transform` result.
 - `to_rasterio()` no longer re-reads and copies datasets that are already
   rasterio-backed but were produced in memory by a previous operation
   (`DatasetWriter`-backed); it now returns the same dataset unchanged. The

--- a/docs/source/user_guide/statistical_locations.rst
+++ b/docs/source/user_guide/statistical_locations.rst
@@ -15,7 +15,7 @@ General Behavior
 ----------------
 All statistical location functions:
     - Mask nodata values automatically
-    - Operate on a single band
+    - Operate on a single band, selected with ``band_idx``
     - Are chainable via ``EEORasterDataset``
     - Return structured dictionaries
 
@@ -27,6 +27,18 @@ Returned structure:
         "value": float,
         "position": (row, col)  # or (x, y)
     }
+
+-------------------------------------
+
+Band Selection
+--------------
+Each function analyses one band at a time. The default ``band_idx=1`` uses a
+single-band raster's only band; for a multi-band raster, pass the 1-based
+band number to analyse:
+
+.. code-block:: python
+
+    ds.get_maximum_pixel(band_idx=3)
 
 -------------------------------------
 

--- a/eeo/analysis/indices.py
+++ b/eeo/analysis/indices.py
@@ -70,10 +70,8 @@ def normalized_difference(
     >>> ndvi = ds_nir.normalized_difference(ds_red)
     >>> ndvi_array = ds_nir.normalized_difference(ds_red, return_as_ndarray=True)
     """
-    # Ensure reprojection for only rasterio-backend datasets
-    backend = ds._adapter.backend
-    if not isinstance(backend, rio.DatasetReader):
-        ds = ds.to_rasterio()
+    # No-op when the dataset is already rasterio-backed
+    ds = ds.to_rasterio()
     if ds.get_shape() != other.get_shape() or ds.get_transform() != other.get_transform():
         if auto_align:
             other = align_raster_to_target(other, ds, method=method)
@@ -87,9 +85,11 @@ def normalized_difference(
     a = ds.read().astype(rio.float32)
     b = other.read().astype(rio.float32)
 
+    # np.where instead of in-place mask assignment so the expression stays
+    # dispatchable to lazy array backends (which reject item assignment).
     with np.errstate(divide="ignore", invalid="ignore"):
         nd = (a - b) / (a + b)
-        nd[np.isnan(nd)] = 0
+    nd = np.where(np.isnan(nd), np.float32(0), nd)
 
     if return_as_ndarray:
         return nd

--- a/eeo/analysis/stats.py
+++ b/eeo/analysis/stats.py
@@ -1,7 +1,6 @@
 """Per-pixel statistics and coordinate sampling."""
 
 import numpy as np
-import rasterio as rio
 
 from eeo.common import mask_nodata
 from eeo.core.core import EEORasterDataset
@@ -53,10 +52,9 @@ def extract_value_at_coordinate(
             f"coordinates must contain exactly 2 values (x, y); got {len(coordinates)}"
         )
 
+    # No-op when the dataset is already rasterio-backed
+    ds = ds.to_rasterio()
     backend = ds._adapter.backend
-    if not isinstance(backend, rio.DatasetReader):
-        ds = ds.to_rasterio()
-        backend = ds._adapter.backend
 
     x, y = coordinates
     # rasterio's DatasetReader.index returns ints on 1.5+ but floats on 1.4,

--- a/eeo/analysis/stats.py
+++ b/eeo/analysis/stats.py
@@ -79,7 +79,9 @@ def get_maximum_pixel(
     ds : EEORasterDataset
         Input raster dataset.
     band_idx : int, default 1
-        1-based band to analyse.
+        1-based band to analyse. The default selects the first band, which
+        for a single-band raster is its only band; pass a band number to
+        analyse a different band of a multi-band raster.
     return_position_as_pixel_coordinate : bool, default False
         If True, return the position as ``(row, col)`` pixel indices;
         otherwise as ``(x, y)`` world coordinates in the raster's CRS.
@@ -90,6 +92,11 @@ def get_maximum_pixel(
         ``{"value": float, "position": tuple}`` — the maximum value and where
         it occurs. Nodata pixels are excluded from the search.
 
+    Raises
+    ------
+    IndexError
+        If ``band_idx`` is outside the range of available bands.
+
     Notes
     -----
     Reads the band into memory. Nodata pixels are masked to NaN and ignored.
@@ -99,12 +106,11 @@ def get_maximum_pixel(
     >>> peak = ds.get_maximum_pixel()
     >>> peak["value"], peak["position"]
     """
-    band = ds.read() if ds.get_count() == 1 else ds.get_band(band_idx)
-    band = mask_nodata(ds, band)
+    band = mask_nodata(ds, ds.get_band(band_idx))
 
     # get max value
     value = float(np.nanmax(band))
-    _, row, col = np.unravel_index(np.nanargmax(band), band.shape)
+    row, col = np.unravel_index(np.nanargmax(band), band.shape)
 
     if return_position_as_pixel_coordinate:
         position = (row, col)
@@ -129,7 +135,9 @@ def get_minimum_pixel(
     ds : EEORasterDataset
         Input raster dataset.
     band_idx : int, default 1
-        1-based band to analyse.
+        1-based band to analyse. The default selects the first band, which
+        for a single-band raster is its only band; pass a band number to
+        analyse a different band of a multi-band raster.
     return_position_as_pixel_coordinate : bool, default False
         If True, return the position as ``(row, col)`` pixel indices;
         otherwise as ``(x, y)`` world coordinates in the raster's CRS.
@@ -140,6 +148,11 @@ def get_minimum_pixel(
         ``{"value": float, "position": tuple}`` — the minimum value and where
         it occurs. Nodata pixels are excluded from the search.
 
+    Raises
+    ------
+    IndexError
+        If ``band_idx`` is outside the range of available bands.
+
     Notes
     -----
     Reads the band into memory. Nodata pixels are masked to NaN and ignored.
@@ -149,12 +162,11 @@ def get_minimum_pixel(
     >>> low = ds.get_minimum_pixel()
     >>> low["value"], low["position"]
     """
-    band = ds.read() if ds.get_count() == 1 else ds.get_band(band_idx)
-    band = mask_nodata(ds, band)
+    band = mask_nodata(ds, ds.get_band(band_idx))
 
     # get min value
     value = float(np.nanmin(band))
-    _, row, col = np.unravel_index(np.nanargmin(band), band.shape)
+    row, col = np.unravel_index(np.nanargmin(band), band.shape)
 
     if return_position_as_pixel_coordinate:
         position = (row, col)
@@ -179,7 +191,9 @@ def get_mean_pixel(
     ds : EEORasterDataset
         Input raster dataset.
     band_idx : int, default 1
-        1-based band to analyse.
+        1-based band to analyse. The default selects the first band, which
+        for a single-band raster is its only band; pass a band number to
+        analyse a different band of a multi-band raster.
     return_position_as_pixel_coordinate : bool, default False
         If True, return the position as ``(row, col)`` pixel indices;
         otherwise as ``(x, y)`` world coordinates in the raster's CRS.
@@ -191,6 +205,11 @@ def get_mean_pixel(
         (nodata excluded), and ``position`` locates the pixel whose value is
         nearest that mean.
 
+    Raises
+    ------
+    IndexError
+        If ``band_idx`` is outside the range of available bands.
+
     Notes
     -----
     Reads the band into memory. Nodata pixels are masked to NaN and ignored.
@@ -200,13 +219,12 @@ def get_mean_pixel(
     >>> centre = ds.get_mean_pixel()
     >>> centre["value"], centre["position"]
     """
-    band = ds.read() if ds.get_count() == 1 else ds.get_band(band_idx)
-    band = mask_nodata(ds, band)
+    band = mask_nodata(ds, ds.get_band(band_idx))
 
     mean_value = float(np.nanmean(band))
     diff = np.abs(band - mean_value)
 
-    _, row, col = np.unravel_index(np.nanargmin(diff), diff.shape)
+    row, col = np.unravel_index(np.nanargmin(diff), diff.shape)
 
     if return_position_as_pixel_coordinate:
         position = (row, col)
@@ -234,7 +252,9 @@ def get_percentile_pixel(
     percentile : float
         Percentile to compute, in the range ``[0, 100]``.
     band_idx : int, default 1
-        1-based band to analyse.
+        1-based band to analyse. The default selects the first band, which
+        for a single-band raster is its only band; pass a band number to
+        analyse a different band of a multi-band raster.
     return_position_as_pixel_coordinate : bool, default False
         If True, return the position as ``(row, col)`` pixel indices;
         otherwise as ``(x, y)`` world coordinates in the raster's CRS.
@@ -246,6 +266,11 @@ def get_percentile_pixel(
         percentile of the band (nodata excluded), and ``position`` locates
         the pixel whose value is nearest that percentile.
 
+    Raises
+    ------
+    IndexError
+        If ``band_idx`` is outside the range of available bands.
+
     Notes
     -----
     Reads the band into memory. Nodata pixels are masked to NaN and ignored.
@@ -255,13 +280,12 @@ def get_percentile_pixel(
     >>> p95 = ds.get_percentile_pixel(95)
     >>> p95["value"], p95["position"]
     """
-    band = ds.read() if ds.get_count() == 1 else ds.get_band(band_idx)
-    band = mask_nodata(ds, band)
+    band = mask_nodata(ds, ds.get_band(band_idx))
 
     perc_value = float(np.nanpercentile(band, percentile))
     diff = np.abs(band - perc_value)
 
-    _, row, col = np.unravel_index(np.nanargmin(diff), band.shape)
+    row, col = np.unravel_index(np.nanargmin(diff), diff.shape)
 
     if return_position_as_pixel_coordinate:
         position = (row, col)

--- a/eeo/core/core.py
+++ b/eeo/core/core.py
@@ -145,10 +145,10 @@ class EEORasterDataset:
         --------
         >>> rio_ds = ds.to_rasterio()
         """
-        backend = self._adapter.backend
-
-        # already a rasterio backend
-        if isinstance(backend, rio.DatasetReader):
+        # Detect by adapter type, not backend class: an op result's backend is
+        # a rasterio DatasetWriter, which a DatasetReader isinstance check
+        # would wrongly re-promote (full read + copy).
+        if isinstance(self._adapter, RasterioAdapter):
             return self
 
         array = self.read()

--- a/eeo/ops/algebra.py
+++ b/eeo/ops/algebra.py
@@ -317,12 +317,11 @@ def divide(
             else:
                 data = src_data / other_data
         else:
-            data = np.divide(
-                src_data,
-                other_data,
-                out=np.zeros_like(src_data, dtype=np.float32),
-                where=other_data != 0,
-            )
+            # np.where instead of the in-place out=/where= ufunc form so the
+            # expression stays dispatchable to lazy array backends.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                quotient = np.divide(src_data, other_data)
+            data = np.where(other_data != 0, quotient, np.float32(0)).astype(np.float32)
     else:
         data = src_data / other_data
 

--- a/eeo/preprocessing/reproject.py
+++ b/eeo/preprocessing/reproject.py
@@ -82,7 +82,7 @@ def reproject_raster(
         src_crs=ds.get_crs(),
         dst_crs=crs,
         width=ds.get_width(),
-        height=ds.get_shape()[1],
+        height=ds.get_height(),
         left=left,
         bottom=bottom,
         right=right,

--- a/eeo/preprocessing/reproject.py
+++ b/eeo/preprocessing/reproject.py
@@ -46,8 +46,9 @@ def reproject_raster(
 
     Notes
     -----
-    Reads the full raster into memory and warps it band-by-band with
-    ``rasterio.warp.reproject``.
+    Warps band-by-band with ``rasterio.warp.reproject`` through rasterio band
+    handles, so the full source array is never materialized at once; the
+    warped output is held in an in-memory dataset.
 
     Examples
     --------

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -7,9 +7,16 @@ from collections.abc import Sequence
 import matplotlib.pyplot as plt
 import numpy as np
 import rasterio.plot as rioplot
+from rasterio.transform import Affine
 
+from eeo.common import is_rasterio_backed
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_viz
+
+# Reads for display are capped at the figure's pixel resolution times this
+# oversampling factor, so moderate zooming stays sharp without ever pulling
+# the full-resolution array.
+_DISPLAY_OVERSAMPLE = 2.0
 
 
 # Visualization helper functions
@@ -81,6 +88,74 @@ def _percentile_stretch(array, pmin=2, pmax=98):
     return np.clip((array - low) / (high - low), 0, 1)
 
 
+def _display_out_shape(shape: tuple[int, int], figsize: tuple[int, int]) -> tuple[int, int] | None:
+    """Compute a decimated read shape capped at the figure's display budget.
+
+    The budget is the figure size in pixels (``figsize`` times the Matplotlib
+    ``figure.dpi``) times ``_DISPLAY_OVERSAMPLE``. Aspect ratio is preserved.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Native raster shape as ``(height, width)`` in pixels.
+    figsize : tuple of int
+        Figure size in inches, as passed to ``matplotlib.pyplot.subplots``.
+
+    Returns
+    -------
+    tuple of int or None
+        Decimated ``(height, width)`` for the read, or None when the raster
+        already fits the display budget and should be read at full
+        resolution.
+    """
+    dpi = float(plt.rcParams.get("figure.dpi", 100.0))
+    max_height = figsize[1] * dpi * _DISPLAY_OVERSAMPLE
+    max_width = figsize[0] * dpi * _DISPLAY_OVERSAMPLE
+
+    height, width = shape
+    scale = min(max_height / height, max_width / width)
+    if scale >= 1.0:
+        return None
+    return max(1, round(height * scale)), max(1, round(width * scale))
+
+
+def _read_band_for_display(
+    ds: EEORasterDataset, band: int, figsize: tuple[int, int]
+) -> tuple[np.ndarray, Affine]:
+    """Read one band at display resolution, with a matching transform.
+
+    Rasterio-backed datasets larger than the display budget are read
+    decimated via ``out_shape`` (GDAL serves such reads from overviews when
+    present), and the returned transform is rescaled so the decimated array
+    still maps to the raster's true extent. Small rasters, and NumPy-backed
+    datasets (whose pixels are already in memory), are returned in full.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Dataset to read from.
+    band : int
+        1-based band index.
+    figsize : tuple of int
+        Figure size in inches, used to derive the display budget.
+
+    Returns
+    -------
+    tuple of (numpy.ndarray, affine.Affine)
+        The band as a 2D array, and the transform mapping that array to
+        world coordinates.
+    """
+    transform = ds.get_transform()
+    out_shape = _display_out_shape(ds.get_shape(), figsize)
+    if out_shape is None or not is_rasterio_backed(ds):
+        return ds.get_band(band), transform
+
+    array = ds.read(band, out_shape=out_shape)
+    height, width = ds.get_shape()
+    out_height, out_width = out_shape
+    return array, transform * Affine.scale(width / out_width, height / out_height)
+
+
 # Plot band as NumPy array
 @eeo_raster_viz
 def plot_band_array(
@@ -132,9 +207,11 @@ def plot_band_array(
 
     Notes
     -----
-    Reads each band at full resolution into memory. Displays the figure with
-    ``matplotlib.pyplot.show`` and, when ``save_path`` is given, writes it to
-    disk as a side effect.
+    Reads each band decimated to the figure's display resolution (rasterio
+    ``out_shape``, served from overviews when present); rasters already
+    within the display budget, and NumPy-backed datasets, are read in full.
+    Displays the figure with ``matplotlib.pyplot.show`` and, when
+    ``save_path`` is given, writes it to disk as a side effect.
 
     Examples
     --------
@@ -148,7 +225,7 @@ def plot_band_array(
     for col, d in enumerate(datasets):
         for row, band in enumerate(bands_list):
             ax = axes[row, col]
-            array = d.get_band(band)
+            array, _ = _read_band_for_display(d, band, figsize)
             if stretch:
                 array = _percentile_stretch(array, pmin, pmax)
             ax.imshow(array, cmap=cmap, **imshow_kwargs)
@@ -217,9 +294,11 @@ def plot_raster(
 
     Notes
     -----
-    Reads each band at full resolution into memory. Displays the figure with
-    ``matplotlib.pyplot.show`` and, when ``save_path`` is given, writes it to
-    disk as a side effect.
+    Reads each band decimated to the figure's display resolution (rasterio
+    ``out_shape``, served from overviews when present); rasters already
+    within the display budget, and NumPy-backed datasets, are read in full.
+    Displays the figure with ``matplotlib.pyplot.show`` and, when
+    ``save_path`` is given, writes it to disk as a side effect.
 
     Examples
     --------
@@ -233,10 +312,10 @@ def plot_raster(
     for col, d in enumerate(datasets):
         for row, band in enumerate(bands_list):
             ax = axes[row, col]
-            array = d.get_band(band)
+            array, transform = _read_band_for_display(d, band, figsize)
             if stretch:
                 array = _percentile_stretch(array, pmin, pmax)
-            rioplot.show(array, transform=d.get_transform(), ax=ax, cmap=cmap, **show_kwargs)
+            rioplot.show(array, transform=transform, ax=ax, cmap=cmap, **show_kwargs)
             ax.set_title(f"Band {band}")
 
     if title:
@@ -378,9 +457,13 @@ def plot_raster_with_histogram(
 
     Notes
     -----
-    Reads each band at full resolution into memory. Displays the figure with
-    ``matplotlib.pyplot.show`` and, when ``save_path`` is given, writes it to
-    disk as a side effect.
+    Reads each band decimated to the figure's display resolution (rasterio
+    ``out_shape``, served from overviews when present); rasters already
+    within the display budget, and NumPy-backed datasets, are read in full.
+    For a decimated raster the histogram is computed from the decimated
+    pixels, so bin counts are an approximation of the full-resolution
+    histogram. Displays the figure with ``matplotlib.pyplot.show`` and, when
+    ``save_path`` is given, writes it to disk as a side effect.
 
     Examples
     --------
@@ -391,11 +474,11 @@ def plot_raster_with_histogram(
     fig, axes = plt.subplots(len(bands_list), 2, squeeze=False, sharey=sharey, figsize=figsize)
 
     for row, band in enumerate(bands_list):
-        array = ds.get_band(band)
+        array, transform = _read_band_for_display(ds, band, figsize)
         if stretch:
             array = _percentile_stretch(array, pmin, pmax)
 
-        rioplot.show(array, transform=ds.get_transform(), ax=axes[row, 0], cmap=cmap)
+        rioplot.show(array, transform=transform, ax=axes[row, 0], cmap=cmap)
         axes[row, 1].hist(array.ravel(), bins=bins)
 
         axes[row, 0].set_title(f"Band {band}")
@@ -455,17 +538,19 @@ def plot_composite(
 
     Notes
     -----
-    Reads the three bands at full resolution into memory. Percentile
-    stretching writes the scaled values back into the composite's own dtype,
-    so stretch a floating-dtype raster to avoid truncating them. Displays the
-    figure with ``matplotlib.pyplot.show`` and, when ``save_path`` is given,
-    writes it to disk as a side effect.
+    Reads the three bands decimated to the figure's display resolution
+    (rasterio ``out_shape``, served from overviews when present); rasters
+    already within the display budget, and NumPy-backed datasets, are read
+    in full. Percentile stretching writes the scaled values back into the
+    composite's own dtype, so stretch a floating-dtype raster to avoid
+    truncating them. Displays the figure with ``matplotlib.pyplot.show``
+    and, when ``save_path`` is given, writes it to disk as a side effect.
 
     Examples
     --------
     >>> ds.plot_composite(bands=(3, 2, 1))
     """
-    composite = np.stack([ds.get_band(b) for b in bands], axis=-1)
+    composite = np.stack([_read_band_for_display(ds, b, figsize)[0] for b in bands], axis=-1)
 
     if stretch:
         for i in range(3):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,22 @@ def multiband_uint16():
 
 
 @pytest.fixture
+def nonsquare_float32():
+    """4x8 single-band float32 raster on the UTM grid, rasterio-backed.
+
+    Non-square (4 rows, 8 columns) so that height/width mix-ups produce
+    observable differences.
+    """
+    ds = load_array(
+        _gradient((4, 8), np.float32),
+        transform=_north_up(),
+        crs=UTM_CRS,
+    ).to_rasterio()
+    yield ds
+    ds.close()
+
+
+@pytest.fixture
 def raster_with_nodata():
     """6x6 float32 raster with nodata=-9999 in the top-left 2x2 block."""
     array = _gradient((6, 6), np.float32)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -102,6 +102,59 @@ def test_get_percentile_pixel_pixel_coordinates(raster_3x3):
     assert result["position"] == (1, 1)
 
 
+# multi-band: locators operate on the selected band (default: band 1)
+def test_get_maximum_pixel_multiband_default_first_band(multiband_uint16):
+    result = multiband_uint16.get_maximum_pixel(return_position_as_pixel_coordinate=True)
+
+    assert result["value"] == 1035.0
+    assert result["position"] == (5, 5)
+
+
+def test_get_maximum_pixel_multiband_band_override(multiband_uint16):
+    result = multiband_uint16.get_maximum_pixel(
+        band_idx=2, return_position_as_pixel_coordinate=True
+    )
+
+    assert result["value"] == 2035.0
+    assert result["position"] == (5, 5)
+
+
+def test_get_minimum_pixel_multiband_band_override(multiband_uint16):
+    result = multiband_uint16.get_minimum_pixel(
+        band_idx=3, return_position_as_pixel_coordinate=True
+    )
+
+    assert result["value"] == 3000.0
+    assert result["position"] == (0, 0)
+
+
+def test_get_mean_pixel_multiband_band_override(multiband_uint16):
+    result = multiband_uint16.get_mean_pixel(band_idx=2, return_position_as_pixel_coordinate=True)
+
+    # band 2 mean is 2017.5; the first pixel nearest it is 2017 at (2, 5)
+    assert result["value"] == 2017.5
+    assert result["position"] == (2, 5)
+
+
+def test_get_percentile_pixel_multiband_band_override(multiband_uint16):
+    result = multiband_uint16.get_percentile_pixel(50, band_idx=4)
+
+    assert result["value"] == 4017.5
+
+
+def test_extract_value_at_coordinate_multiband_band_override(multiband_uint16):
+    # 10 m UTM grid, origin (500000, 4200000): world (500015, 4199985) is
+    # pixel (1, 1) = gradient value 7
+    value = multiband_uint16.extract_value_at_coordinate((500_015.0, 4_199_985.0), band_idx=2)
+
+    assert value == 2007
+
+
+def test_stats_locators_reject_out_of_range_band(multiband_uint16):
+    with pytest.raises(IndexError):
+        multiband_uint16.get_maximum_pixel(band_idx=9)
+
+
 # no data handling
 def test_nodata_is_masked_in_stats(raster_with_nodata):
     # nodata (-9999) occupies the top-left 2x2 block of the 0..35 gradient;

--- a/tests/test_backend_promotion.py
+++ b/tests/test_backend_promotion.py
@@ -1,10 +1,58 @@
 import numpy as np
 import rasterio.io
 
+from eeo.core.adapters import RasterioAdapter
+
 
 def test_numpy_backend_initial(numpy_backed_dataset):
     backend = numpy_backed_dataset._adapter.backend
     assert isinstance(backend, np.ndarray)
+
+
+# op results are DatasetWriter-backed; to_rasterio() must
+# recognise them as already-rasterio and return self instead of re-reading
+# the full array into a new MemoryFile.
+def test_to_rasterio_is_noop_on_op_result(single_band_float32):
+    result = single_band_float32.add(1)
+
+    assert isinstance(result.ds, rasterio.io.DatasetWriter)
+    assert result.to_rasterio() is result
+
+
+def test_to_rasterio_is_noop_on_file_backed(tmp_path, single_band_float32):
+    path = tmp_path / "plain.tif"
+    single_band_float32.save_raster(str(path))
+
+    import eeo
+
+    ds = eeo.load_raster(str(path))
+    assert ds.to_rasterio() is ds
+    ds.close()
+
+
+def _forbid_promotion(monkeypatch):
+    def fail_from_array(*args, **kwargs):
+        raise AssertionError("rasterio-backed dataset was needlessly re-promoted")
+
+    monkeypatch.setattr(RasterioAdapter, "from_array", fail_from_array)
+
+
+def test_extract_value_does_not_repromote_rasterio_dataset(single_band_float32, monkeypatch):
+    _forbid_promotion(monkeypatch)
+
+    # pixel (1, 1) on the 10 m UTM grid holds gradient value 7
+    value = single_band_float32.extract_value_at_coordinate((500_015.0, 4_199_985.0))
+    assert value == 7.0
+
+
+def test_normalized_difference_does_not_repromote_rasterio_dataset(
+    single_band_float32, monkeypatch
+):
+    _forbid_promotion(monkeypatch)
+
+    result = single_band_float32.normalized_difference(single_band_float32)
+    # (x - x) / (x + x) is 0 everywhere; the 0/0 pixel is guarded to 0
+    assert np.all(result.read() == 0)
 
 
 def test_resample_promotes_to_rasterio(numpy_backed_dataset):

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -5,8 +5,27 @@ from affine import Affine
 from rasterio.crs import CRS
 
 from eeo import load_array, load_raster
+from eeo.core.adapters import RasterioAdapter
 from eeo.core.core import EEORasterDataset
 from eeo.core.exceptions import BackendError, ValidationError
+
+
+def _write_tiny_tif(path):
+    data = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+    transform = Affine.translation(0, 2) * Affine.scale(1, -1)
+
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype=data.dtype,
+        crs=CRS.from_epsg(4326),
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
 
 
 # File does not exist
@@ -53,6 +72,48 @@ def test_load_raster_success(tmp_path):
     assert ds.get_shape() == (2, 2)
     assert ds.get_count() == 1
     assert ds.get_crs() == crs
+
+
+# Memory model: opening a raster and touching metadata must not read pixels
+def test_load_raster_performs_no_pixel_read(tmp_path, monkeypatch):
+    path = tmp_path / "lazy.tif"
+    _write_tiny_tif(path)
+
+    read_calls = []
+    real_read = RasterioAdapter.read
+    real_read_band = RasterioAdapter.read_band
+
+    def spy_read(self, *args, **kwargs):
+        read_calls.append(("read", args, kwargs))
+        return real_read(self, *args, **kwargs)
+
+    def spy_read_band(self, idx):
+        read_calls.append(("read_band", idx))
+        return real_read_band(self, idx)
+
+    monkeypatch.setattr(RasterioAdapter, "read", spy_read)
+    monkeypatch.setattr(RasterioAdapter, "read_band", spy_read_band)
+
+    ds = load_raster(str(path))
+
+    # metadata access must also stay read-free
+    ds.get_crs()
+    ds.get_transform()
+    ds.get_shape()
+    ds.get_bounds()
+    ds.get_metadata()
+    ds.get_width()
+    ds.get_height()
+    ds.get_count()
+
+    assert read_calls == []
+
+    # the spy is live: an actual pixel read goes through it and still works
+    band = ds.get_band(1)
+    np.testing.assert_array_equal(band, np.array([[1, 2], [3, 4]], dtype=np.uint8))
+    assert read_calls == [("read_band", 1)]
+
+    ds.close()
 
 
 # Load array non-empty input

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -57,6 +57,16 @@ def test_divide_safe(raster_a):
     assert np.all(result.read() == 0)
 
 
+def test_divide_safe_raster_with_zero_denominators(raster_a):
+    denom = load_array(
+        np.array([[2, 0], [0, 4]], dtype=np.float32),
+        transform=GRID,
+        crs=CRS.from_epsg(4326),
+    )
+    result = raster_a.divide(denom)
+    np.testing.assert_array_equal(result.read()[0], [[0.5, 0], [0, 1]])
+
+
 def test_power(raster_a):
     result = raster_a.power(2)
     np.testing.assert_array_equal(result.read()[0], [[1, 4], [9, 16]])

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from rasterio.crs import CRS
+from rasterio.warp import calculate_default_transform
 
 from eeo.core.exceptions import ValidationError
 from eeo.preprocessing import (
@@ -95,3 +97,34 @@ def test_resample_default_is_nearest(single_band_float32):
     resampled_values = set(resampled.read().ravel().tolist())
 
     assert resampled_values <= original_values
+
+
+# ---------------------------------------------------------------------
+# Reproject
+# ---------------------------------------------------------------------
+
+
+def test_reproject_nonsquare_raster_uses_correct_dimensions(nonsquare_float32):
+    # A prior version passed the raster's width as the source height when
+    # computing the destination grid, distorting the output resolution and
+    # shape for any non-square raster (square fixtures hid it).
+    target_crs = CRS.from_epsg(4326)
+    left, bottom, right, top = nonsquare_float32.get_bounds()
+    expected_transform, expected_width, expected_height = calculate_default_transform(
+        src_crs=nonsquare_float32.get_crs(),
+        dst_crs=target_crs,
+        width=nonsquare_float32.get_width(),
+        height=nonsquare_float32.get_height(),
+        left=left,
+        bottom=bottom,
+        right=right,
+        top=top,
+    )
+
+    reprojected = nonsquare_float32.reproject_raster(target_crs=4326)
+
+    assert reprojected.get_width() == expected_width
+    assert reprojected.get_height() == expected_height
+    assert reprojected.get_transform() == expected_transform
+    # the 4x8 source must stay wider than it is tall
+    assert reprojected.get_width() > reprojected.get_height()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from affine import Affine
@@ -12,9 +13,12 @@ from eeo.viz import (
     plot_raster_with_histogram,
 )
 from eeo.viz.plot import (
+    _DISPLAY_OVERSAMPLE,
     _as_list,
+    _display_out_shape,
     _normalize_bands,
     _percentile_stretch,
+    _read_band_for_display,
 )
 
 # ---------------------------------------------------------------------
@@ -83,6 +87,57 @@ def test_percentile_stretch_constant_array():
     stretched = _percentile_stretch(arr)
 
     assert np.all(stretched == 0)
+
+
+# ---------------------------------------------------------------------
+# Display-resolution (decimated read) helpers
+# ---------------------------------------------------------------------
+
+
+def test_display_out_shape_small_raster_reads_full():
+    assert _display_out_shape((6, 6), (8, 8)) is None
+
+
+def test_display_out_shape_caps_large_raster():
+    dpi = plt.rcParams["figure.dpi"]
+    out = _display_out_shape((100_000, 50_000), (10, 5))
+
+    assert out is not None
+    out_h, out_w = out
+    # height-limited: budget is figsize height x dpi x oversample
+    assert out_h == round(5 * dpi * _DISPLAY_OVERSAMPLE)
+    # native 2:1 aspect ratio preserved
+    assert out_w == round(out_h / 2)
+
+
+def test_read_band_for_display_decimates_and_rescales_transform():
+    ds = load_array(
+        np.zeros((600, 600), dtype=np.float32),
+        transform=Affine.translation(0, 600) * Affine.scale(1, -1),
+        crs=CRS.from_epsg(32633),
+    ).to_rasterio()
+
+    array, transform = _read_band_for_display(ds, 1, (1, 1))
+
+    expected = round(plt.rcParams["figure.dpi"] * _DISPLAY_OVERSAMPLE)
+    assert array.shape == (expected, expected)
+    # coarser pixels, unchanged extent
+    assert transform.a == pytest.approx(600 / expected)
+    assert transform.e == pytest.approx(-600 / expected)
+    ds.close()
+
+
+def test_read_band_for_display_numpy_backend_reads_full():
+    ds = load_array(
+        np.zeros((600, 600), dtype=np.float32),
+        transform=Affine.translation(0, 600) * Affine.scale(1, -1),
+        crs=CRS.from_epsg(32633),
+    )
+
+    array, transform = _read_band_for_display(ds, 1, (1, 1))
+
+    assert array.shape == (600, 600)
+    assert transform == ds.get_transform()
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,3 +1,5 @@
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -5,6 +7,7 @@ from affine import Affine
 from rasterio.crs import CRS
 
 from eeo import load_array
+from eeo.core.adapters import RasterioAdapter
 from eeo.viz import (
     plot_band_array,
     plot_composite,
@@ -138,6 +141,79 @@ def test_read_band_for_display_numpy_backend_reads_full():
 
     assert array.shape == (600, 600)
     assert transform == ds.get_transform()
+
+
+# ---------------------------------------------------------------------
+# Large-raster plotting reads reduced arrays (end-to-end)
+# ---------------------------------------------------------------------
+
+LARGE_SIDE = 600
+
+
+@pytest.fixture
+def large_rgb_raster():
+    """3-band 600x600 float32 raster, rasterio-backed.
+
+    Large relative to the tiny ``figsize=(1, 1)`` display budget used in the
+    decimation tests, so every band read must come back reduced.
+    """
+    ds = load_array(
+        np.zeros((3, LARGE_SIDE, LARGE_SIDE), dtype=np.float32),
+        transform=Affine.translation(0, LARGE_SIDE) * Affine.scale(1, -1),
+        crs=CRS.from_epsg(32633),
+    ).to_rasterio()
+    yield ds
+    ds.close()
+
+
+def _record_pixel_read_shapes(monkeypatch):
+    """Spy on both adapter read paths, recording each result's shape."""
+    shapes = []
+    real_read = RasterioAdapter.read
+    real_read_band = RasterioAdapter.read_band
+
+    def spy_read(self, *args, **kwargs):
+        result = real_read(self, *args, **kwargs)
+        shapes.append(result.shape)
+        return result
+
+    def spy_read_band(self, idx):
+        result = real_read_band(self, idx)
+        shapes.append(result.shape)
+        return result
+
+    monkeypatch.setattr(RasterioAdapter, "read", spy_read)
+    monkeypatch.setattr(RasterioAdapter, "read_band", spy_read_band)
+    return shapes
+
+
+@pytest.mark.parametrize(
+    "plot_func",
+    [
+        lambda ds: plot_raster(ds, figsize=(1, 1)),
+        lambda ds: plot_band_array(ds, figsize=(1, 1)),
+        lambda ds: plot_raster_with_histogram(ds, figsize=(1, 1)),
+        lambda ds: plot_composite(ds, bands=(1, 2, 3), figsize=(1, 1)),
+    ],
+    ids=["plot_raster", "plot_band_array", "plot_raster_with_histogram", "plot_composite"],
+)
+def test_plotting_large_raster_reads_reduced_arrays(large_rgb_raster, plot_func, monkeypatch):
+    shapes = _record_pixel_read_shapes(monkeypatch)
+
+    # The deliberately tiny figure cannot fit all subplot decorations;
+    # matplotlib's cosmetic tight_layout warning is irrelevant to the reads
+    # under test.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Tight layout not applied", category=UserWarning)
+        plot_func(large_rgb_raster)
+
+    budget = round(plt.rcParams["figure.dpi"] * _DISPLAY_OVERSAMPLE)
+    assert budget < LARGE_SIDE  # sanity: decimation must actually trigger
+    assert shapes  # pixels were read through the adapter
+    for shape in shapes:
+        height, width = shape[-2:]
+        assert height <= budget
+        assert width <= budget
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -155,10 +155,15 @@ def large_rgb_raster():
     """3-band 600x600 float32 raster, rasterio-backed.
 
     Large relative to the tiny ``figsize=(1, 1)`` display budget used in the
-    decimation tests, so every band read must come back reduced.
+    decimation tests, so every band read must come back reduced. The bands
+    must not be constant: rasterio >= 1.5 normalizes float bands in
+    ``show()`` by their value range, and a zero range divides 0/0 and warns.
     """
+    base = np.linspace(0.0, 1.0, LARGE_SIDE * LARGE_SIDE, dtype=np.float32).reshape(
+        LARGE_SIDE, LARGE_SIDE
+    )
     ds = load_array(
-        np.zeros((3, LARGE_SIDE, LARGE_SIDE), dtype=np.float32),
+        np.stack([base, 0.5 * base, 0.25 * base]),
         transform=Affine.translation(0, LARGE_SIDE) * Affine.scale(1, -1),
         crs=CRS.from_epsg(32633),
     ).to_rasterio()


### PR DESCRIPTION
## Summary

Enforces the project's memory model by verifying lazy loading, preventing unnecessary raster materialisation, and reducing memory usage during visualisation. This PR adds regression tests to lock in lazy behaviour, refactors operations to better support adapter-backed array-likes, introduces decimated reads for plotting large rasters, documents memory behaviour throughout the API, and fixes a multi-band statistics bug discovered during the audit.

## Related issues / tasks

- Completes **Memory Model Enforcement**

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behaviour is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`) *(not applicable; public API unchanged)*
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

- Verified that `load_raster()` and the adapter initialisation path remain fully
  lazy and perform no pixel reads until data is explicitly requested.
- Added regression tests to prevent future eager pixel reads during loading and
  to ensure plotting large rasters performs decimated reads within the display
  resolution budget.
- Refactored operations to avoid unnecessary raster materialisation and use
  NumPy public APIs that better support adapter-backed array-like objects.
- Updated raster plotting functions to use `out_shape`-based decimated reads for
  rasterio-backed datasets while preserving exact georeferencing.
- Documented memory behaviour consistently across all bound operations and
  corrected the documented behaviour of `reproject_raster`.
- Fixed a multi-band bug in the statistics pixel locator functions by ensuring
  they operate on the selected band and return clear `IndexError`s for invalid
  band indices. Added corresponding documentation to the user guide.
- Two additional issues were identified during the audit: statistics pixel locators, while the
  `reproject_raster` transform bug that passed width as height was also fixed.