### PR TITLE
Feature/example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ htmlcov/
 
 # OS
 .DS_Store
+
+# Sample data (downloaded, not tracked)
+sample-data/
+scripts/build_sample_data.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,20 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **Sample-data helper (`eeo.datasets`).** `eeo.datasets.load(name)` fetches a
+  small curated Sentinel-2 / Copernicus-DEM sample and returns it ready to use
+  (band names and acquisition timestamp already set for rasters; the cached
+  path for vectors); `eeo.datasets.fetch(name)` returns the cached file path(s)
+  without opening them. Files download on first use to `~/.cache/easy-eo`
+  (override with `EEO_DATA_DIR`, or `XDG_CACHE_HOME`) and are verified against a
+  checksum shipped inside the package, so fetches are instant after the first
+  call and never return corrupt data. `available()` lists the datasets and
+  `info(name)` prints the description and required Copernicus attribution.
+  Downloading uses only the standard library — no new dependency. Registered
+  datasets: `sentinel2_small` (a single pre-stacked 4-band GeoTIFF),
+  `sentinel2_small_cog` (its COG variant), `sentinel2_small_bands` (the same
+  four bands as separate single-band files), `dem_small`, `dem_small_cog`, and
+  `sentinel2_small_boundary`.
 - **Band names on `EEORasterDataset`.** Datasets now carry an optional
   per-band name list (one entry per band, `None` for an unnamed band), seeded
   from the raster's GDAL band descriptions at load time. Read or replace them
@@ -174,6 +188,11 @@ are called out under a **Breaking** heading.
 
 ### Fixed
 
+- **`plot_composite(stretch=True)` no longer renders integer rasters black.**
+  The percentile-stretched channels (floats in ``[0, 1]``) were written back
+  into the composite's integer band dtype, truncating every value below 1 to 0
+  — so a true-colour composite of any integer raster (e.g. Sentinel-2
+  reflectance) came out black. The composite now stays floating when stretched.
 - `normalized_difference` no longer leaves `inf` where the denominator is zero
   but the numerator is not (``ds + other == 0`` with ``ds != other``); the
   zero-denominator guard now sets both the ``0/0`` and ``x/0`` cases to 0.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,6 +75,7 @@ arithmetic, computing indices, and visualizing results.
 
    getting_started
    user_guide/core_dataset
+   user_guide/sample_data
    user_guide/band_names
    user_guide/ops
    user_guide/spectral_indices
@@ -91,6 +92,7 @@ arithmetic, computing indices, and visualizing results.
    modules/core
    modules/adapters
    modules/analysis
+   modules/datasets
    modules/ops
    modules/preprocessing
    modules/viz

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -1,0 +1,6 @@
+Datasets Module
+===============
+
+.. automodule:: eeo.datasets
+    :members: fetch, load, info, available, cache_dir, DatasetError
+    :show-inheritance:

