### PR TITLE
Added a spectral index library - NDVI/NDWI/NDMI/NDBI/EVI/SAVI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **Spectral index library** (`eeo.analysis.indices`): six chainable,
+  nodata-safe, float32-output indices bound onto `EEORasterDataset` —
+  `ndvi`, `ndwi` (McFeeters water), `ndmi`, `ndbi`, `evi`, and `savi`. Each
+  band argument accepts **either** a separate single-band `EEORasterDataset`
+  **or** a 1-based `int` band index into the receiver, so the same method
+  serves per-band rasters (`nir.ndvi(red)`) and one stacked scene
+  (`scene.ndvi(red=3, nir=4)`); the primary band defaults to index 1.
+  Mismatched-grid bands auto-align by default, a zero denominator is guarded
+  to 0, and nodata is contagious across all input bands (output nodata is
+  `NaN`). A new "Spectral Indices" user-guide page documents the formulas,
+  per-sensor band conventions (Sentinel-2, Landsat 8/9), and a comparison
+  figure.
 - **Custom exception hierarchy** in `eeo.core.exceptions`, exported from the
   top-level package: `EEOError` (base), `ValidationError`, `CRSMismatchError`,
   `AlignmentError`, and `BackendError`. Catch `EEOError` to handle any

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,9 +25,18 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "matplotlib.sphinxext.plot_directive",
 ]
 
 extensions.append("sphinx_copybutton")
+
+# -- matplotlib plot_directive -----------------------------------------------
+# Render the spectral-index comparison figure from source at build time (no
+# committed binary). Show only the image, not the source/PNG-vs-HiRes links.
+plot_include_source = False
+plot_html_show_source_link = False
+plot_html_show_formats = False
+plot_formats = [("png", 100)]
 
 # -- Napoleon (NumPy-style docstrings) ---------------------------------------
 # Docstrings are NumPy style everywhere (see CODE_STYLE.md); disable the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ arithmetic, computing indices, and visualizing results.
    getting_started
    user_guide/core_dataset
    user_guide/ops
+   user_guide/spectral_indices
    user_guide/preprocessing
    user_guide/nodata_and_dtype
    user_guide/visualization