--- a/docs/source/user_guide/sample_data.rst
+++ b/docs/source/user_guide/sample_data.rst
@@ -1,0 +1,125 @@
+Sample Data
+===========
+
+Easy-EO ships a tiny, curated sample so every tutorial and quickstart runs in
+minutes without hunting for data. The helpers in :mod:`eeo.datasets` download a
+hosted Sentinel-2 / Copernicus-DEM subset on first use, cache it locally, and
+verify it against a checksum baked into the package — so a fetch is instant
+after the first call and never returns corrupt data. Downloading uses only the
+Python standard library, so it adds **no extra dependency**.
+
+.. seealso::
+
+   :doc:`band_names` for how the loaded bands are addressed by name, and
+   :doc:`spectral_indices` for computing NDVI and friends on the sample.
+
+-----
+
+Loading the sample
+------------------
+
+``load()`` returns a ready-to-use dataset for rasters — band names and the
+acquisition timestamp are already set — so you can go straight to analysis:
+
+.. code-block:: python
+
+   import eeo
+
+   scene = eeo.datasets.load("sentinel2_small")
+   scene.band_names          # ['blue', 'green', 'red', 'nir']
+   scene.timestamp           # 2023-09-07 10:00:31+00:00
+
+   ndvi = scene.ndvi(red="red", nir="nir")
+   ndvi.plot_raster()
+
+Vector datasets have no raster representation, so ``load()`` returns their
+cached path — read them with GeoPandas:
+
+.. code-block:: python
+
+   import geopandas as gpd
+
+   boundary = gpd.read_file(eeo.datasets.load("sentinel2_small_boundary"))
+   clipped = scene.clip_raster_with_vector(boundary)
+
+Getting file paths with ``fetch()``
+-----------------------------------
+
+When you want the files rather than an opened dataset — to pass to another
+library, or to work with the Cloud-Optimized GeoTIFFs directly — use
+``fetch()``. It returns a single :class:`~pathlib.Path` for a one-file dataset,
+or a list of paths (in band order) for a multi-file one:
+
+.. code-block:: python
+
+   scene_path = eeo.datasets.fetch("sentinel2_small")         # Path (one 4-band file)
+   boundary_path = eeo.datasets.fetch("sentinel2_small_boundary")  # Path
+   band_paths = eeo.datasets.fetch("sentinel2_small_bands")   # [Path, Path, Path, Path]
+
+Available datasets
+------------------
+
+List everything with ``eeo.datasets.available()``; describe one with
+``eeo.datasets.info(name)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 10 64
+
+   * - Name
+     - Kind
+     - Contents
+   * - ``sentinel2_small``
+     - raster
+     - Sentinel-2 L2A blue/green/red/nir as one 4-band file, 1024×1024 @ 10 m,
+       EPSG:32633.
+   * - ``sentinel2_small_cog``
+     - raster
+     - Cloud-Optimized GeoTIFF variant of the 4-band stack (HTTP range-read).
+   * - ``sentinel2_small_bands``
+     - raster
+     - The same four bands as *separate* single-band files (stacked in memory
+       on load); handy for workflows that treat bands as individual rasters.
+   * - ``dem_small``
+     - raster
+     - Copernicus GLO-30 DEM warped onto the same grid (float32 metres).
+   * - ``dem_small_cog``
+     - raster
+     - Cloud-Optimized GeoTIFF variant of the DEM.
+   * - ``sentinel2_small_boundary``
+     - vector
+     - Region-of-interest polygon (GeoPackage, EPSG:4326) inside the footprint.
+
+``sentinel2_small`` is a single pre-stacked 4-band GeoTIFF, so ``load`` opens it
+lazily and ``fetch`` returns one path; ``sentinel2_small_bands`` is the same
+imagery split across four single-band files, read into an in-memory stack on
+load and returned by ``fetch`` as a list of paths. All names share one
+1024×1024 grid (the DEM is warped to match), so the imagery, elevation, and
+boundary overlay pixel-for-pixel.
+
+Where files are cached
+----------------------
+
+Files are cached under ``~/.cache/easy-eo`` by default. The location is
+resolved as:
+
+1. ``$EEO_DATA_DIR`` if set,
+2. ``$XDG_CACHE_HOME/easy-eo`` if ``XDG_CACHE_HOME`` is set,
+3. ``~/.cache/easy-eo`` otherwise.
+
+A cached file whose checksum still matches is reused untouched; a missing or
+corrupted file is transparently re-downloaded.
+
+Licensing and attribution
+--------------------------
+
+The sample is derived from open Copernicus data. If you redistribute figures or
+data made from it, carry the attribution — ``eeo.datasets.info(name)`` prints
+the exact text:
+
+- **Sentinel-2:** *Contains modified Copernicus Sentinel-2 L2A data 2023 (tile
+  T33UUP, acquired 2023-09-07), processed by ESA; accessed via Microsoft
+  Planetary Computer.*
+- **Copernicus DEM GLO-30:** *© DLR e.V. 2010–2014 and © Airbus Defence and
+  Space GmbH 2014–2018, provided under COPERNICUS by the European Union and
+  ESA; accessed via Microsoft Planetary Computer.*

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -4,6 +4,7 @@ A lightweight library of chainable raster operations, algebra, and
 visualization built on rasterio, NumPy, GeoPandas, and matplotlib.
 """
 
+from . import datasets
 from ._show_versions import show_versions
 from .analysis import *
 from .core import (
@@ -21,6 +22,7 @@ from .preprocessing import *
 from .viz import *
 
 __all__ = [
+    "datasets",
     "load_raster",
     "load_array",
     "show_versions",

--- a/eeo/datasets/__init__.py
+++ b/eeo/datasets/__init__.py
@@ -1,0 +1,183 @@
+"""Curated sample datasets with checksum-verified caching.
+
+The functions here download a small, hosted Sentinel-2 / Copernicus-DEM sample
+so tutorials and quickstarts run in minutes without hunting for data. Files are
+cached under ``~/.cache/easy-eo`` (override with ``EEO_DATA_DIR``) and verified
+against a checksum shipped inside the package, so a fetch is fast after the
+first call and never returns corrupt data.
+
+Downloading uses only the Python standard library - no extra dependency.
+
+Examples
+--------
+>>> import eeo
+>>> ds = eeo.datasets.load("sentinel2_small")
+>>> ndvi = ds.ndvi(red="red", nir="nir")
+>>> boundary = eeo.datasets.fetch("sentinel2_small_boundary")
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import rasterio
+
+from eeo.core.core import EEORasterDataset
+from eeo.core.loader import load_array, load_raster
+
+from ._cache import DatasetError, cache_dir, ensure_asset
+from ._registry import available, get_dataset
+
+__all__ = ["fetch", "load", "info", "available", "cache_dir", "DatasetError"]
+
+
+def fetch(name: str) -> Path | list[Path]:
+    """Download a sample dataset and return its cached path(s).
+
+    The file is downloaded on first use and verified against a pinned checksum;
+    subsequent calls return the cached copy without touching the network.
+
+    Parameters
+    ----------
+    name : str
+        A registered dataset name. See :func:`available` for the full list.
+
+    Returns
+    -------
+    pathlib.Path or list of pathlib.Path
+        The cached file path for a single-file dataset, or a list of paths (in
+        band order) for a multi-file dataset such as ``"sentinel2_small"``.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered dataset.
+    DatasetError
+        If a download fails or a file fails checksum verification.
+
+    Examples
+    --------
+    >>> boundary = fetch("sentinel2_small_boundary")
+    >>> band_paths = fetch("sentinel2_small")
+    """
+    dataset = get_dataset(name)
+    paths = [ensure_asset(asset) for asset in dataset.assets]
+    return paths if dataset.multi else paths[0]
+
+
+def load(name: str) -> EEORasterDataset | Path:
+    """Fetch a sample dataset and open it ready to use.
+
+    Raster datasets are returned as an :class:`~eeo.core.core.EEORasterDataset`
+    with band names and acquisition timestamp already set; a single-file raster
+    is opened lazily via :func:`eeo.load_raster`, while a multi-band dataset
+    backed by several single-band files is read into an in-memory stack (the
+    sample is small by design). Vector datasets have no raster representation,
+    so their cached path is returned unchanged — read them with GeoPandas.
+
+    Parameters
+    ----------
+    name : str
+        A registered dataset name. See :func:`available` for the full list.
+
+    Returns
+    -------
+    EEORasterDataset or pathlib.Path
+        An opened dataset for raster entries; the cached file path for vector
+        entries.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered dataset.
+    DatasetError
+        If a download fails or a file fails checksum verification.
+
+    Notes
+    -----
+    A multi-file raster (e.g. ``"sentinel2_small"``) is read eagerly into a
+    NumPy-backed dataset when stacked; single-file rasters remain lazy until an
+    operation needs pixels.
+
+    Examples
+    --------
+    >>> ds = load("sentinel2_small")
+    >>> ds.band_names
+    ['blue', 'green', 'red', 'nir']
+    >>> import geopandas as gpd
+    >>> roi = gpd.read_file(load("sentinel2_small_boundary"))
+    """
+    dataset = get_dataset(name)
+    paths = fetch(name)
+
+    if dataset.kind == "vector":
+        return paths  # type: ignore[return-value]  # single-asset vector -> Path
+
+    if not dataset.multi:
+        return load_raster(
+            str(paths),  # single-asset raster -> Path
+            timestamp=dataset.timestamp,
+            band_names=dataset.band_names or None,
+        )
+
+    return _load_stack(paths, dataset.timestamp, dataset.nodata, dataset.band_names)  # type: ignore[arg-type]
+
+
+def _load_stack(
+    paths: list[Path],
+    timestamp: datetime | None,
+    nodata: float | int | None,
+    band_names: list[str | None],
+) -> EEORasterDataset:
+    """Read single-band files into one georeferenced multi-band dataset."""
+    bands = []
+    transform = crs = None
+    for path in paths:
+        with rasterio.open(path) as src:
+            if transform is None:
+                transform, crs = src.transform, src.crs
+            bands.append(src.read(1))
+    stack = np.stack(bands)
+    return load_array(
+        stack,
+        transform=transform,
+        crs=crs,
+        nodata=nodata,
+        timestamp=timestamp,
+        band_names=band_names or None,
+    )
+
+
+def info(name: str) -> str:
+    """Return a human-readable description and attribution for a dataset.
+
+    Parameters
+    ----------
+    name : str
+        A registered dataset name.
+
+    Returns
+    -------
+    str
+        A multi-line summary: the description followed by the data
+        licence/attribution that must accompany reuse.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered dataset.
+
+    Examples
+    --------
+    >>> print(info("sentinel2_small"))
+    """
+    dataset = get_dataset(name)
+    files = ", ".join(asset.remote for asset in dataset.assets)
+    return (
+        f"{dataset.name} ({dataset.kind})\n"
+        f"  {dataset.description}\n"
+        f"  files: {files}\n"
+        f"  attribution: {dataset.attribution}"
+    )