--- a/docs/source/user_guide/spectral_indices.rst
+++ b/docs/source/user_guide/spectral_indices.rst
@@ -1,0 +1,208 @@
+Spectral Indices
+================
+
+Spectral indices combine a few bands into a single, physically meaningful
+layer — vegetation, surface water, moisture, or built-up density.
+Easy-EO ships six ready-made indices as **chainable, nodata-safe,
+float32-output** methods on :class:`~eeo.core.core.EEORasterDataset`, built on
+the same algebra primitives you can use directly.
+
+.. seealso::
+
+   :doc:`nodata_and_dtype` for how every index treats nodata pixels and why
+   the output is always float32.
+
+-----
+
+Two ways to supply bands
+------------------------
+
+Every band argument accepts **either** a separate single-band
+``EEORasterDataset`` **or** a 1-based ``int`` band index into the receiver, so
+the same method works whether your bands are individual files or one stacked
+multi-band scene. The *primary* band defaults to index ``1``, which keeps the
+separate-band case a clean one-liner.
+
+.. code-block:: python
+
+   from eeo import load_raster
+
+   # (a) one band per raster -- call on the primary band, pass the others
+   nir = load_raster("B08.tif")
+   red = load_raster("B04.tif")
+   ndvi = nir.ndvi(red)
+
+   # (b) one stacked scene -- select bands by 1-based index
+   scene = load_raster("sentinel2_stack.tif")   # e.g. [B02, B03, B04, B08]
+   ndvi = scene.ndvi(red=3, nir=4)
+
+When a band is a separate raster on a different grid, it is resampled onto the
+receiver's grid automatically (``auto_align=True``, the default); pass
+``auto_align=False`` to require an exact match instead.
+
+Each method returns a new single-band ``EEORasterDataset`` and is fully
+chainable; pass ``return_as_ndarray=True`` to get the raw 2D array instead.
+
+.. code-block:: python
+
+   # chain straight into a stretch and a plot
+   (
+       nir.ndvi(red)
+       .normalize_percentile(lower_percentile=2, upper_percentile=98)
+       .plot_raster()
+   )
+
+-----
+
+The indices and their bands
+---------------------------
+
+The table gives the formula and the band each argument maps to on two common
+sensors. "Call on" names the band the method is invoked on (the primary band,
+default index ``1``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 34 18 19 19
+
+   * - Index
+     - Formula
+     - Call on
+     - Sentinel-2
+     - Landsat 8/9 (OLI)
+   * - ``ndvi``
+     - ``(NIR - Red) / (NIR + Red)``
+     - NIR
+     - NIR B8, Red B4
+     - NIR B5, Red B4
+   * - ``ndwi``
+     - ``(Green - NIR) / (Green + NIR)``
+     - Green
+     - Green B3, NIR B8
+     - Green B3, NIR B5
+   * - ``ndmi``
+     - ``(NIR - SWIR1) / (NIR + SWIR1)``
+     - NIR
+     - NIR B8, SWIR1 B11
+     - NIR B5, SWIR1 B6
+   * - ``ndbi``
+     - ``(SWIR1 - NIR) / (SWIR1 + NIR)``
+     - SWIR1
+     - SWIR1 B11, NIR B8
+     - SWIR1 B6, NIR B5
+   * - ``evi``
+     - ``2.5 (NIR - Red) / (NIR + 6 Red - 7.5 Blue + 1)``
+     - NIR
+     - NIR B8, Red B4, Blue B2
+     - NIR B5, Red B4, Blue B2
+   * - ``savi``
+     - ``(1 + L)(NIR - Red) / (NIR + Red + L)``
+     - NIR
+     - NIR B8, Red B4
+     - NIR B5, Red B4
+
+.. note::
+
+   ``ndwi`` here is McFeeters' **water** NDWI ``(Green - NIR)``. The moisture
+   variant ``(NIR - SWIR1)`` is exposed separately as :meth:`ndmi`.
+
+   ``evi`` expects surface reflectance scaled to roughly ``[0, 1]``. If your
+   bands are integer DN or reflectance scaled by 10000, rescale first, e.g.
+   ``scene.divide(10000).evi(red=3, blue=1, nir=4)``.
+
+   ``savi`` takes a soil-brightness factor ``soil_factor`` (``L``): ``0`` for
+   dense cover (then SAVI equals NDVI), ``1`` for very sparse cover, ``0.5``
+   (the default) for intermediate cover. Sentinel-2's SWIR1 (B11) is 20 m;
+   auto-alignment resamples it onto a 10 m NIR grid for ``ndmi`` / ``ndbi``.
+
+-----
+
+Nodata and dtype
+----------------
+
+Every index follows the library :doc:`nodata_and_dtype`:
+
+- Output is always **float32**.
+- Nodata is **contagious**: a pixel that is nodata in *any* input band is
+  ``NaN`` in the output, and the result's ``nodata`` is ``NaN`` when any input
+  declares nodata (otherwise ``None``).
+- A zero denominator (e.g. ``NIR + Red == 0``) is guarded to ``0`` rather than
+  producing ``inf``/``NaN``.
+
+-----
+
+Comparing the indices
+---------------------
+
+The panel below runs all six indices over the same small synthetic scene — a
+vegetation patch (top-left), open water (top-right), and a built-up area
+(bottom) — so you can see how each responds to the same ground cover.
+
+.. plot::
+   :caption: The six built-in indices computed over one synthetic scene.
+
+   import numpy as np
+   import matplotlib.pyplot as plt
+   from affine import Affine
+   from eeo import load_array
+
+   # A 60x60 scene split into vegetation, water, and built-up regions, with
+   # per-region reflectance for Blue, Green, Red, NIR, and SWIR1.
+   h = w = 60
+   region = np.zeros((h, w), dtype=int)
+   region[: h // 2, w // 2 :] = 1          # water   (top-right)
+   region[h // 2 :, :] = 2                  # built-up (bottom)
+
+   # reflectance [blue, green, red, nir, swir1] per region
+   sig = {
+       0: [0.04, 0.07, 0.05, 0.45, 0.20],   # vegetation: high NIR, low red
+       1: [0.06, 0.09, 0.05, 0.03, 0.02],   # water: very low NIR/SWIR
+       2: [0.18, 0.20, 0.24, 0.28, 0.34],   # built-up: high SWIR, flat
+   }
+   rng = np.random.default_rng(0)
+   bands = {}
+   for i, name in enumerate(["blue", "green", "red", "nir", "swir"]):
+       arr = np.zeros((h, w), dtype=np.float32)
+       for r, vals in sig.items():
+           arr[region == r] = vals[i]
+       arr += rng.normal(0, 0.01, size=arr.shape).astype(np.float32)
+       bands[name] = arr
+
+   transform = Affine.translation(0, h) * Affine.scale(1, -1)
+   ds = {n: load_array(a, transform=transform, crs=4326) for n, a in bands.items()}
+
+   panels = [
+       ("NDVI", ds["nir"].ndvi(ds["red"], return_as_ndarray=True), "RdYlGn", -1, 1),
+       ("NDWI", ds["green"].ndwi(ds["nir"], return_as_ndarray=True), "BrBG_r", -1, 1),
+       ("NDMI", ds["nir"].ndmi(ds["swir"], return_as_ndarray=True), "BrBG", -1, 1),
+       ("NDBI", ds["swir"].ndbi(ds["nir"], return_as_ndarray=True), "pink", -1, 1),
+       ("EVI", ds["nir"].evi(ds["red"], ds["blue"], return_as_ndarray=True), "YlGn", -1, 1),
+       ("SAVI", ds["nir"].savi(ds["red"], return_as_ndarray=True), "YlGn", -1, 1),
+   ]
+
+   fig, axes = plt.subplots(2, 3, figsize=(9, 6))
+   for ax, (title, data, cmap, vmin, vmax) in zip(axes.ravel(), panels):
+       im = ax.imshow(data, cmap=cmap, vmin=vmin, vmax=vmax)
+       ax.set_title(title)
+       ax.set_xticks([])
+       ax.set_yticks([])
+       fig.colorbar(im, ax=ax, shrink=0.7)
+   fig.suptitle("Vegetation (top-left) · Water (top-right) · Built-up (bottom)")
+   fig.tight_layout()
+
+-----
+
+Doing it by hand
+----------------
+
+Because the indices are thin wrappers over the algebra primitives, you can
+always build a custom index yourself. The normalized-difference family is one
+call to :func:`~eeo.analysis.indices.normalized_difference`:
+
+.. code-block:: python
+
+   # NDVI, written out
+   ndvi = nir.normalized_difference(red)
+
+   # a custom ratio index
+   custom = nir.subtract(red).divide(nir.add(red).add(0.5))

--- a/eeo/analysis/__init__.py
+++ b/eeo/analysis/__init__.py
@@ -1,6 +1,14 @@
 """Analysis operations: spectral indices and pixel statistics."""
 
-from .indices import normalized_difference
+from .indices import (
+    evi,
+    ndbi,
+    ndmi,
+    ndvi,
+    ndwi,
+    normalized_difference,
+    savi,
+)
 from .stats import (
     extract_value_at_coordinate,
     get_maximum_pixel,
@@ -12,6 +20,12 @@ from .stats import (
 __all__ = [
     "extract_value_at_coordinate",
     "normalized_difference",
+    "ndvi",
+    "ndwi",
+    "ndmi",
+    "ndbi",
+    "evi",
+    "savi",
     "get_minimum_pixel",
     "get_percentile_pixel",
     "get_mean_pixel",

--- a/eeo/analysis/indices.py
+++ b/eeo/analysis/indices.py
@@ -1,8 +1,16 @@
-"""Spectral analysis helpers built on the algebra primitives.
+"""Spectral indices built on the raster algebra primitives.
 
-Rather than predefined indices, this module exposes algebraic primitives:
-most vegetation and water indices can be expressed directly using
-``normalized_difference`` or raster arithmetic.
+Each index (NDVI, NDWI, NDMI, NDBI, EVI, SAVI) is a thin, chainable wrapper
+that combines a handful of bands into a nodata-safe, float32 index raster.
+
+Every band argument accepts either an :class:`~eeo.core.core.EEORasterDataset`
+(a separate single-band raster) or an ``int`` (a 1-based band index into the
+receiver), so the same method serves both a per-band collection of rasters and
+one stacked multi-band scene. The primary band defaults to index ``1``, which
+keeps the separate-band case a clean one-liner (``nir_ds.ndvi(red_ds)``).
+
+The general two-operand primitive, :func:`normalized_difference`, is also kept
+here: any normalized-difference index can be expressed with it directly.
 """
 
 import numpy as np
@@ -11,7 +19,103 @@ import rasterio as rio
 from eeo.common import align_raster_to_target, apply_nodata_contract, get_nodata
 from eeo.core.core import EEORasterDataset
 from eeo.core.decorators import eeo_raster_op
-from eeo.core.exceptions import AlignmentError
+from eeo.core.exceptions import AlignmentError, ValidationError
+
+BandSpec = EEORasterDataset | int
+
+_ALIGN_MISMATCH = (
+    "rasters must share the same grid for this operation; "
+    "got shape {other} vs {ds}. "
+    "Pass auto_align=True to resample the other raster onto this grid."
+)
+
+
+def _safe_ratio(numerator, denominator):
+    """Divide element-wise, mapping a zero denominator to 0 instead of inf/nan.
+
+    Uses ``numpy.where`` (not in-place assignment) so the expression stays
+    dispatchable to lazy array backends, and returns float32.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        quotient = numerator / denominator
+    return np.where(denominator != 0, quotient, np.float32(0)).astype(rio.float32)
+
+
+def _resolve_band(ds, spec, *, auto_align, method):
+    """Resolve a band spec to ``(band_float32, band_raw, nodata)``.
+
+    ``spec`` is either a 1-based ``int`` band index into ``ds`` or a separate
+    ``EEORasterDataset`` (its first band is used, aligned onto ``ds``'s grid
+    when ``auto_align`` is True). ``band_raw`` keeps its source dtype so the
+    nodata mask compares against the declared sentinel exactly.
+    """
+    if isinstance(spec, EEORasterDataset):
+        other = spec
+        if ds.get_shape() != other.get_shape() or ds.get_transform() != other.get_transform():
+            if auto_align:
+                other = align_raster_to_target(other, ds, method=method)
+            else:
+                raise AlignmentError(
+                    _ALIGN_MISMATCH.format(other=other.get_shape(), ds=ds.get_shape())
+                )
+        raw = other.get_band(1)
+        nodata = get_nodata(other)
+    elif isinstance(spec, int) and not isinstance(spec, bool):
+        raw = ds.get_band(spec)
+        nodata = get_nodata(ds)
+    else:
+        raise ValidationError(
+            "band must be an EEORasterDataset or a 1-based int band index; "
+            f"got {type(spec).__name__}"
+        )
+    return raw.astype(rio.float32), raw, nodata
+
+
+def _compute_index(ds, band_specs, formula, *, auto_align, method, return_as_ndarray):
+    """Resolve band specs, apply ``formula``, and package the float32 result.
+
+    ``band_specs`` is the ordered list of band specs; the first is the primary
+    band. ``formula`` maps the list of float32 band arrays to a 2D result. The
+    result is masked per the nodata contract (contagious across every band) and
+    returned as a raw array or a single-band float32 ``EEORasterDataset``.
+    """
+    ds = ds.to_rasterio()
+    resolved = [
+        _resolve_band(ds, spec, auto_align=auto_align, method=method) for spec in band_specs
+    ]
+    floats = [band for band, _raw, _nodata in resolved]
+    operands = [(raw, nodata) for _band, raw, nodata in resolved]
+    primary_nodata = resolved[0][2]
+
+    result = formula(floats)
+
+    index, out_nodata = apply_nodata_contract(
+        result, operands, fractional=True, ds_nodata=primary_nodata
+    )
+
+    if return_as_ndarray:
+        return index
+
+    data = index[np.newaxis, ...] if index.ndim == 2 else index
+    meta = ds.get_metadata().copy()
+    meta.update(
+        driver="GTiff",
+        dtype="float32",
+        nodata=out_nodata,
+        height=data.shape[-2],
+        width=data.shape[-1],
+        count=data.shape[0],
+    )
+    memfile = rio.io.MemoryFile()
+    out_ds = memfile.open(**meta)
+    out_ds.write(data)
+    return EEORasterDataset.from_rasterio(out_ds)
+
+
+def _normalized_difference(bands):
+    """Return ``(a - b) / (a + b)`` for the two-band normalized-difference family."""
+    a, b = bands
+    return _safe_ratio(a - b, a + b)
 
 
 @eeo_raster_op
@@ -25,10 +129,12 @@ def normalized_difference(
 ) -> np.ndarray | EEORasterDataset:
     """Compute the normalized difference ``(ds - other) / (ds + other)``.
 
-    This is the family of indices that includes NDVI (NIR, Red) and NDWI
-    (Green, NIR): ``ds`` is the first band of the pair, ``other`` the second.
-    NumPy-backed inputs are promoted to rasterio, and ``other`` is resampled
-    onto ``ds``'s grid when ``auto_align`` is True.
+    This is the general primitive underlying the normalized-difference indices
+    (NDVI, NDWI, NDMI, NDBI): ``ds`` is the first band of the pair, ``other``
+    the second. Unlike the named indices, it operates on whole datasets
+    band-by-band rather than selecting a single band. NumPy-backed inputs are
+    promoted to rasterio, and ``other`` is resampled onto ``ds``'s grid when
+    ``auto_align`` is True.
 
     Parameters
     ----------
@@ -72,17 +178,12 @@ def normalized_difference(
     >>> ndvi = ds_nir.normalized_difference(ds_red)
     >>> ndvi_array = ds_nir.normalized_difference(ds_red, return_as_ndarray=True)
     """
-    # No-op when the dataset is already rasterio-backed
     ds = ds.to_rasterio()
     if ds.get_shape() != other.get_shape() or ds.get_transform() != other.get_transform():
         if auto_align:
             other = align_raster_to_target(other, ds, method=method)
         else:
-            raise AlignmentError(
-                "rasters must share the same grid for this operation; "
-                f"got shape {other.get_shape()} vs {ds.get_shape()}. "
-                "Pass auto_align=True to resample the other raster onto this grid."
-            )
+            raise AlignmentError(_ALIGN_MISMATCH.format(other=other.get_shape(), ds=ds.get_shape()))
 
     ds_nodata = get_nodata(ds)
     other_nodata = get_nodata(other)
@@ -91,13 +192,7 @@ def normalized_difference(
     a = a_raw.astype(rio.float32)
     b = b_raw.astype(rio.float32)
 
-    # np.where instead of in-place mask assignment so the expression stays
-    # dispatchable to lazy array backends (which reject item assignment). The
-    # denominator guard catches both 0/0 (nan) and x/0 (inf) at a+b == 0.
-    denom = a + b
-    with np.errstate(divide="ignore", invalid="ignore"):
-        quotient = (a - b) / denom
-    nd = np.where(denom != 0, quotient, np.float32(0))
+    nd = _safe_ratio(a - b, a + b)
 
     # Mask nodata last so a masked pixel is NaN regardless of its ratio.
     nd, out_nodata = apply_nodata_contract(
@@ -111,8 +206,6 @@ def normalized_difference(
         return nd
 
     meta = ds.get_metadata().copy()
-
-    # Ensure correct metadata for writing
     meta.update(
         driver="GTiff",
         dtype="float32",
@@ -127,3 +220,504 @@ def normalized_difference(
     out_ds.write(nd)
 
     return EEORasterDataset.from_rasterio(out_ds)
+
+
+@eeo_raster_op
+def ndvi(
+    ds: EEORasterDataset,
+    red: BandSpec,
+    *,
+    nir: BandSpec = 1,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Normalized Difference Vegetation Index.
+
+    ``NDVI = (NIR - Red) / (NIR + Red)``. Higher values indicate denser, more
+    photosynthetically active vegetation; values fall in ``[-1, 1]``.
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The NIR band defaults to band ``1`` of ``ds``, so
+    calling on a single-band NIR raster and passing the Red raster is enough.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster. When ``nir`` is an int index, this is the multi-band
+        scene the bands are read from; when ``nir`` defaults to band 1, this is
+        the NIR band itself.
+    red : EEORasterDataset or int
+        Red band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B4; Landsat 8/9 (OLI): B4.
+    nir : EEORasterDataset or int, default 1
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8; Landsat 8/9 (OLI): B5.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 NDVI in ``[-1, 1]`` — an ``EEORasterDataset`` by
+        default, or the raw 2D array when ``return_as_ndarray=True``. Pixels
+        where ``NIR + Red == 0`` are set to 0. A pixel that is nodata in any
+        input band is nodata (NaN) in the output; the output nodata value is
+        NaN when any input band declares nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise.
+
+    Examples
+    --------
+    >>> ndvi = nir_ds.ndvi(red_ds)          # separate band rasters
+    >>> ndvi = scene.ndvi(red=4, nir=8)     # bands of one Sentinel-2 stack
+    """
+    return _compute_index(
+        ds,
+        [nir, red],
+        _normalized_difference,
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+@eeo_raster_op
+def ndwi(
+    ds: EEORasterDataset,
+    nir: BandSpec,
+    *,
+    green: BandSpec = 1,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Normalized Difference Water Index (McFeeters, 1996).
+
+    ``NDWI = (Green - NIR) / (Green + NIR)``. Highlights open water, which
+    takes positive values while vegetation and soil go negative; values fall
+    in ``[-1, 1]``.
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The Green band defaults to band ``1`` of ``ds``, so
+    calling on a single-band Green raster and passing the NIR raster is enough.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster (the multi-band scene, or the Green band when ``green``
+        defaults to band 1).
+    nir : EEORasterDataset or int
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8; Landsat 8/9 (OLI): B5.
+    green : EEORasterDataset or int, default 1
+        Green band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B3; Landsat 8/9 (OLI): B3.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 NDWI in ``[-1, 1]`` — an ``EEORasterDataset`` by
+        default, or the raw 2D array when ``return_as_ndarray=True``. Pixels
+        where ``Green + NIR == 0`` are set to 0. A pixel that is nodata in any
+        input band is nodata (NaN) in the output; the output nodata value is
+        NaN when any input band declares nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise. This is McFeeters' water NDWI; the moisture variant is
+    :meth:`ndmi`.
+
+    Examples
+    --------
+    >>> ndwi = green_ds.ndwi(nir_ds)          # separate band rasters
+    >>> ndwi = scene.ndwi(nir=8, green=3)     # bands of one Sentinel-2 stack
+    """
+    return _compute_index(
+        ds,
+        [green, nir],
+        _normalized_difference,
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+@eeo_raster_op
+def ndmi(
+    ds: EEORasterDataset,
+    swir: BandSpec,
+    *,
+    nir: BandSpec = 1,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Normalized Difference Moisture Index.
+
+    ``NDMI = (NIR - SWIR1) / (NIR + SWIR1)``. Tracks vegetation water content;
+    higher values indicate wetter canopies. Values fall in ``[-1, 1]``.
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The NIR band defaults to band ``1`` of ``ds``, so
+    calling on a single-band NIR raster and passing the SWIR1 raster is enough.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster (the multi-band scene, or the NIR band when ``nir``
+        defaults to band 1).
+    swir : EEORasterDataset or int
+        SWIR1 band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B11; Landsat 8/9 (OLI): B6.
+    nir : EEORasterDataset or int, default 1
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8 (or B8A); Landsat 8/9 (OLI): B5.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 NDMI in ``[-1, 1]`` — an ``EEORasterDataset`` by
+        default, or the raw 2D array when ``return_as_ndarray=True``. Pixels
+        where ``NIR + SWIR1 == 0`` are set to 0. A pixel that is nodata in any
+        input band is nodata (NaN) in the output; the output nodata value is
+        NaN when any input band declares nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise. Sentinel-2's SWIR1 (B11) is 20 m; pass ``auto_align=True``
+    (the default) to resample it onto a 10 m NIR grid.
+
+    Examples
+    --------
+    >>> ndmi = nir_ds.ndmi(swir1_ds)          # separate band rasters
+    >>> ndmi = scene.ndmi(swir=11, nir=8)     # bands of one Sentinel-2 stack
+    """
+    return _compute_index(
+        ds,
+        [nir, swir],
+        _normalized_difference,
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+@eeo_raster_op
+def ndbi(
+    ds: EEORasterDataset,
+    nir: BandSpec,
+    *,
+    swir: BandSpec = 1,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Normalized Difference Built-up Index.
+
+    ``NDBI = (SWIR1 - NIR) / (SWIR1 + NIR)``. Highlights built-up and
+    impervious surfaces, which take higher values than vegetation. Values fall
+    in ``[-1, 1]``.
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The SWIR1 band defaults to band ``1`` of ``ds``, so
+    calling on a single-band SWIR1 raster and passing the NIR raster is enough.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster (the multi-band scene, or the SWIR1 band when ``swir``
+        defaults to band 1).
+    nir : EEORasterDataset or int
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8; Landsat 8/9 (OLI): B5.
+    swir : EEORasterDataset or int, default 1
+        SWIR1 band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B11; Landsat 8/9 (OLI): B6.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 NDBI in ``[-1, 1]`` — an ``EEORasterDataset`` by
+        default, or the raw 2D array when ``return_as_ndarray=True``. Pixels
+        where ``SWIR1 + NIR == 0`` are set to 0. A pixel that is nodata in any
+        input band is nodata (NaN) in the output; the output nodata value is
+        NaN when any input band declares nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise. Sentinel-2's SWIR1 (B11) is 20 m; pass ``auto_align=True``
+    (the default) to resample it onto a 10 m NIR grid.
+
+    Examples
+    --------
+    >>> ndbi = swir1_ds.ndbi(nir_ds)          # separate band rasters
+    >>> ndbi = scene.ndbi(nir=8, swir=11)     # bands of one Sentinel-2 stack
+    """
+    return _compute_index(
+        ds,
+        [swir, nir],
+        _normalized_difference,
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+@eeo_raster_op
+def evi(
+    ds: EEORasterDataset,
+    red: BandSpec,
+    blue: BandSpec,
+    *,
+    nir: BandSpec = 1,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Enhanced Vegetation Index.
+
+    ``EVI = 2.5 * (NIR - Red) / (NIR + 6*Red - 7.5*Blue + 1)`` using the
+    standard MODIS/Sentinel-2 coefficients (gain 2.5; aerosol terms 6 and 7.5;
+    canopy background 1). EVI reduces the atmospheric and soil-background
+    effects that saturate NDVI over dense canopies.
+
+    EVI assumes surface reflectance scaled to roughly ``[0, 1]``; if your bands
+    are integer DN or reflectance scaled by 10000, divide by the scale factor
+    first (e.g. ``scene.divide(10000).evi(...)``).
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The NIR band defaults to band ``1`` of ``ds``.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster (the multi-band scene, or the NIR band when ``nir``
+        defaults to band 1).
+    red : EEORasterDataset or int
+        Red band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B4; Landsat 8/9 (OLI): B4.
+    blue : EEORasterDataset or int
+        Blue band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B2; Landsat 8/9 (OLI): B2.
+    nir : EEORasterDataset or int, default 1
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8; Landsat 8/9 (OLI): B5.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 EVI (typically ``[-1, 1]`` for valid reflectance) —
+        an ``EEORasterDataset`` by default, or the raw 2D array when
+        ``return_as_ndarray=True``. Pixels where the denominator is 0 are set
+        to 0. A pixel that is nodata in any input band is nodata (NaN) in the
+        output; the output nodata value is NaN when any input band declares
+        nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise.
+
+    Examples
+    --------
+    >>> evi = nir_ds.evi(red_ds, blue_ds)             # separate band rasters
+    >>> evi = scene.evi(red=4, blue=2, nir=8)         # bands of one S2 stack
+    """
+    return _compute_index(
+        ds,
+        [nir, red, blue],
+        _evi_formula,
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+def _evi_formula(bands):
+    """Standard-coefficient EVI over ``[nir, red, blue]`` float32 bands."""
+    nir, red, blue = bands
+    return _safe_ratio(2.5 * (nir - red), nir + 6.0 * red - 7.5 * blue + 1.0)
+
+
+@eeo_raster_op
+def savi(
+    ds: EEORasterDataset,
+    red: BandSpec,
+    *,
+    nir: BandSpec = 1,
+    soil_factor: float = 0.5,
+    auto_align: bool = True,
+    method: str = "bilinear",
+    return_as_ndarray: bool = False,
+) -> np.ndarray | EEORasterDataset:
+    """Compute the Soil-Adjusted Vegetation Index.
+
+    ``SAVI = (1 + L) * (NIR - Red) / (NIR + Red + L)`` where ``L`` is the soil
+    brightness correction (``soil_factor``). SAVI dampens soil-background
+    influence in sparsely vegetated areas; with ``L = 0`` it reduces to NDVI.
+
+    Each band is either a separate ``EEORasterDataset`` or a 1-based ``int``
+    band index into ``ds``. The NIR band defaults to band ``1`` of ``ds``.
+
+    Parameters
+    ----------
+    ds : EEORasterDataset
+        Receiver raster (the multi-band scene, or the NIR band when ``nir``
+        defaults to band 1).
+    red : EEORasterDataset or int
+        Red band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B4; Landsat 8/9 (OLI): B4.
+    nir : EEORasterDataset or int, default 1
+        NIR band, as a separate raster or a 1-based band index into ``ds``.
+        Sentinel-2: B8; Landsat 8/9 (OLI): B5.
+    soil_factor : float, default 0.5
+        Soil brightness correction ``L`` in ``[0, 1]``: 0 for dense
+        vegetation (equivalent to NDVI), 1 for very sparse cover; 0.5 is the
+        common default for intermediate cover.
+    auto_align : bool, default True
+        If True, resample a dataset band onto ``ds``'s grid when their shape or
+        transform differ. If False, a mismatch raises ``AlignmentError``.
+    method : str, default "bilinear"
+        Resampling method used when ``auto_align`` triggers alignment; one of
+        rasterio's resampling names (e.g. ``"nearest"``, ``"bilinear"``).
+    return_as_ndarray : bool, default False
+        If True, return the raw 2D ``(height, width)`` NumPy array instead of
+        an ``EEORasterDataset``.
+
+    Returns
+    -------
+    EEORasterDataset or numpy.ndarray
+        Single-band float32 SAVI in ``[-1, 1]`` — an ``EEORasterDataset`` by
+        default, or the raw 2D array when ``return_as_ndarray=True``. Pixels
+        where ``NIR + Red + L == 0`` are set to 0. A pixel that is nodata in
+        any input band is nodata (NaN) in the output; the output nodata value
+        is NaN when any input band declares nodata, otherwise None.
+
+    Raises
+    ------
+    AlignmentError
+        If a dataset band is on a different grid and ``auto_align`` is False.
+    IndexError
+        If an int band index is outside the range of available bands.
+    ValidationError
+        If a band argument is neither an ``EEORasterDataset`` nor an int.
+
+    Notes
+    -----
+    Reads the required bands fully into memory rather than streaming
+    block-wise.
+
+    Examples
+    --------
+    >>> savi = nir_ds.savi(red_ds, soil_factor=0.5)   # separate band rasters
+    >>> savi = scene.savi(red=4, nir=8)               # bands of one S2 stack
+    """
+    return _compute_index(
+        ds,
+        [nir, red],
+        lambda bands: _savi_formula(bands, soil_factor),
+        auto_align=auto_align,
+        method=method,
+        return_as_ndarray=return_as_ndarray,
+    )
+
+
+def _savi_formula(bands, soil_factor):
+    """Soil-adjusted vegetation index over ``[nir, red]`` float32 bands."""
+    nir, red = bands
+    return _safe_ratio((1.0 + soil_factor) * (nir - red), nir + red + soil_factor)

--- a/eeo/core/core.pyi
+++ b/eeo/core/core.pyi
@@ -16,6 +16,7 @@ from rasterio import CRS
 from rasterio.coords import BoundingBox
 from rasterio.enums import Resampling
 
+from eeo.analysis.indices import BandSpec
 from eeo.analysis.stats import Coordinate
 from eeo.core.adapters import BaseRasterAdapter
 from eeo.core.types import ResamplingMethod
@@ -107,6 +108,16 @@ class EEORasterDataset:
         method: str = ...,
         safe: bool = ...,
     ) -> EEORasterDataset: ...
+    def evi(
+        self,
+        red: BandSpec,
+        blue: BandSpec,
+        *,
+        nir: BandSpec = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
     def extract_value_at_coordinate(
         self, coordinates: Coordinate, band_idx: int = ...
     ) -> int | float: ...
@@ -139,6 +150,42 @@ class EEORasterDataset:
     def multiply(
         self, other: EEORasterDataset | float | int, *, auto_align: bool = ..., method: str = ...
     ) -> EEORasterDataset: ...
+    def ndbi(
+        self,
+        nir: BandSpec,
+        *,
+        swir: BandSpec = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
+    def ndmi(
+        self,
+        swir: BandSpec,
+        *,
+        nir: BandSpec = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
+    def ndvi(
+        self,
+        red: BandSpec,
+        *,
+        nir: BandSpec = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
+    def ndwi(
+        self,
+        nir: BandSpec,
+        *,
+        green: BandSpec = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
     def normalize_min_max(
         self, *, new_min: float | int = ..., new_max: float | int = ...
     ) -> EEORasterDataset: ...
@@ -229,6 +276,16 @@ class EEORasterDataset:
         plot_kwargs=...,
         show_preview: bool = ...,
     ) -> EEORasterDataset: ...
+    def savi(
+        self,
+        red: BandSpec,
+        *,
+        nir: BandSpec = ...,
+        soil_factor: float = ...,
+        auto_align: bool = ...,
+        method: str = ...,
+        return_as_ndarray: bool = ...,
+    ) -> np.ndarray | EEORasterDataset: ...
     def sqrt(self) -> EEORasterDataset: ...
     def stack(self, others: EEORasterDataset | Iterable[EEORasterDataset]) -> EEORasterDataset: ...
     def standardize(self) -> EEORasterDataset: ...

--- a/scripts/generate_core_stub.py
+++ b/scripts/generate_core_stub.py
@@ -71,6 +71,7 @@ from rasterio import CRS
 from rasterio.coords import BoundingBox
 from rasterio.enums import Resampling
 
+from eeo.analysis.indices import BandSpec
 from eeo.analysis.stats import Coordinate
 from eeo.core.adapters import BaseRasterAdapter
 from eeo.core.types import ResamplingMethod

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -1,0 +1,215 @@
+"""Value-correctness and contract tests for the spectral index library."""
+
+import numpy as np
+import pytest
+from affine import Affine
+from rasterio.crs import CRS
+
+from eeo import load_array
+from eeo.core.core import EEORasterDataset
+from eeo.core.exceptions import AlignmentError, ValidationError
+
+UTM_CRS = CRS.from_epsg(32633)
+
+# A north-up 2x2 grid shared by every band raster below.
+_TRANSFORM = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+
+# Deterministic band values chosen so every index is hand-computable and no
+# denominator is zero.
+NIR = np.array([[0.4, 0.6], [0.8, 0.5]], dtype=np.float32)
+RED = np.array([[0.2, 0.1], [0.3, 0.25]], dtype=np.float32)
+BLUE = np.array([[0.1, 0.05], [0.2, 0.15]], dtype=np.float32)
+GREEN = np.array([[0.3, 0.35], [0.25, 0.4]], dtype=np.float32)
+SWIR = np.array([[0.15, 0.2], [0.35, 0.3]], dtype=np.float32)
+
+
+def _band(array, nodata=None):
+    """Build a rasterio-backed single-band raster on the shared grid."""
+    return load_array(array, transform=_TRANSFORM, crs=UTM_CRS, nodata=nodata).to_rasterio()
+
+
+def _nd(a, b):
+    """Reference normalized difference ``(a - b) / (a + b)``."""
+    return (a - b) / (a + b)
+
+
+# ---------------------------------------------------------------------------
+# Value correctness (hand-computed reference arrays)
+# ---------------------------------------------------------------------------
+def test_ndvi_matches_reference():
+    result = _band(NIR).ndvi(_band(RED), return_as_ndarray=True)
+    assert np.allclose(result, _nd(NIR, RED))
+
+
+def test_ndwi_matches_reference():
+    # McFeeters water NDWI: (Green - NIR) / (Green + NIR), called on Green.
+    result = _band(GREEN).ndwi(_band(NIR), return_as_ndarray=True)
+    assert np.allclose(result, _nd(GREEN, NIR))
+
+
+def test_ndmi_matches_reference():
+    result = _band(NIR).ndmi(_band(SWIR), return_as_ndarray=True)
+    assert np.allclose(result, _nd(NIR, SWIR))
+
+
+def test_ndbi_matches_reference():
+    # Built-up NDBI: (SWIR1 - NIR) / (SWIR1 + NIR), called on SWIR1.
+    result = _band(SWIR).ndbi(_band(NIR), return_as_ndarray=True)
+    assert np.allclose(result, _nd(SWIR, NIR))
+
+
+def test_evi_matches_reference():
+    result = _band(NIR).evi(_band(RED), _band(BLUE), return_as_ndarray=True)
+    expected = 2.5 * (NIR - RED) / (NIR + 6.0 * RED - 7.5 * BLUE + 1.0)
+    assert np.allclose(result, expected)
+
+
+def test_savi_matches_reference():
+    result = _band(NIR).savi(_band(RED), soil_factor=0.5, return_as_ndarray=True)
+    expected = (1.0 + 0.5) * (NIR - RED) / (NIR + RED + 0.5)
+    assert np.allclose(result, expected)
+
+
+def test_savi_with_zero_soil_factor_equals_ndvi():
+    savi = _band(NIR).savi(_band(RED), soil_factor=0.0, return_as_ndarray=True)
+    ndvi = _band(NIR).ndvi(_band(RED), return_as_ndarray=True)
+    assert np.allclose(savi, ndvi)
+
+
+# ---------------------------------------------------------------------------
+# Band-index selection vs separate datasets are equivalent
+# ---------------------------------------------------------------------------
+def test_band_index_selection_matches_separate_datasets():
+    scene = _band(np.stack([NIR, RED]))  # 2-band stack: band 1 NIR, band 2 Red
+    from_indices = scene.ndvi(red=2, nir=1, return_as_ndarray=True)
+    from_datasets = _band(NIR).ndvi(_band(RED), return_as_ndarray=True)
+    assert np.allclose(from_indices, from_datasets)
+
+
+def test_evi_band_index_selection():
+    scene = _band(np.stack([NIR, RED, BLUE]))
+    result = scene.evi(red=2, blue=3, nir=1, return_as_ndarray=True)
+    expected = 2.5 * (NIR - RED) / (NIR + 6.0 * RED - 7.5 * BLUE + 1.0)
+    assert np.allclose(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# Output type, dtype, and chainability
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: _band(NIR).ndvi(_band(RED)),
+        lambda: _band(GREEN).ndwi(_band(NIR)),
+        lambda: _band(NIR).ndmi(_band(SWIR)),
+        lambda: _band(SWIR).ndbi(_band(NIR)),
+        lambda: _band(NIR).evi(_band(RED), _band(BLUE)),
+        lambda: _band(NIR).savi(_band(RED)),
+    ],
+)
+def test_index_returns_single_band_float32_dataset(call):
+    result = call()
+    assert isinstance(result, EEORasterDataset)
+    meta = result.get_metadata()
+    assert meta["dtype"] == "float32"
+    assert result.get_count() == 1
+    # Chainable: the result is itself a dataset an op can consume.
+    doubled = result.multiply(2)
+    assert isinstance(doubled, EEORasterDataset)
+
+
+def test_index_result_is_chainable_end_to_end():
+    result = _band(NIR).ndvi(_band(RED)).multiply(100).add(1)
+    assert isinstance(result, EEORasterDataset)
+
+
+# ---------------------------------------------------------------------------
+# Nodata propagation
+# ---------------------------------------------------------------------------
+def test_nodata_is_contagious_and_output_nodata_is_nan():
+    nir = NIR.copy()
+    nir[0, 0] = -9999.0
+    result = _band(nir, nodata=-9999.0).ndvi(_band(RED))
+    meta = result.get_metadata()
+    assert meta["nodata"] is not None and np.isnan(meta["nodata"])
+
+    data = result.read()[0]
+    assert np.isnan(data[0, 0])  # masked pixel
+    assert not np.isnan(data[1, 1])  # valid pixel survives
+
+
+def test_nodata_in_second_band_propagates():
+    red = RED.copy()
+    red[1, 1] = -1.0
+    result = _band(NIR).ndvi(_band(red, nodata=-1.0), return_as_ndarray=True)
+    assert np.isnan(result[1, 1])
+    assert not np.isnan(result[0, 0])
+
+
+def test_no_declared_nodata_yields_none_nodata():
+    result = _band(NIR).ndvi(_band(RED))
+    assert result.get_metadata()["nodata"] is None
+
+
+# ---------------------------------------------------------------------------
+# Numerical safety: zero denominator guarded to 0
+# ---------------------------------------------------------------------------
+def test_zero_denominator_maps_to_zero():
+    zeros = np.zeros((2, 2), dtype=np.float32)
+    result = _band(zeros).ndvi(_band(zeros), return_as_ndarray=True)
+    assert np.all(result == 0)
+    assert not np.any(np.isnan(result))
+
+
+# ---------------------------------------------------------------------------
+# Alignment
+# ---------------------------------------------------------------------------
+def test_mismatched_grid_raises_without_auto_align():
+    coarse = load_array(
+        np.ones((1, 1), dtype=np.float32),
+        transform=Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(20.0, -20.0),
+        crs=UTM_CRS,
+    ).to_rasterio()
+    with pytest.raises(AlignmentError):
+        _band(NIR).ndvi(coarse, auto_align=False)
+
+
+def test_mismatched_grid_auto_aligns_by_default():
+    coarse = load_array(
+        np.full((1, 1), 0.2, dtype=np.float32),
+        transform=Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(20.0, -20.0),
+        crs=UTM_CRS,
+    ).to_rasterio()
+    result = _band(NIR).ndvi(coarse)  # auto_align=True by default
+    assert result.get_shape() == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+def test_invalid_band_spec_type_raises_validation_error():
+    with pytest.raises(ValidationError):
+        _band(NIR).ndvi(2.5)  # float is neither a dataset nor an int index
+
+
+def test_out_of_range_band_index_raises_index_error():
+    with pytest.raises(IndexError):
+        _band(NIR).ndvi(red=5, nir=1)  # single-band raster has no band 5
+
+
+# ---------------------------------------------------------------------------
+# Provenance preservation (timestamp / attrs survive the operation)
+# ---------------------------------------------------------------------------
+def test_index_preserves_provenance():
+    from datetime import datetime
+
+    nir = load_array(
+        NIR,
+        transform=_TRANSFORM,
+        crs=UTM_CRS,
+        timestamp=datetime(2024, 6, 1),
+        attrs={"tile": "T33"},
+    ).to_rasterio()
+    result = nir.ndvi(_band(RED))
+    assert result.timestamp == datetime(2024, 6, 1)
+    assert result.attrs == {"tile": "T33"}


### PR DESCRIPTION
## Summary

Adds a built-in spectral index library with chainable implementations of six commonly used remote sensing indices. All indices follow the library's nodata and dtype contract, support both band-index and dataset-based inputs, include comprehensive documentation, and are backed by correctness and regression tests.

## Related issues / tasks

- **Spectral Index Library**

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behavior is stated in the docstring and covered by a test
- [x] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

- Added chainable implementations of the following spectral indices:
  - NDVI
  - NDWI
  - NDMI
  - NDBI
  - EVI
  - SAVI
- Each index accepts either another `EEORasterDataset` or a 1-based band index
  into the receiver, allowing both multi-band and separate-raster workflows.
- Shared helper functions centralize band resolution, ratio computation, nodata
  propagation, zero-denominator handling, and float32 output to ensure
  consistent behavior across all indices.
- Added comprehensive docstrings including mathematical formulas, recommended
  Sentinel-2 and Landsat 8/9 band mappings, and runnable examples for both
  supported calling styles.
- Added correctness tests against hand-computed reference arrays, along with
  regression tests covering nodata handling, float32 output, chainability,
  alignment checks, zero-denominator behavior, and input validation.
- Added a new user guide page documenting the available spectral indices,
  sensor band conventions, and a build-generated comparison figure for all
  implemented indices.