--- a/eeo/datasets/_cache.py
+++ b/eeo/datasets/_cache.py
@@ -1,0 +1,118 @@
+"""Local caching and checksum-verified download of sample assets.
+
+Downloads use only the Python standard library (``urllib`` + ``hashlib``), so
+:mod:`eeo.datasets` adds no runtime dependency. Files are cached under a
+per-user directory and re-verified on every access, so a corrupt or partial
+download is transparently repaired.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from eeo.core.exceptions import EEOError
+
+from ._registry import BASE_URL, Asset
+
+_CHUNK = 1 << 20  # 1 MiB streaming reads keep peak memory flat on large assets.
+
+
+class DatasetError(EEOError):
+    """Raised when a sample dataset cannot be fetched or verified."""
+
+
+def cache_dir() -> Path:
+    """Return the directory sample assets are cached in, creating it.
+
+    Resolution order:
+
+    1. ``EEO_DATA_DIR`` environment variable, if set (used by tests and CI).
+    2. ``XDG_CACHE_HOME/easy-eo`` when ``XDG_CACHE_HOME`` is set.
+    3. ``~/.cache/easy-eo`` otherwise.
+
+    Returns
+    -------
+    pathlib.Path
+        The cache directory. It is created (with parents) if absent.
+    """
+    override = os.environ.get("EEO_DATA_DIR")
+    if override:
+        base = Path(override)
+    elif os.environ.get("XDG_CACHE_HOME"):
+        base = Path(os.environ["XDG_CACHE_HOME"]) / "easy-eo"
+    else:
+        base = Path.home() / ".cache" / "easy-eo"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _download(url: str, dest: Path) -> None:
+    """Stream ``url`` to ``dest`` atomically (via a temp file + rename)."""
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(dest.parent), suffix=".part")
+    tmp = Path(tmp_name)
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": "easy-eo"})
+        with urllib.request.urlopen(request) as response, os.fdopen(tmp_fd, "wb") as out:
+            shutil.copyfileobj(response, out, _CHUNK)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+        tmp.unlink(missing_ok=True)
+        raise DatasetError(
+            f"failed to download sample data from {url}: {exc}. "
+            "Check your network connection and try again."
+        ) from exc
+    os.replace(tmp, dest)
+
+
+def ensure_asset(asset: Asset) -> Path:
+    """Return the cached path of ``asset``, downloading and verifying if needed.
+
+    A cached copy whose checksum matches is returned untouched. A missing or
+    checksum-mismatched copy is (re)downloaded and re-verified; a download that
+    still fails verification raises rather than returning corrupt data.
+
+    Parameters
+    ----------
+    asset : Asset
+        Registry asset to materialize.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the verified local file.
+
+    Raises
+    ------
+    DatasetError
+        If the download fails, or the downloaded bytes do not match the pinned
+        sha256 (indicating corruption or a changed remote file).
+    """
+    dest = cache_dir() / asset.remote
+    if dest.is_file() and _sha256(dest) == asset.sha256:
+        return dest
+
+    url = BASE_URL + asset.remote
+    _download(url, dest)
+
+    digest = _sha256(dest)
+    if digest != asset.sha256:
+        dest.unlink(missing_ok=True)
+        raise DatasetError(
+            f"checksum mismatch for {asset.remote}: expected {asset.sha256}, got "
+            f"{digest}. The remote file may have changed or the download was "
+            "corrupted; please retry, and report the issue if it persists."
+        )
+    return dest

--- a/eeo/datasets/_cache.py
+++ b/eeo/datasets/_cache.py
@@ -65,9 +65,14 @@ def _download(url: str, dest: Path) -> None:
     tmp_fd, tmp_name = tempfile.mkstemp(dir=str(dest.parent), suffix=".part")
     tmp = Path(tmp_name)
     try:
-        request = urllib.request.Request(url, headers={"User-Agent": "easy-eo"})
-        with urllib.request.urlopen(request) as response, os.fdopen(tmp_fd, "wb") as out:
-            shutil.copyfileobj(response, out, _CHUNK)
+        # Wrap the temp fd in its closing context BEFORE opening the URL, so a
+        # failure in urlopen still closes the file. Otherwise the descriptor
+        # leaks open and the cleanup unlink below fails on Windows, where an
+        # open file cannot be deleted (WinError 32).
+        with os.fdopen(tmp_fd, "wb") as out:
+            request = urllib.request.Request(url, headers={"User-Agent": "easy-eo"})
+            with urllib.request.urlopen(request) as response:
+                shutil.copyfileobj(response, out, _CHUNK)
     except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
         tmp.unlink(missing_ok=True)
         raise DatasetError(

--- a/eeo/datasets/_registry.py
+++ b/eeo/datasets/_registry.py
@@ -1,0 +1,253 @@
+"""Curated sample-dataset registry for :mod:`eeo.datasets`.
+
+Each entry maps a logical dataset name to the remote assets hosting it, with a
+pinned sha256 so a download is verified against a checksum that ships *inside*
+the package (never fetched over the same channel as the data). Assets are
+served from a GitHub Release; see ``BASE_URL``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+#: Root URL of the hosted sample assets (a GitHub Release; asset paths are
+#: flattened by GitHub, so every remote name here is a bare filename).
+BASE_URL = "https://github.com/Tommy-Burns/easy-eo/releases/download/sample-data-v1/"
+
+#: Acquisition time of the Sentinel-2 scene the samples are cut from.
+_S2_ACQUIRED = datetime(2023, 9, 7, 10, 0, 31, tzinfo=timezone.utc)
+
+#: Human-facing provenance/attribution shown by :func:`eeo.datasets.info` and
+#: required by the data licence.
+_S2_ATTRIBUTION = (
+    "Contains modified Copernicus Sentinel-2 L2A data 2023 (tile T33UUP, "
+    "acquired 2023-09-07), processed by ESA; accessed via Microsoft Planetary "
+    "Computer. Licensed under the Copernicus open data terms."
+)
+_DEM_ATTRIBUTION = (
+    "Contains modified Copernicus DEM GLO-30 data (© DLR e.V. 2010-2014 and "
+    "© Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS "
+    "by the European Union and ESA); accessed via Microsoft Planetary Computer."
+)
+
+
+@dataclass(frozen=True)
+class Asset:
+    """One downloadable file backing a dataset.
+
+    Attributes
+    ----------
+    remote : str
+        Filename appended to :data:`BASE_URL` to form the download URL, and the
+        basename used for the cached copy.
+    sha256 : str
+        Expected hex digest of the file's bytes, verified after download.
+    nbytes : int
+        Expected size in bytes, used only for progress/reporting.
+    band_name : str or None
+        Name to assign this asset's band when several single-band assets are
+        loaded together as one multi-band dataset; ``None`` for non-raster or
+        already-multiband assets.
+    """
+
+    remote: str
+    sha256: str
+    nbytes: int
+    band_name: str | None = None
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """A named sample dataset made of one or more :class:`Asset` files.
+
+    Attributes
+    ----------
+    name : str
+        Registry key passed to :func:`eeo.datasets.fetch` / ``load``.
+    kind : str
+        ``"raster"`` or ``"vector"``. Vectors are returned as a path by both
+        ``fetch`` and ``load``; rasters are opened by ``load``.
+    assets : list of Asset
+        Backing files, in band order for a multi-asset raster.
+    description : str
+        One-line summary for :func:`eeo.datasets.info`.
+    attribution : str
+        Data licence/attribution text.
+    timestamp : datetime.datetime or None
+        Acquisition time applied to the loaded raster.
+    nodata : float or int or None
+        Nodata value applied when a multi-asset raster is stacked in memory.
+    """
+
+    name: str
+    kind: str
+    assets: list[Asset]
+    description: str
+    attribution: str
+    timestamp: datetime | None = None
+    nodata: float | int | None = None
+    band_names: list[str | None] = field(default_factory=list)
+
+    @property
+    def multi(self) -> bool:
+        """Whether the dataset is backed by more than one file."""
+        return len(self.assets) > 1
+
+
+#: Per-band single-band files (hosted as raw components). Kept as a multi-asset
+#: dataset (``sentinel2_small_bands``) for workflows that want the bands as
+#: separate rasters; ``sentinel2_small`` itself is the pre-stacked file below.
+_S2_BANDS = [
+    Asset(
+        "B02.tif",
+        "dc60e793fde0b2d88a43a39c1e9ebf8a32fa6215e3c72e6e60057f178e0a328e",
+        1500038,
+        "blue",
+    ),
+    Asset(
+        "B03.tif",
+        "4e8c9e0a4d79271607b1b9ae1c99649302c8b75dc22efb619811cc713c23bd38",
+        1542821,
+        "green",
+    ),
+    Asset(
+        "B04.tif",
+        "56145db8d431d03718a0e082bf5e38dae2afe49eda54f6431ef208687c1be1b0",
+        1553010,
+        "red",
+    ),
+    Asset(
+        "B08.tif",
+        "1f7ca601fae06ebec9a9ccaa7a255ce571f228bd6366f25c6ef90c08bcac6a2a",
+        1544666,
+        "nir",
+    ),
+]
+_S2_BAND_NAMES: list[str | None] = ["blue", "green", "red", "nir"]
+
+_DATASETS: dict[str, Dataset] = {
+    "sentinel2_small": Dataset(
+        name="sentinel2_small",
+        kind="raster",
+        assets=[
+            Asset(
+                "sentinel2_small.tif",
+                "f57186fc62574f123bd15359af55e5efa2e654e2146da662aff2320ff8617b92",
+                5750737,
+            )
+        ],
+        description="Sentinel-2 L2A 4-band stack (blue/green/red/nir), 1024x1024 @ 10 m, EPSG:32633.",
+        attribution=_S2_ATTRIBUTION,
+        timestamp=_S2_ACQUIRED,
+        nodata=0,
+        band_names=_S2_BAND_NAMES,
+    ),
+    "sentinel2_small_cog": Dataset(
+        name="sentinel2_small_cog",
+        kind="raster",
+        assets=[
+            Asset(
+                "sentinel2_small_cog.tif",
+                "192ba37bc715a4358e60b56407fed0e2a7f5bf7b57e8a721b6ce7c57b4569f8c",
+                7870231,
+            )
+        ],
+        description="Cloud-Optimized GeoTIFF variant of sentinel2_small (for HTTP range-read demos).",
+        attribution=_S2_ATTRIBUTION,
+        timestamp=_S2_ACQUIRED,
+        nodata=0,
+        band_names=_S2_BAND_NAMES,
+    ),
+    "sentinel2_small_bands": Dataset(
+        name="sentinel2_small_bands",
+        kind="raster",
+        assets=_S2_BANDS,
+        description="The blue/green/red/nir bands of sentinel2_small as separate single-band files.",
+        attribution=_S2_ATTRIBUTION,
+        timestamp=_S2_ACQUIRED,
+        nodata=0,
+        band_names=_S2_BAND_NAMES,
+    ),
+    "dem_small": Dataset(
+        name="dem_small",
+        kind="raster",
+        assets=[
+            Asset(
+                "DEM.tif",
+                "4aa03df4de877570d728ace4b0c07e71cb8be79a0c0640c6de602116ad1b3f88",
+                3413595,
+                "elevation",
+            )
+        ],
+        description="Copernicus GLO-30 DEM warped onto the sentinel2_small grid, float32 metres.",
+        attribution=_DEM_ATTRIBUTION,
+        band_names=["elevation"],
+    ),
+    "dem_small_cog": Dataset(
+        name="dem_small_cog",
+        kind="raster",
+        assets=[
+            Asset(
+                "DEM_COG.tif",
+                "c1d763c4dcbec033695ab0d73c75fdbc58d5a2c0d91eb1fe443c13d48644ee27",
+                5385324,
+                "elevation",
+            )
+        ],
+        description="Cloud-Optimized GeoTIFF variant of dem_small.",
+        attribution=_DEM_ATTRIBUTION,
+        band_names=["elevation"],
+    ),
+    "sentinel2_small_boundary": Dataset(
+        name="sentinel2_small_boundary",
+        kind="vector",
+        assets=[
+            Asset(
+                "roi.gpkg",
+                "788a1800caed8d03ef7893de1a61ead281edd901ea049cdf969c5749c0af0744",
+                98304,
+            )
+        ],
+        description="Region-of-interest polygon (GeoPackage, EPSG:4326) inside the sentinel2_small footprint.",
+        attribution=_S2_ATTRIBUTION,
+    ),
+}
+
+
+def get_dataset(name: str) -> Dataset:
+    """Return the registry entry for ``name`` or raise a listing error.
+
+    Parameters
+    ----------
+    name : str
+        Dataset name.
+
+    Returns
+    -------
+    Dataset
+        The matching registry entry.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered dataset. The message lists the
+        available names.
+    """
+    try:
+        return _DATASETS[name]
+    except KeyError:
+        available = ", ".join(sorted(_DATASETS))
+        raise KeyError(f'unknown dataset "{name}"; available datasets are: {available}') from None
+
+
+def available() -> list[str]:
+    """Return the sorted names of every registered sample dataset.
+
+    Returns
+    -------
+    list of str
+        Dataset names accepted by :func:`eeo.datasets.fetch` and
+        :func:`eeo.datasets.load`.
+    """
+    return sorted(_DATASETS)

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -594,9 +594,9 @@ def plot_composite(
     Reads the three bands decimated to the figure's display resolution
     (rasterio ``out_shape``, served from overviews when present); rasters
     already within the display budget, and NumPy-backed datasets, are read
-    in full. Percentile stretching writes the scaled values back into the
-    composite's own dtype, so stretch a floating-dtype raster to avoid
-    truncating them. Displays the figure with ``matplotlib.pyplot.show``
+    in full. When ``stretch=True`` the channels are rescaled to floating-point
+    ``[0, 1]`` before display, so integer rasters (e.g. Sentinel-2 reflectance)
+    render correctly. Displays the figure with ``matplotlib.pyplot.show``
     and, when ``save_path`` is given, writes it to disk as a side effect.
 
     Examples
@@ -606,11 +606,15 @@ def plot_composite(
     bands_list = _normalize_bands(ds, bands)
     if len(bands_list) != 3:
         raise ValidationError(f"a composite needs exactly 3 bands (R, G, B); got {len(bands_list)}")
-    composite = np.stack([_read_band_for_display(ds, b, figsize)[0] for b in bands_list], axis=-1)
+    channels = [_read_band_for_display(ds, b, figsize)[0] for b in bands_list]
 
     if stretch:
-        for i in range(3):
-            composite[..., i] = _percentile_stretch(composite[..., i], pmin, pmax)
+        # Stretch into float [0, 1]; stacking the float results keeps the
+        # composite floating so the scaled values are not truncated to an
+        # integer band dtype (which would render the image black).
+        channels = [_percentile_stretch(channel, pmin, pmax) for channel in channels]
+
+    composite = np.stack(channels, axis=-1)
 
     plt.figure(figsize=figsize)
     plt.imshow(composite)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,9 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]
+markers = [
+    "network: test performs a real network download (opt in with --run-network)",
+]
 # Coverage is always measured; the suite fails below the documented ≥80%
 # target (see CODE_STYLE.md "Testing Expectations").
 addopts = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,26 @@ RES = 10.0
 NODATA = -9999.0
 
 
+def pytest_addoption(parser):
+    """Register ``--run-network`` to opt in to the live-download tests."""
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests marked @pytest.mark.network (real downloads)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``network``-marked tests unless ``--run-network`` is given."""
+    if config.getoption("--run-network"):
+        return
+    skip = pytest.mark.skip(reason="needs --run-network (real download)")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip)
+
+
 @pytest.fixture(autouse=True)
 def _silence_agg_show_warning():
     """Filter the UserWarning ``plt.show()`` emits under Agg.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -142,6 +142,25 @@ def test_ensure_asset_checksum_mismatch_raises(cache_env, local_asset, monkeypat
     assert not (cache_dir() / asset.remote).exists()  # corrupt download removed
 
 
+def test_download_writes_and_replaces_atomically(cache_env, monkeypatch):
+    """The real ``_download`` streams the response to dest via a temp file.
+
+    Exercises the success path (copy + atomic replace) without a network call
+    by patching ``urlopen`` to return an in-memory response, and confirms no
+    stray ``.part`` temp file is left behind.
+    """
+    import io
+
+    payload = b"streamed sample bytes \x00\x01" * 200
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: io.BytesIO(payload))
+
+    dest = cache_dir() / "downloaded.bin"
+    _cache._download("https://example.invalid/downloaded.bin", dest)
+
+    assert dest.read_bytes() == payload
+    assert not list(dest.parent.glob("*.part"))  # temp file renamed
+
+
 def test_download_network_error_raises_dataset_error(cache_env, local_asset, monkeypatch):
     import urllib.error
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,319 @@
+"""Tests for the sample-dataset fetch/cache helpers (:mod:`eeo.datasets`).
+
+Every test in the default run is offline: downloads are redirected to
+locally-built synthetic files via a patched ``_download``. One real-network
+integration test is marked ``network`` and skipped unless ``--run-network``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from affine import Affine
+from rasterio.crs import CRS
+
+import eeo
+from eeo.datasets import _cache, _registry
+from eeo.datasets._cache import DatasetError, cache_dir, ensure_asset
+from eeo.datasets._registry import Asset, Dataset
+
+UTM = CRS.from_epsg(32633)
+TRANSFORM = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / fixtures
+# --------------------------------------------------------------------------- #
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_band(path: Path, value: int, name: str) -> None:
+    """Write a tiny single-band GeoTIFF with a band description."""
+    arr = np.full((4, 4), value, dtype="uint16")
+    profile = dict(
+        driver="GTiff",
+        width=4,
+        height=4,
+        count=1,
+        dtype="uint16",
+        crs=UTM,
+        transform=TRANSFORM,
+        nodata=0,
+    )
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(arr, 1)
+        dst.descriptions = (name,)
+
+
+@pytest.fixture
+def cache_env(tmp_path, monkeypatch):
+    """Point the cache at a temp dir for the duration of a test."""
+    monkeypatch.setenv("EEO_DATA_DIR", str(tmp_path / "cache"))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def local_asset(tmp_path):
+    """A source file on disk plus the matching Asset (checksum computed here)."""
+    src = tmp_path / "source.bin"
+    payload = b"easy-eo sample payload \x00\x01\x02" * 100
+    src.write_bytes(payload)
+    asset = Asset("thing.bin", _sha256_bytes(payload), len(payload))
+    return src, asset
+
+
+def _patch_download_from(monkeypatch, source: Path):
+    """Make ``_download`` copy ``source`` instead of hitting the network."""
+    calls = {"n": 0}
+
+    def fake_download(url, dest):
+        calls["n"] += 1
+        dest.write_bytes(source.read_bytes())
+
+    monkeypatch.setattr(_cache, "_download", fake_download)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# cache_dir resolution
+# --------------------------------------------------------------------------- #
+def test_cache_dir_prefers_eeo_data_dir(tmp_path, monkeypatch):
+    target = tmp_path / "explicit"
+    monkeypatch.setenv("EEO_DATA_DIR", str(target))
+    assert cache_dir() == target
+    assert target.is_dir()
+
+
+def test_cache_dir_uses_xdg_when_no_override(tmp_path, monkeypatch):
+    monkeypatch.delenv("EEO_DATA_DIR", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert cache_dir() == tmp_path / "xdg" / "easy-eo"
+
+
+def test_cache_dir_defaults_to_home_cache(tmp_path, monkeypatch):
+    monkeypatch.delenv("EEO_DATA_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert cache_dir() == tmp_path / ".cache" / "easy-eo"
+
+
+# --------------------------------------------------------------------------- #
+# ensure_asset: download, cache, verify
+# --------------------------------------------------------------------------- #
+def test_ensure_asset_downloads_and_verifies(cache_env, local_asset, monkeypatch):
+    src, asset = local_asset
+    _patch_download_from(monkeypatch, src)
+    path = ensure_asset(asset)
+    assert path.is_file()
+    assert path.read_bytes() == src.read_bytes()
+
+
+def test_ensure_asset_uses_cache_second_time(cache_env, local_asset, monkeypatch):
+    src, asset = local_asset
+    calls = _patch_download_from(monkeypatch, src)
+    ensure_asset(asset)
+    ensure_asset(asset)
+    assert calls["n"] == 1  # second call served from cache, no re-download
+
+
+def test_ensure_asset_redownloads_corrupt_cache(cache_env, local_asset, monkeypatch):
+    src, asset = local_asset
+    calls = _patch_download_from(monkeypatch, src)
+    # Seed a corrupt cached file with the right name but wrong bytes.
+    (cache_dir() / asset.remote).write_bytes(b"corrupt")
+    path = ensure_asset(asset)
+    assert calls["n"] == 1  # corruption detected -> downloaded
+    assert path.read_bytes() == src.read_bytes()
+
+
+def test_ensure_asset_checksum_mismatch_raises(cache_env, local_asset, monkeypatch):
+    src, asset = local_asset
+    bad = asset.__class__(asset.remote, "0" * 64, asset.nbytes)  # wrong expected hash
+    _patch_download_from(monkeypatch, src)
+    with pytest.raises(DatasetError, match="checksum mismatch"):
+        ensure_asset(bad)
+    assert not (cache_dir() / asset.remote).exists()  # corrupt download removed
+
+
+def test_download_network_error_raises_dataset_error(cache_env, local_asset, monkeypatch):
+    import urllib.error
+
+    _, asset = local_asset
+
+    def boom(url, headers=None):
+        raise urllib.error.URLError("no route to host")
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: boom(None))
+    with pytest.raises(DatasetError, match="failed to download"):
+        ensure_asset(asset)
+
+
+# --------------------------------------------------------------------------- #
+# fetch / load / info via a synthetic registry
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def synthetic_registry(cache_env, tmp_path, monkeypatch):
+    """Replace the registry with local synthetic rasters + a vector stand-in."""
+    # Build two single-band rasters and a "vector" blob on disk.
+    red = tmp_path / "red_src.tif"
+    nir = tmp_path / "nir_src.tif"
+    _write_band(red, value=1000, name="red")
+    _write_band(nir, value=4000, name="nir")
+    vec = tmp_path / "roi_src.gpkg"
+    vec.write_bytes(b"fake-geopackage-bytes")
+
+    sources = {"red.tif": red, "nir.tif": nir, "roi.gpkg": vec}
+
+    def sha(p: Path) -> str:
+        return _sha256_bytes(p.read_bytes())
+
+    ts = datetime(2023, 9, 7, 10, 0, 31, tzinfo=timezone.utc)
+    registry = {
+        "s2": Dataset(
+            name="s2",
+            kind="raster",
+            assets=[
+                Asset("red.tif", sha(red), red.stat().st_size, "red"),
+                Asset("nir.tif", sha(nir), nir.stat().st_size, "nir"),
+            ],
+            description="synthetic two-band",
+            attribution="test attribution",
+            timestamp=ts,
+            nodata=0,
+            band_names=["red", "nir"],
+        ),
+        "single": Dataset(
+            name="single",
+            kind="raster",
+            assets=[Asset("red.tif", sha(red), red.stat().st_size, "red")],
+            description="synthetic one-band",
+            attribution="test attribution",
+            timestamp=ts,
+            band_names=["red"],
+        ),
+        "roi": Dataset(
+            name="roi",
+            kind="vector",
+            assets=[Asset("roi.gpkg", sha(vec), vec.stat().st_size)],
+            description="synthetic vector",
+            attribution="test attribution",
+        ),
+    }
+    monkeypatch.setattr(_registry, "_DATASETS", registry)
+
+    def fake_download(url, dest):
+        dest.write_bytes(sources[dest.name].read_bytes())
+
+    monkeypatch.setattr(_cache, "_download", fake_download)
+    return registry, ts
+
+
+def test_fetch_single_returns_path(synthetic_registry):
+    path = eeo.datasets.fetch("single")
+    assert isinstance(path, Path)
+    assert path.name == "red.tif"
+
+
+def test_fetch_multi_returns_list_in_band_order(synthetic_registry):
+    paths = eeo.datasets.fetch("s2")
+    assert isinstance(paths, list)
+    assert [p.name for p in paths] == ["red.tif", "nir.tif"]
+
+
+def test_load_stack_sets_names_timestamp_and_stacks(synthetic_registry):
+    _, ts = synthetic_registry
+    ds = eeo.datasets.load("s2")
+    assert ds.get_count() == 2
+    assert ds.band_names == ["red", "nir"]
+    assert ds.timestamp == ts
+    arr = ds.to_array()
+    assert arr.shape == (2, 4, 4)
+    assert arr[0].min() == 1000 and arr[1].min() == 4000  # band order preserved
+
+
+def test_load_single_raster_is_lazy_with_names(synthetic_registry):
+    ds = eeo.datasets.load("single")
+    assert ds.get_count() == 1
+    assert ds.band_names == ["red"]
+
+
+def test_load_vector_returns_path(synthetic_registry):
+    result = eeo.datasets.load("roi")
+    assert isinstance(result, Path)
+    assert result.name == "roi.gpkg"
+
+
+def test_load_stack_ndvi_by_name(synthetic_registry):
+    ds = eeo.datasets.load("s2")
+    ndvi = ds.ndvi(red="red", nir="nir")
+    a = ndvi.to_array()
+    # (4000 - 1000) / (4000 + 1000) = 0.6 everywhere
+    assert np.allclose(a, 0.6, atol=1e-4)
+    assert a.dtype == np.float32
+
+
+def test_info_includes_attribution(synthetic_registry):
+    text = eeo.datasets.info("s2")
+    assert "test attribution" in text
+    assert "red.tif" in text and "nir.tif" in text
+
+
+# --------------------------------------------------------------------------- #
+# Error handling and registry integrity (no network, real registry)
+# --------------------------------------------------------------------------- #
+def test_unknown_dataset_lists_available():
+    with pytest.raises(KeyError, match="unknown dataset"):
+        eeo.datasets.fetch("does_not_exist")
+
+
+def test_available_matches_registry():
+    names = eeo.datasets.available()
+    assert names == sorted(names)
+    assert "sentinel2_small" in names
+    assert set(names) == set(_registry._DATASETS)
+
+
+def test_real_registry_checksums_are_wellformed():
+    for name in eeo.datasets.available():
+        ds = _registry.get_dataset(name)
+        assert ds.assets, name
+        for asset in ds.assets:
+            assert len(asset.sha256) == 64
+            assert all(c in "0123456789abcdef" for c in asset.sha256)
+            assert asset.nbytes > 0
+
+
+def test_sentinel2_small_is_single_stacked_raster():
+    ds = _registry.get_dataset("sentinel2_small")
+    assert ds.kind == "raster"
+    assert not ds.multi  # a single pre-stacked 4-band file
+    assert len(ds.assets) == 1
+    assert ds.band_names == ["blue", "green", "red", "nir"]
+
+
+def test_sentinel2_small_bands_is_multi_in_band_order():
+    ds = _registry.get_dataset("sentinel2_small_bands")
+    assert ds.multi and ds.kind == "raster"
+    assert [a.band_name for a in ds.assets] == ["blue", "green", "red", "nir"]
+
+
+# --------------------------------------------------------------------------- #
+# Opt-in real-download integration test
+# --------------------------------------------------------------------------- #
+@pytest.mark.network
+def test_real_download_roundtrip(tmp_path, monkeypatch):
+    """Download the smallest real asset and verify checksum + open it."""
+    monkeypatch.setenv("EEO_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    path = eeo.datasets.fetch("sentinel2_small_boundary")
+    assert path.is_file()
+    ds = eeo.datasets.load("sentinel2_small")
+    assert ds.band_names == ["blue", "green", "red", "nir"]
+    assert ds.get_count() == 4

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -27,9 +27,10 @@ from eeo.viz.plot import (
 # ---------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------
-# General-purpose rasters come from conftest.py. Composite tests need a
-# module-local fixture: plot_composite feeds bands straight to imshow and
-# stretches in place, so it needs float RGB data already in display range.
+# General-purpose rasters come from conftest.py. Composite tests use a
+# module-local float RGB fixture (values already in imshow's [0, 1] display
+# range) for the no-stretch path; the stretch path is covered separately
+# against the shared uint16 fixture.
 
 
 @pytest.fixture
@@ -268,3 +269,22 @@ def test_plot_composite_rgb(rgb_float32_raster):
 
 def test_plot_composite_stretched(rgb_float32_raster):
     plot_composite(rgb_float32_raster, bands=(1, 2, 3), stretch=True)
+
+
+def test_plot_composite_stretch_integer_not_truncated(multiband_uint16, monkeypatch):
+    """Regression: stretching an integer raster must not render black.
+
+    The stretched channels are floats in ``[0, 1]``; the composite must stay
+    floating rather than write them back into the uint16 band dtype, which
+    would floor every value below 1 to 0 and produce a black image.
+    """
+    captured = {}
+    monkeypatch.setattr(plt, "imshow", lambda arr, *a, **k: captured.update(arr=np.asarray(arr)))
+
+    plot_composite(multiband_uint16, bands=(3, 2, 1), stretch=True)
+
+    arr = captured["arr"]
+    assert np.issubdtype(arr.dtype, np.floating)  # not truncated to the band dtype
+    assert arr.min() >= 0.0 and arr.max() <= 1.0
+    assert arr.max() > 0.5  # real contrast survives; the image is not black
+    assert np.count_nonzero(arr) > arr.size // 2


### PR DESCRIPTION
## Summary

Adds a built-in sample dataset library with hosted datasets, local caching, and convenient loading utilities. Sample data is distributed through GitHub Releases, verified with checksums, cached locally, and documented for reproducible examples, tutorials, and testing.

## Related issues / tasks

- Completes **Sample Data & Fetch Helper**

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behaviour are stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`) *(not applicable)*
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

- Added a hosted sample dataset collection based on a Sentinel-2 subset, a
  matching DEM, and a vector ROI, distributed through GitHub Releases.
- Introduced the `eeo.datasets` module with `fetch()`, `load()`, `info()`,
  `available()`, and `cache_dir()` helpers for discovering, downloading, and
  loading sample datasets.
- Downloads are cached locally, verified using SHA-256 checksums, and
  automatically re-downloaded if the cache becomes corrupted.
- Cache location follows `EEO_DATA_DIR`, `XDG_CACHE_HOME`, or the default
  `~/.cache/easy-eo` location without introducing additional runtime
  dependencies.
- Added comprehensive offline unit tests covering cache management, download
  verification, registry integrity, and dataset loading, together with an
  opt-in integration test for real downloads.
- Added user guide documentation describing the available datasets, caching
  behaviour, usage examples, and licensing/attribution, along with an API
  reference for the new datasets module.