### PR TITLE
Used Namespaces for the Sample Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,33 +71,23 @@ are called out under a **Breaking** heading.
 
 ### Added
 
-- **Sample-data helper (`eeo.datasets`).** `eeo.datasets.load(name)` fetches a
-  small curated Sentinel-2 / Copernicus-DEM sample and returns it ready to use
-  (band names and acquisition timestamp already set for rasters; the cached
-  path for vectors); `eeo.datasets.fetch(name)` returns the cached file path(s)
-  without opening them. Files download on first use to `~/.cache/easy-eo`
-  (override with `EEO_DATA_DIR`, or `XDG_CACHE_HOME`) and are verified against a
-  checksum shipped inside the package, so fetches are instant after the first
-  call and never return corrupt data. `available()` lists the datasets and
-  `info(name)` prints the description and required Copernicus attribution.
-  Downloading uses only the standard library — no new dependency. Registered
-  datasets: `sentinel2_small` (a single pre-stacked 4-band GeoTIFF),
-  `sentinel2_small_cog` (its COG variant), `sentinel2_small_bands` (the same
-  four bands as separate single-band files), `dem_small`, `dem_small_cog`, and
-  `sentinel2_small_boundary`.
-- **Dotted sample access (`eeo.datasets.load_sample_dataset`).** Returns a
-  `SampleDataset` namespace whose attributes are the individual sample files, so
-  a file can be opened by readable, autocompletable name —
-  `load_raster(sd.copernicus_dem)`, `load_raster(sd.sentinel2_blue)`,
-  `load_raster(sd.sentinel2_cog_stacked)` — instead of a string key. Each
-  attribute is a lazy `SamplePath` (an `os.PathLike`): constructing the
-  namespace touches no network, and a file is downloaded and checksum-verified
-  only when it is actually opened. Pass `prefetch=True` to warm the whole cache
-  up front. Exposed attributes: `sentinel2_stacked`, `sentinel2_cog_stacked`,
+- **Sample-data helper (`eeo.datasets.load_sample_dataset`).** Returns a
+  `SampleDataset` namespace whose attributes are the individual bundled files, so
+  a curated Sentinel-2 / Copernicus-DEM sample is opened by readable,
+  autocompletable name — `load_raster(sd.copernicus_dem)`,
+  `load_raster(sd.sentinel2_blue)`, `load_raster(sd.sentinel2_cog_stacked)` —
+  never by a hard-coded string key. Each attribute is a lazy `SamplePath` (an
+  `os.PathLike`): constructing the namespace touches no network, and a file is
+  downloaded to `~/.cache/easy-eo` (override with `EEO_DATA_DIR`, or
+  `XDG_CACHE_HOME`) and checksum-verified only when it is actually opened, so a
+  fetch is instant after the first call and never returns corrupt data. Pass
+  `prefetch=True` to warm the whole cache up front. Provenance travels with each
+  handle: `sd.<name>.info()` and `sd.<name>.attribution` carry the required
+  Copernicus attribution; `sd.<name>.path` gives the raw cached path; the
+  namespace is iterable. Downloading uses only the standard library — no new
+  dependency. Exposed files: `sentinel2_stacked`, `sentinel2_cog_stacked`,
   `sentinel2_blue`/`green`/`red`/`nir`, `copernicus_dem`, `copernicus_dem_cog`,
-  and `boundary` (a vector, for GeoPandas). A thin convenience layer over the
-  existing `load`/`fetch` string API, which remains the way to get the
-  timestamped in-memory band stack.
+  and `boundary` (a vector, for GeoPandas).
 - **Band names on `EEORasterDataset`.** Datasets now carry an optional
   per-band name list (one entry per band, `None` for an unnamed band), seeded
   from the raster's GDAL band descriptions at load time. Read or replace them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,19 @@ are called out under a **Breaking** heading.
   `sentinel2_small_cog` (its COG variant), `sentinel2_small_bands` (the same
   four bands as separate single-band files), `dem_small`, `dem_small_cog`, and
   `sentinel2_small_boundary`.
+- **Dotted sample access (`eeo.datasets.load_sample_dataset`).** Returns a
+  `SampleDataset` namespace whose attributes are the individual sample files, so
+  a file can be opened by readable, autocompletable name —
+  `load_raster(sd.copernicus_dem)`, `load_raster(sd.sentinel2_blue)`,
+  `load_raster(sd.sentinel2_cog_stacked)` — instead of a string key. Each
+  attribute is a lazy `SamplePath` (an `os.PathLike`): constructing the
+  namespace touches no network, and a file is downloaded and checksum-verified
+  only when it is actually opened. Pass `prefetch=True` to warm the whole cache
+  up front. Exposed attributes: `sentinel2_stacked`, `sentinel2_cog_stacked`,
+  `sentinel2_blue`/`green`/`red`/`nir`, `copernicus_dem`, `copernicus_dem_cog`,
+  and `boundary` (a vector, for GeoPandas). A thin convenience layer over the
+  existing `load`/`fetch` string API, which remains the way to get the
+  timestamped in-memory band stack.
 - **Band names on `EEORasterDataset`.** Datasets now carry an optional
   per-band name list (one entry per band, `None` for an unnamed band), seeded
   from the raster's GDAL band descriptions at load time. Read or replace them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ are called out under a **Breaking** heading.
     `"bilinear"`), matching `reproject_raster` and avoiding blending of
     categorical values and nodata edges. Pass `resampling_method="bilinear"`
     to restore the old default.
+  - `plot_band_array`, `plot_raster` and `plot_composite` now default to
+    `stretch=True` (previously `False`), so a 2-98 percentile contrast stretch
+    is applied out of the box — the setting that renders most EO rasters best
+    (and stops integer rasters such as Sentinel-2 reflectance from displaying as
+    black). Pass `stretch=False` to display raw values. `pmin`/`pmax` are
+    unchanged (2/98). `plot_raster_with_histogram` deliberately keeps
+    `stretch=False` so its histogram reflects the raw value distribution.
 - **Operations now raise the Easy-EO exception hierarchy** instead of bare
   built-ins. Most raises keep a built-in base for backward compatibility, so
   `except ValueError` (validation, CRS, alignment) and `except RuntimeError`

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -179,20 +179,23 @@ Visualization functions are **terminal operations** and should be used last in a
         plot_raster_with_histogram
     )
 
-    # Plot a single band
-    ds.plot_raster(bands=1, cmap="gray", stretch=True)
+    # Plot a single band (2-98 percentile stretch is on by default)
+    ds.plot_raster(bands=1, cmap="gray")
 
     # Plot histogram for multiple bands
     ds.plot_histogram(bands=[1,2,3], bins=256, sharey=True)
 
-    # Plot raster and its histogram
+    # Plot raster and its histogram (histogram shows raw values; opt in to stretch)
     ds.plot_raster_with_histogram(bands=[1,2], stretch=True, sharey=True)
 
-    # Plot composite (e.g., RGB)
-    ds.plot_composite(bands=(4,3,2), stretch=True)
+    # Plot composite (e.g., RGB) — stretched by default
+    ds.plot_composite(bands=(4,3,2))
 
 .. note::
-    - Percentile stretching (`stretch=True`) improves contrast
+    - Percentile stretching is on by default for ``plot_raster``,
+      ``plot_band_array`` and ``plot_composite`` (pass ``stretch=False`` for raw
+      values); ``plot_raster_with_histogram`` defaults to raw so its histogram
+      reflects true values
     - `sharey=True` aligns histogram axes across multiple bands
     - Multi-band plotting works with single or multiple rasters
     - Composite plotting supports RGB/false-color conventions

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -4,3 +4,11 @@ Datasets Module
 .. automodule:: eeo.datasets
     :members: fetch, load, info, available, cache_dir, DatasetError
     :show-inheritance:
+
+.. autofunction:: eeo.datasets.load_sample_dataset
+
+.. autoclass:: eeo.datasets.SampleDataset
+    :members:
+
+.. autoclass:: eeo.datasets.SamplePath
+    :members:

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -2,7 +2,7 @@ Datasets Module
 ===============
 
 .. automodule:: eeo.datasets
-    :members: fetch, load, info, available, cache_dir, DatasetError
+    :members: cache_dir, DatasetError
     :show-inheritance:
 
 .. autofunction:: eeo.datasets.load_sample_dataset

--- a/docs/source/user_guide/sample_data.rst
+++ b/docs/source/user_guide/sample_data.rst
@@ -42,6 +42,42 @@ cached path — read them with GeoPandas:
    boundary = gpd.read_file(eeo.datasets.load("sentinel2_small_boundary"))
    clipped = scene.clip_raster_with_vector(boundary)
 
+Dotted access with ``load_sample_dataset()``
+--------------------------------------------
+
+When you want the individual files by a readable, autocompletable name — rather
+than remembering string keys — call :func:`~eeo.datasets.load_sample_dataset`.
+It returns a namespace whose attributes are the sample files; pass any attribute
+straight to :func:`~eeo.load_raster`:
+
+.. code-block:: python
+
+   from eeo.datasets import load_sample_dataset
+   from eeo import load_raster
+
+   sd = load_sample_dataset()                     # instant — no download
+
+   scene = load_raster(sd.sentinel2_cog_stacked)  # downloads that one file
+   dem = load_raster(sd.copernicus_dem)
+   blue = load_raster(sd.sentinel2_blue)
+
+Each attribute is *lazy*: holding ``sd.copernicus_dem`` touches no network — the
+file is downloaded and checksum-verified only when it is actually opened. Nothing
+is fetched that you do not use. To warm the whole cache up front (before going
+offline), pass ``load_sample_dataset(prefetch=True)``.
+
+Available attributes: ``sentinel2_stacked``, ``sentinel2_cog_stacked``,
+``sentinel2_blue`` / ``sentinel2_green`` / ``sentinel2_red`` / ``sentinel2_nir``,
+``copernicus_dem``, ``copernicus_dem_cog``, and ``boundary`` (a vector — read it
+with GeoPandas, ``gpd.read_file(sd.boundary)``, not ``load_raster``).
+
+.. note::
+
+   ``load_raster(sd.<name>)`` reads band names from the file but does **not**
+   set the acquisition timestamp. Use ``load("sentinel2_small")`` when you need
+   the timestamp too, or the in-memory four-band stack from the separate band
+   files.
+
 Getting file paths with ``fetch()``
 -----------------------------------
 

--- a/docs/source/user_guide/sample_data.rst
+++ b/docs/source/user_guide/sample_data.rst
@@ -2,11 +2,12 @@ Sample Data
 ===========
 
 Easy-EO ships a tiny, curated sample so every tutorial and quickstart runs in
-minutes without hunting for data. The helpers in :mod:`eeo.datasets` download a
-hosted Sentinel-2 / Copernicus-DEM subset on first use, cache it locally, and
-verify it against a checksum baked into the package — so a fetch is instant
-after the first call and never returns corrupt data. Downloading uses only the
-Python standard library, so it adds **no extra dependency**.
+minutes without hunting for data. :func:`~eeo.datasets.load_sample_dataset`
+returns a namespace whose attributes are the individual sample files; each is
+downloaded on first use, cached locally, and verified against a checksum baked
+into the package — so a fetch is instant after the first call and never returns
+corrupt data. Downloading uses only the Python standard library, so it adds
+**no extra dependency**.
 
 .. seealso::
 
@@ -15,40 +16,12 @@ Python standard library, so it adds **no extra dependency**.
 
 -----
 
-Loading the sample
-------------------
+Loading a sample
+----------------
 
-``load()`` returns a ready-to-use dataset for rasters — band names and the
-acquisition timestamp are already set — so you can go straight to analysis:
-
-.. code-block:: python
-
-   import eeo
-
-   scene = eeo.datasets.load("sentinel2_small")
-   scene.band_names          # ['blue', 'green', 'red', 'nir']
-   scene.timestamp           # 2023-09-07 10:00:31+00:00
-
-   ndvi = scene.ndvi(red="red", nir="nir")
-   ndvi.plot_raster()
-
-Vector datasets have no raster representation, so ``load()`` returns their
-cached path — read them with GeoPandas:
-
-.. code-block:: python
-
-   import geopandas as gpd
-
-   boundary = gpd.read_file(eeo.datasets.load("sentinel2_small_boundary"))
-   clipped = scene.clip_raster_with_vector(boundary)
-
-Dotted access with ``load_sample_dataset()``
---------------------------------------------
-
-When you want the individual files by a readable, autocompletable name — rather
-than remembering string keys — call :func:`~eeo.datasets.load_sample_dataset`.
-It returns a namespace whose attributes are the sample files; pass any attribute
-straight to :func:`~eeo.load_raster`:
+Call :func:`~eeo.datasets.load_sample_dataset` once, then open any file by
+dotted name with :func:`~eeo.load_raster` — no string keys, and your editor
+autocompletes the available names:
 
 .. code-block:: python
 
@@ -61,77 +34,66 @@ straight to :func:`~eeo.load_raster`:
    dem = load_raster(sd.copernicus_dem)
    blue = load_raster(sd.sentinel2_blue)
 
+   ndvi = scene.ndvi(red="red", nir="nir")
+   ndvi.plot_raster()
+
 Each attribute is *lazy*: holding ``sd.copernicus_dem`` touches no network — the
 file is downloaded and checksum-verified only when it is actually opened. Nothing
 is fetched that you do not use. To warm the whole cache up front (before going
 offline), pass ``load_sample_dataset(prefetch=True)``.
 
-Available attributes: ``sentinel2_stacked``, ``sentinel2_cog_stacked``,
-``sentinel2_blue`` / ``sentinel2_green`` / ``sentinel2_red`` / ``sentinel2_nir``,
-``copernicus_dem``, ``copernicus_dem_cog``, and ``boundary`` (a vector — read it
-with GeoPandas, ``gpd.read_file(sd.boundary)``, not ``load_raster``).
-
-.. note::
-
-   ``load_raster(sd.<name>)`` reads band names from the file but does **not**
-   set the acquisition timestamp. Use ``load("sentinel2_small")`` when you need
-   the timestamp too, or the in-memory four-band stack from the separate band
-   files.
-
-Getting file paths with ``fetch()``
------------------------------------
-
-When you want the files rather than an opened dataset — to pass to another
-library, or to work with the Cloud-Optimized GeoTIFFs directly — use
-``fetch()``. It returns a single :class:`~pathlib.Path` for a one-file dataset,
-or a list of paths (in band order) for a multi-file one:
+The ``boundary`` sample is a vector, so read it with GeoPandas rather than
+``load_raster`` (the handle is a path, so pass it straight in):
 
 .. code-block:: python
 
-   scene_path = eeo.datasets.fetch("sentinel2_small")         # Path (one 4-band file)
-   boundary_path = eeo.datasets.fetch("sentinel2_small_boundary")  # Path
-   band_paths = eeo.datasets.fetch("sentinel2_small_bands")   # [Path, Path, Path, Path]
+   import geopandas as gpd
 
-Available datasets
-------------------
+   roi = gpd.read_file(sd.boundary)
+   clipped = scene.clip_raster_with_vector(roi)
 
-List everything with ``eeo.datasets.available()``; describe one with
-``eeo.datasets.info(name)``.
+Need the raw cached path (to hand to another library, or to inspect the
+Cloud-Optimized GeoTIFFs directly)? Use ``.path``:
+
+.. code-block:: python
+
+   scene_path = sd.sentinel2_cog_stacked.path   # pathlib.Path (downloads if needed)
+
+Available samples
+-----------------
+
+Iterate ``sd`` to see every handle; each carries a description and the required
+attribution (``sd.<name>.info()`` / ``sd.<name>.attribution``).
 
 .. list-table::
    :header-rows: 1
    :widths: 26 10 64
 
-   * - Name
+   * - Attribute
      - Kind
      - Contents
-   * - ``sentinel2_small``
+   * - ``sentinel2_stacked``
      - raster
      - Sentinel-2 L2A blue/green/red/nir as one 4-band file, 1024×1024 @ 10 m,
        EPSG:32633.
-   * - ``sentinel2_small_cog``
+   * - ``sentinel2_cog_stacked``
      - raster
      - Cloud-Optimized GeoTIFF variant of the 4-band stack (HTTP range-read).
-   * - ``sentinel2_small_bands``
+   * - ``sentinel2_blue`` / ``sentinel2_green`` / ``sentinel2_red`` / ``sentinel2_nir``
      - raster
-     - The same four bands as *separate* single-band files (stacked in memory
-       on load); handy for workflows that treat bands as individual rasters.
-   * - ``dem_small``
+     - The four Sentinel-2 bands as separate single-band files.
+   * - ``copernicus_dem``
      - raster
      - Copernicus GLO-30 DEM warped onto the same grid (float32 metres).
-   * - ``dem_small_cog``
+   * - ``copernicus_dem_cog``
      - raster
      - Cloud-Optimized GeoTIFF variant of the DEM.
-   * - ``sentinel2_small_boundary``
+   * - ``boundary``
      - vector
      - Region-of-interest polygon (GeoPackage, EPSG:4326) inside the footprint.
 
-``sentinel2_small`` is a single pre-stacked 4-band GeoTIFF, so ``load`` opens it
-lazily and ``fetch`` returns one path; ``sentinel2_small_bands`` is the same
-imagery split across four single-band files, read into an in-memory stack on
-load and returned by ``fetch`` as a list of paths. All names share one
-1024×1024 grid (the DEM is warped to match), so the imagery, elevation, and
-boundary overlay pixel-for-pixel.
+All rasters share one 1024×1024 grid (the DEM is warped to match), so the
+imagery, elevation, and boundary overlay pixel-for-pixel.
 
 Where files are cached
 ----------------------
@@ -144,14 +106,15 @@ resolved as:
 3. ``~/.cache/easy-eo`` otherwise.
 
 A cached file whose checksum still matches is reused untouched; a missing or
-corrupted file is transparently re-downloaded.
+corrupted file is transparently re-downloaded. :func:`eeo.datasets.cache_dir`
+returns the resolved directory.
 
 Licensing and attribution
 --------------------------
 
 The sample is derived from open Copernicus data. If you redistribute figures or
-data made from it, carry the attribution — ``eeo.datasets.info(name)`` prints
-the exact text:
+data made from it, carry the attribution — ``sd.<name>.info()`` and
+``sd.<name>.attribution`` print the exact text:
 
 - **Sentinel-2:** *Contains modified Copernicus Sentinel-2 L2A data 2023 (tile
   T33UUP, acquired 2023-09-07), processed by ESA; accessed via Microsoft

--- a/docs/source/user_guide/visualization.rst
+++ b/docs/source/user_guide/visualization.rst
@@ -19,8 +19,9 @@ Visualization in Easy-EO supports:
     - Side-by-side raster and histogram views
     - Three-band composites (RGB or false-color)
 
-Most plotting functions support optional **percentile contrast stretching**
-for improved visual interpretation.
+Most plotting functions apply **percentile contrast stretching** by default
+(a 2-98 percentile stretch), because that renders most Earth-observation
+rasters best without any tuning.
 
 Every ``bands`` argument accepts a 1-based band index, a band name, or a list
 mixing the two (``bands=["red", 2, "blue"]``), and each subplot is titled with
@@ -29,7 +30,7 @@ the band's name when it has one. See :doc:`band_names`.
 Percentile Contrast Stretching
 ------------------------------
 
-Several visualization functions accept a ``stretch`` parameter. When
+Every visualization function accepts a ``stretch`` parameter. When
 ``stretch=True``, raster values are normalized using a percentile-based
 contrast stretch:
 
@@ -37,15 +38,25 @@ contrast stretch:
 
    x_{norm} = \frac{x - p_{min}}{p_{max} - p_{min}}
 
-where ``pmin`` and ``pmax`` are computed using NaN-aware percentile estimation.
+where ``pmin`` and ``pmax`` (defaulting to ``2`` and ``98``) are computed using
+NaN-aware percentile estimation.
+
+Defaults:
+    - ``plot_band_array``, ``plot_raster`` and ``plot_composite`` default to
+      ``stretch=True`` — so rasters display well out of the box. Pass
+      ``stretch=False`` to show raw values.
+    - ``plot_raster_with_histogram`` defaults to ``stretch=False``, so its
+      histogram shows the **raw** value distribution (the point of pairing a
+      raster with its histogram is to inspect real values before choosing a
+      stretch). Pass ``stretch=True`` to stretch its raster panel.
 
 Important behavior notes:
     - When ``stretch=False``, values are passed directly to Matplotlib and may be
       auto-scaled according to Matplotlib’s default behavior.
     - When ``stretch=True``, values are explicitly normalized into the range
-      ``[0, 1]``.
-    - The output becomes float-like, even if the original raster bands are
-      ``uint16`` or integer types.
+      ``[0, 1]``. The output becomes float-like, even if the original raster
+      bands are ``uint16`` or integer types — which is also why integer rasters
+      such as Sentinel-2 reflectance render correctly rather than as black.
     - Percentile stretching is intended for **visualization only** and does not
       modify the underlying dataset.
 
@@ -54,7 +65,7 @@ This approach is robust to outliers and commonly used for EO raster inspection.
 Plot Band Arrays (Array Coordinates)
 ------------------------------------
 
-.. function:: plot_band_array(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (8, 8), stretch=False, pmin=2, pmax=98, title=None, save_path=None, **imshow_kwargs)
+.. function:: plot_band_array(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (8, 8), stretch=True, pmin=2, pmax=98, title=None, save_path=None, **imshow_kwargs)
 
    Plot raster bands as NumPy arrays using row/column coordinates.
 
@@ -65,7 +76,7 @@ Plot Band Arrays (Array Coordinates)
    :param bands: Band index or indices (1-based). If ``None``, all bands are plotted.
    :type bands: int | Sequence[int] | None
    :param cmap: Matplotlib colormap.
-   :param stretch: Apply percentile contrast stretching.
+   :param stretch: Apply percentile contrast stretching. Defaults to ``True``; pass ``False`` for raw values.
    :param pmin: Lower percentile used when ``stretch=True``.
    :param pmax: Upper percentile used when ``stretch=True``.
    :param title: Optional figure title.
@@ -76,7 +87,7 @@ Plot Band Arrays (Array Coordinates)
 Plot Raster (Spatial Coordinates)
 ---------------------------------
 
-.. function:: plot_raster(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (10, 5), stretch=False, pmin=2, pmax=98, title=None, save_path=None, **show_kwargs)
+.. function:: plot_raster(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (10, 5), stretch=True, pmin=2, pmax=98, title=None, save_path=None, **show_kwargs)
 
    Plot raster bands in spatial (CRS-aware) coordinates.
 
@@ -88,7 +99,7 @@ Plot Raster (Spatial Coordinates)
    :param bands: Band index or indices (1-based). If ``None``, all bands are plotted.
    :param cmap: Matplotlib colormap.
    :param figsize: Size of the matplotlib figure
-   :param stretch: Apply percentile contrast stretching.
+   :param stretch: Apply percentile contrast stretching. Defaults to ``True``; pass ``False`` for raw values.
    :param pmin: Lower percentile used when ``stretch=True``.
    :param pmax: Upper percentile used when ``stretch=True``.
    :param title: Optional figure title.
@@ -133,7 +144,7 @@ Plot Raster with Histogram
    :param cmap: Matplotlib colormap.
    :param figsize: Size of the matplotlib figure
    :param bins: Number of histogram bins.
-   :param stretch: Apply percentile contrast stretching to the raster display.
+   :param stretch: Apply percentile contrast stretching to the raster display. Defaults to ``False`` so the histogram shows the raw value distribution.
    :param pmin: Lower percentile used when ``stretch=True``.
    :param pmax: Upper percentile used when ``stretch=True``.
    :param sharey: Share the y-axis between histogram plots.
@@ -143,7 +154,7 @@ Plot Raster with Histogram
 Plot Composite (RGB / False-Color)
 ----------------------------------
 
-.. function:: plot_composite(ds, bands, *, stretch=False, figsize=(8, 8), pmin=2, pmax=98, title=None, save_path=None)
+.. function:: plot_composite(ds, bands, *, stretch=True, figsize=(8, 8), pmin=2, pmax=98, title=None, save_path=None)
 
    Plot a three-band raster composite (e.g., RGB or false-color).
 
@@ -152,7 +163,7 @@ Plot Composite (RGB / False-Color)
    :param ds: Raster dataset.
    :type ds: EEORasterDataset
    :param bands: Tuple of three band indices ``(R, G, B)``.
-   :param stretch: Apply percentile contrast stretching independently to each band.
+   :param stretch: Apply percentile contrast stretching independently to each band. Defaults to ``True``; pass ``False`` for raw values.
    :param figsize: Size of the matplotlib figure.
    :param pmin: Lower percentile used when ``stretch=True``.
    :param pmax: Upper percentile used when ``stretch=True``.
@@ -161,5 +172,8 @@ Plot Composite (RGB / False-Color)
 
    .. note::
 
-      When ``stretch=False``, composite values are passed directly to Matplotlib
-      and may be auto-scaled depending on their data range.
+      ``stretch`` is ``True`` by default, so a 2-98 percentile stretch is applied
+      to each band — this is what makes integer rasters (e.g. Sentinel-2
+      reflectance) display correctly rather than as black. When ``stretch=False``,
+      composite values are passed directly to Matplotlib and may be auto-scaled
+      depending on their data range.

--- a/eeo/datasets/__init__.py
+++ b/eeo/datasets/__init__.py
@@ -29,8 +29,19 @@ from eeo.core.loader import load_array, load_raster
 
 from ._cache import DatasetError, cache_dir, ensure_asset
 from ._registry import available, get_dataset
+from ._samples import SampleDataset, SamplePath, load_sample_dataset
 
-__all__ = ["fetch", "load", "info", "available", "cache_dir", "DatasetError"]
+__all__ = [
+    "fetch",
+    "load",
+    "info",
+    "available",
+    "cache_dir",
+    "DatasetError",
+    "load_sample_dataset",
+    "SampleDataset",
+    "SamplePath",
+]
 
 
 def fetch(name: str) -> Path | list[Path]:

--- a/eeo/datasets/__init__.py
+++ b/eeo/datasets/__init__.py
@@ -1,194 +1,30 @@
 """Curated sample datasets with checksum-verified caching.
 
-The functions here download a small, hosted Sentinel-2 / Copernicus-DEM sample
-so tutorials and quickstarts run in minutes without hunting for data. Files are
-cached under ``~/.cache/easy-eo`` (override with ``EEO_DATA_DIR``) and verified
-against a checksum shipped inside the package, so a fetch is fast after the
-first call and never returns corrupt data.
+The bundled Sentinel-2 / Copernicus-DEM sample lets tutorials and quickstarts
+run in minutes without hunting for data. Reach it through
+:func:`load_sample_dataset`, whose attributes are the individual files:
 
-Downloading uses only the Python standard library - no extra dependency.
+>>> from eeo.datasets import load_sample_dataset
+>>> from eeo import load_raster
+>>> sd = load_sample_dataset()
+>>> scene = load_raster(sd.sentinel2_cog_stacked)  # doctest: +SKIP
+>>> dem = load_raster(sd.copernicus_dem)           # doctest: +SKIP
 
-Examples
---------
->>> import eeo
->>> ds = eeo.datasets.load("sentinel2_small")
->>> ndvi = ds.ndvi(red="red", nir="nir")
->>> boundary = eeo.datasets.fetch("sentinel2_small_boundary")
+Files are cached under ``~/.cache/easy-eo`` (override with ``EEO_DATA_DIR``) and
+verified against a checksum shipped inside the package, so a fetch is fast after
+the first call and never returns corrupt data. Downloading uses only the Python
+standard library - no extra dependency.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-from pathlib import Path
-
-import numpy as np
-import rasterio
-
-from eeo.core.core import EEORasterDataset
-from eeo.core.loader import load_array, load_raster
-
-from ._cache import DatasetError, cache_dir, ensure_asset
-from ._registry import available, get_dataset
+from ._cache import DatasetError, cache_dir
 from ._samples import SampleDataset, SamplePath, load_sample_dataset
 
 __all__ = [
-    "fetch",
-    "load",
-    "info",
-    "available",
-    "cache_dir",
-    "DatasetError",
     "load_sample_dataset",
     "SampleDataset",
     "SamplePath",
+    "cache_dir",
+    "DatasetError",
 ]
-
-
-def fetch(name: str) -> Path | list[Path]:
-    """Download a sample dataset and return its cached path(s).
-
-    The file is downloaded on first use and verified against a pinned checksum;
-    subsequent calls return the cached copy without touching the network.
-
-    Parameters
-    ----------
-    name : str
-        A registered dataset name. See :func:`available` for the full list.
-
-    Returns
-    -------
-    pathlib.Path or list of pathlib.Path
-        The cached file path for a single-file dataset, or a list of paths (in
-        band order) for a multi-file dataset such as ``"sentinel2_small"``.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not a registered dataset.
-    DatasetError
-        If a download fails or a file fails checksum verification.
-
-    Examples
-    --------
-    >>> boundary = fetch("sentinel2_small_boundary")
-    >>> band_paths = fetch("sentinel2_small")
-    """
-    dataset = get_dataset(name)
-    paths = [ensure_asset(asset) for asset in dataset.assets]
-    return paths if dataset.multi else paths[0]
-
-
-def load(name: str) -> EEORasterDataset | Path:
-    """Fetch a sample dataset and open it ready to use.
-
-    Raster datasets are returned as an :class:`~eeo.core.core.EEORasterDataset`
-    with band names and acquisition timestamp already set; a single-file raster
-    is opened lazily via :func:`eeo.load_raster`, while a multi-band dataset
-    backed by several single-band files is read into an in-memory stack (the
-    sample is small by design). Vector datasets have no raster representation,
-    so their cached path is returned unchanged — read them with GeoPandas.
-
-    Parameters
-    ----------
-    name : str
-        A registered dataset name. See :func:`available` for the full list.
-
-    Returns
-    -------
-    EEORasterDataset or pathlib.Path
-        An opened dataset for raster entries; the cached file path for vector
-        entries.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not a registered dataset.
-    DatasetError
-        If a download fails or a file fails checksum verification.
-
-    Notes
-    -----
-    A multi-file raster (e.g. ``"sentinel2_small"``) is read eagerly into a
-    NumPy-backed dataset when stacked; single-file rasters remain lazy until an
-    operation needs pixels.
-
-    Examples
-    --------
-    >>> ds = load("sentinel2_small")
-    >>> ds.band_names
-    ['blue', 'green', 'red', 'nir']
-    >>> import geopandas as gpd
-    >>> roi = gpd.read_file(load("sentinel2_small_boundary"))
-    """
-    dataset = get_dataset(name)
-    paths = fetch(name)
-
-    if dataset.kind == "vector":
-        return paths  # type: ignore[return-value]  # single-asset vector -> Path
-
-    if not dataset.multi:
-        return load_raster(
-            str(paths),  # single-asset raster -> Path
-            timestamp=dataset.timestamp,
-            band_names=dataset.band_names or None,
-        )
-
-    return _load_stack(paths, dataset.timestamp, dataset.nodata, dataset.band_names)  # type: ignore[arg-type]
-
-
-def _load_stack(
-    paths: list[Path],
-    timestamp: datetime | None,
-    nodata: float | int | None,
-    band_names: list[str | None],
-) -> EEORasterDataset:
-    """Read single-band files into one georeferenced multi-band dataset."""
-    bands = []
-    transform = crs = None
-    for path in paths:
-        with rasterio.open(path) as src:
-            if transform is None:
-                transform, crs = src.transform, src.crs
-            bands.append(src.read(1))
-    stack = np.stack(bands)
-    return load_array(
-        stack,
-        transform=transform,
-        crs=crs,
-        nodata=nodata,
-        timestamp=timestamp,
-        band_names=band_names or None,
-    )
-
-
-def info(name: str) -> str:
-    """Return a human-readable description and attribution for a dataset.
-
-    Parameters
-    ----------
-    name : str
-        A registered dataset name.
-
-    Returns
-    -------
-    str
-        A multi-line summary: the description followed by the data
-        licence/attribution that must accompany reuse.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not a registered dataset.
-
-    Examples
-    --------
-    >>> print(info("sentinel2_small"))
-    """
-    dataset = get_dataset(name)
-    files = ", ".join(asset.remote for asset in dataset.assets)
-    return (
-        f"{dataset.name} ({dataset.kind})\n"
-        f"  {dataset.description}\n"
-        f"  files: {files}\n"
-        f"  attribution: {dataset.attribution}"
-    )

--- a/eeo/datasets/_registry.py
+++ b/eeo/datasets/_registry.py
@@ -1,25 +1,24 @@
-"""Curated sample-dataset registry for :mod:`eeo.datasets`.
+"""Curated sample-file registry for :mod:`eeo.datasets`.
 
-Each entry maps a logical dataset name to the remote assets hosting it, with a
-pinned sha256 so a download is verified against a checksum that ships *inside*
-the package (never fetched over the same channel as the data). Assets are
-served from a GitHub Release; see ``BASE_URL``.
+Each entry of :data:`SAMPLE_FILES` maps a readable name to one downloadable
+asset with a pinned sha256 that ships *inside* the package (never fetched over
+the same channel as the data), plus the provenance/attribution that must
+accompany reuse. Assets are served from a GitHub Release; see :data:`BASE_URL`.
+
+This registry is an internal detail: users reach the files through
+:func:`eeo.datasets.load_sample_dataset`, never by these names as strings.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
 
 #: Root URL of the hosted sample assets (a GitHub Release; asset paths are
 #: flattened by GitHub, so every remote name here is a bare filename).
 BASE_URL = "https://github.com/Tommy-Burns/easy-eo/releases/download/sample-data-v1/"
 
-#: Acquisition time of the Sentinel-2 scene the samples are cut from.
-_S2_ACQUIRED = datetime(2023, 9, 7, 10, 0, 31, tzinfo=timezone.utc)
-
-#: Human-facing provenance/attribution shown by :func:`eeo.datasets.info` and
-#: required by the data licence.
+#: Human-facing provenance/attribution required by the data licence, surfaced by
+#: :meth:`eeo.datasets.SamplePath.info` / :attr:`~eeo.datasets.SamplePath.attribution`.
 _S2_ATTRIBUTION = (
     "Contains modified Copernicus Sentinel-2 L2A data 2023 (tile T33UUP, "
     "acquired 2023-09-07), processed by ESA; accessed via Microsoft Planetary "
@@ -34,7 +33,7 @@ _DEM_ATTRIBUTION = (
 
 @dataclass(frozen=True)
 class Asset:
-    """One downloadable file backing a dataset.
+    """One downloadable file.
 
     Attributes
     ----------
@@ -45,229 +44,131 @@ class Asset:
         Expected hex digest of the file's bytes, verified after download.
     nbytes : int
         Expected size in bytes, used only for progress/reporting.
-    band_name : str or None
-        Name to assign this asset's band when several single-band assets are
-        loaded together as one multi-band dataset; ``None`` for non-raster or
-        already-multiband assets.
     """
 
     remote: str
     sha256: str
     nbytes: int
-    band_name: str | None = None
 
 
 @dataclass(frozen=True)
-class Dataset:
-    """A named sample dataset made of one or more :class:`Asset` files.
+class SampleFile:
+    """One curated sample exposed as a namespace attribute.
 
     Attributes
     ----------
-    name : str
-        Registry key passed to :func:`eeo.datasets.fetch` / ``load``.
+    asset : Asset
+        The single downloadable file backing this sample.
     kind : str
-        ``"raster"`` or ``"vector"``. Vectors are returned as a path by both
-        ``fetch`` and ``load``; rasters are opened by ``load``.
-    assets : list of Asset
-        Backing files, in band order for a multi-asset raster.
+        ``"raster"`` (open with :func:`eeo.load_raster`) or ``"vector"`` (read
+        the path with GeoPandas).
     description : str
-        One-line summary for :func:`eeo.datasets.info`.
+        One-line summary shown by :meth:`eeo.datasets.SamplePath.info`.
     attribution : str
         Data licence/attribution text.
-    timestamp : datetime.datetime or None
-        Acquisition time applied to the loaded raster.
-    nodata : float or int or None
-        Nodata value applied when a multi-asset raster is stacked in memory.
     """
 
-    name: str
+    asset: Asset
     kind: str
-    assets: list[Asset]
     description: str
     attribution: str
-    timestamp: datetime | None = None
-    nodata: float | int | None = None
-    band_names: list[str | None] = field(default_factory=list)
-
-    @property
-    def multi(self) -> bool:
-        """Whether the dataset is backed by more than one file."""
-        return len(self.assets) > 1
 
 
-#: Per-band single-band files (hosted as raw components). Kept as a multi-asset
-#: dataset (``sentinel2_small_bands``) for workflows that want the bands as
-#: separate rasters; ``sentinel2_small`` itself is the pre-stacked file below.
-_S2_BANDS = [
-    Asset(
-        "B02.tif",
-        "dc60e793fde0b2d88a43a39c1e9ebf8a32fa6215e3c72e6e60057f178e0a328e",
-        1500038,
-        "blue",
+#: The curated samples, keyed by the attribute name they are exposed under on
+#: :class:`eeo.datasets.SampleDataset`. Band files use the library's colour band
+#: names. This is the single source of truth for both the download machinery and
+#: the namespace attributes. Per-band Cloud-Optimized GeoTIFFs are intentionally
+#: absent: only the stacked COG has a checksum pinned today, and fabricating one
+#: would defeat the download verification.
+SAMPLE_FILES: dict[str, SampleFile] = {
+    "sentinel2_stacked": SampleFile(
+        Asset(
+            "sentinel2_small.tif",
+            "f57186fc62574f123bd15359af55e5efa2e654e2146da662aff2320ff8617b92",
+            5750737,
+        ),
+        "raster",
+        "Sentinel-2 L2A 4-band stack (blue/green/red/nir), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
     ),
-    Asset(
-        "B03.tif",
-        "4e8c9e0a4d79271607b1b9ae1c99649302c8b75dc22efb619811cc713c23bd38",
-        1542821,
-        "green",
+    "sentinel2_cog_stacked": SampleFile(
+        Asset(
+            "sentinel2_small_cog.tif",
+            "192ba37bc715a4358e60b56407fed0e2a7f5bf7b57e8a721b6ce7c57b4569f8c",
+            7870231,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the 4-band Sentinel-2 stack (HTTP range-read demos).",
+        _S2_ATTRIBUTION,
     ),
-    Asset(
-        "B04.tif",
-        "56145db8d431d03718a0e082bf5e38dae2afe49eda54f6431ef208687c1be1b0",
-        1553010,
-        "red",
+    "sentinel2_blue": SampleFile(
+        Asset(
+            "B02.tif",
+            "dc60e793fde0b2d88a43a39c1e9ebf8a32fa6215e3c72e6e60057f178e0a328e",
+            1500038,
+        ),
+        "raster",
+        "Sentinel-2 L2A band B02 (blue), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
     ),
-    Asset(
-        "B08.tif",
-        "1f7ca601fae06ebec9a9ccaa7a255ce571f228bd6366f25c6ef90c08bcac6a2a",
-        1544666,
-        "nir",
+    "sentinel2_green": SampleFile(
+        Asset(
+            "B03.tif",
+            "4e8c9e0a4d79271607b1b9ae1c99649302c8b75dc22efb619811cc713c23bd38",
+            1542821,
+        ),
+        "raster",
+        "Sentinel-2 L2A band B03 (green), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
     ),
-]
-_S2_BAND_NAMES: list[str | None] = ["blue", "green", "red", "nir"]
-
-_DATASETS: dict[str, Dataset] = {
-    "sentinel2_small": Dataset(
-        name="sentinel2_small",
-        kind="raster",
-        assets=[
-            Asset(
-                "sentinel2_small.tif",
-                "f57186fc62574f123bd15359af55e5efa2e654e2146da662aff2320ff8617b92",
-                5750737,
-            )
-        ],
-        description="Sentinel-2 L2A 4-band stack (blue/green/red/nir), 1024x1024 @ 10 m, EPSG:32633.",
-        attribution=_S2_ATTRIBUTION,
-        timestamp=_S2_ACQUIRED,
-        nodata=0,
-        band_names=_S2_BAND_NAMES,
+    "sentinel2_red": SampleFile(
+        Asset(
+            "B04.tif",
+            "56145db8d431d03718a0e082bf5e38dae2afe49eda54f6431ef208687c1be1b0",
+            1553010,
+        ),
+        "raster",
+        "Sentinel-2 L2A band B04 (red), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
     ),
-    "sentinel2_small_cog": Dataset(
-        name="sentinel2_small_cog",
-        kind="raster",
-        assets=[
-            Asset(
-                "sentinel2_small_cog.tif",
-                "192ba37bc715a4358e60b56407fed0e2a7f5bf7b57e8a721b6ce7c57b4569f8c",
-                7870231,
-            )
-        ],
-        description="Cloud-Optimized GeoTIFF variant of sentinel2_small (for HTTP range-read demos).",
-        attribution=_S2_ATTRIBUTION,
-        timestamp=_S2_ACQUIRED,
-        nodata=0,
-        band_names=_S2_BAND_NAMES,
+    "sentinel2_nir": SampleFile(
+        Asset(
+            "B08.tif",
+            "1f7ca601fae06ebec9a9ccaa7a255ce571f228bd6366f25c6ef90c08bcac6a2a",
+            1544666,
+        ),
+        "raster",
+        "Sentinel-2 L2A band B08 (nir), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
     ),
-    "sentinel2_small_bands": Dataset(
-        name="sentinel2_small_bands",
-        kind="raster",
-        assets=_S2_BANDS,
-        description="The blue/green/red/nir bands of sentinel2_small as separate single-band files.",
-        attribution=_S2_ATTRIBUTION,
-        timestamp=_S2_ACQUIRED,
-        nodata=0,
-        band_names=_S2_BAND_NAMES,
+    "copernicus_dem": SampleFile(
+        Asset(
+            "DEM.tif",
+            "4aa03df4de877570d728ace4b0c07e71cb8be79a0c0640c6de602116ad1b3f88",
+            3413595,
+        ),
+        "raster",
+        "Copernicus GLO-30 DEM warped onto the Sentinel-2 grid, float32 metres.",
+        _DEM_ATTRIBUTION,
     ),
-    "dem_small": Dataset(
-        name="dem_small",
-        kind="raster",
-        assets=[
-            Asset(
-                "DEM.tif",
-                "4aa03df4de877570d728ace4b0c07e71cb8be79a0c0640c6de602116ad1b3f88",
-                3413595,
-                "elevation",
-            )
-        ],
-        description="Copernicus GLO-30 DEM warped onto the sentinel2_small grid, float32 metres.",
-        attribution=_DEM_ATTRIBUTION,
-        band_names=["elevation"],
+    "copernicus_dem_cog": SampleFile(
+        Asset(
+            "DEM_COG.tif",
+            "c1d763c4dcbec033695ab0d73c75fdbc58d5a2c0d91eb1fe443c13d48644ee27",
+            5385324,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the Copernicus GLO-30 DEM.",
+        _DEM_ATTRIBUTION,
     ),
-    "dem_small_cog": Dataset(
-        name="dem_small_cog",
-        kind="raster",
-        assets=[
-            Asset(
-                "DEM_COG.tif",
-                "c1d763c4dcbec033695ab0d73c75fdbc58d5a2c0d91eb1fe443c13d48644ee27",
-                5385324,
-                "elevation",
-            )
-        ],
-        description="Cloud-Optimized GeoTIFF variant of dem_small.",
-        attribution=_DEM_ATTRIBUTION,
-        band_names=["elevation"],
-    ),
-    "sentinel2_small_boundary": Dataset(
-        name="sentinel2_small_boundary",
-        kind="vector",
-        assets=[
-            Asset(
-                "roi.gpkg",
-                "788a1800caed8d03ef7893de1a61ead281edd901ea049cdf969c5749c0af0744",
-                98304,
-            )
-        ],
-        description="Region-of-interest polygon (GeoPackage, EPSG:4326) inside the sentinel2_small footprint.",
-        attribution=_S2_ATTRIBUTION,
+    "boundary": SampleFile(
+        Asset(
+            "roi.gpkg",
+            "788a1800caed8d03ef7893de1a61ead281edd901ea049cdf969c5749c0af0744",
+            98304,
+        ),
+        "vector",
+        "Region-of-interest polygon (GeoPackage, EPSG:4326) inside the Sentinel-2 footprint.",
+        _S2_ATTRIBUTION,
     ),
 }
-
-
-#: Single-file sample assets exposed as attributes by
-#: :func:`eeo.datasets.load_sample_dataset`. Each maps a readable attribute name
-#: to exactly one :class:`Asset`, so the value can be handed straight to
-#: :func:`eeo.load_raster`. Band files use the library's colour band names
-#: (matching the band-name-centric API). Per-band Cloud-Optimized GeoTIFFs are
-#: intentionally absent: only the stacked COG has a checksum pinned in this
-#: registry today, and fabricating one would defeat the download verification.
-SAMPLE_FILES: dict[str, Asset] = {
-    "sentinel2_stacked": _DATASETS["sentinel2_small"].assets[0],
-    "sentinel2_cog_stacked": _DATASETS["sentinel2_small_cog"].assets[0],
-    "sentinel2_blue": _S2_BANDS[0],
-    "sentinel2_green": _S2_BANDS[1],
-    "sentinel2_red": _S2_BANDS[2],
-    "sentinel2_nir": _S2_BANDS[3],
-    "copernicus_dem": _DATASETS["dem_small"].assets[0],
-    "copernicus_dem_cog": _DATASETS["dem_small_cog"].assets[0],
-    "boundary": _DATASETS["sentinel2_small_boundary"].assets[0],
-}
-
-
-def get_dataset(name: str) -> Dataset:
-    """Return the registry entry for ``name`` or raise a listing error.
-
-    Parameters
-    ----------
-    name : str
-        Dataset name.
-
-    Returns
-    -------
-    Dataset
-        The matching registry entry.
-
-    Raises
-    ------
-    KeyError
-        If ``name`` is not a registered dataset. The message lists the
-        available names.
-    """
-    try:
-        return _DATASETS[name]
-    except KeyError:
-        available = ", ".join(sorted(_DATASETS))
-        raise KeyError(f'unknown dataset "{name}"; available datasets are: {available}') from None
-
-
-def available() -> list[str]:
-    """Return the sorted names of every registered sample dataset.
-
-    Returns
-    -------
-    list of str
-        Dataset names accepted by :func:`eeo.datasets.fetch` and
-        :func:`eeo.datasets.load`.
-    """
-    return sorted(_DATASETS)

--- a/eeo/datasets/_registry.py
+++ b/eeo/datasets/_registry.py
@@ -215,6 +215,26 @@ _DATASETS: dict[str, Dataset] = {
 }
 
 
+#: Single-file sample assets exposed as attributes by
+#: :func:`eeo.datasets.load_sample_dataset`. Each maps a readable attribute name
+#: to exactly one :class:`Asset`, so the value can be handed straight to
+#: :func:`eeo.load_raster`. Band files use the library's colour band names
+#: (matching the band-name-centric API). Per-band Cloud-Optimized GeoTIFFs are
+#: intentionally absent: only the stacked COG has a checksum pinned in this
+#: registry today, and fabricating one would defeat the download verification.
+SAMPLE_FILES: dict[str, Asset] = {
+    "sentinel2_stacked": _DATASETS["sentinel2_small"].assets[0],
+    "sentinel2_cog_stacked": _DATASETS["sentinel2_small_cog"].assets[0],
+    "sentinel2_blue": _S2_BANDS[0],
+    "sentinel2_green": _S2_BANDS[1],
+    "sentinel2_red": _S2_BANDS[2],
+    "sentinel2_nir": _S2_BANDS[3],
+    "copernicus_dem": _DATASETS["dem_small"].assets[0],
+    "copernicus_dem_cog": _DATASETS["dem_small_cog"].assets[0],
+    "boundary": _DATASETS["sentinel2_small_boundary"].assets[0],
+}
+
+
 def get_dataset(name: str) -> Dataset:
     """Return the registry entry for ``name`` or raise a listing error.
 

--- a/eeo/datasets/_samples.py
+++ b/eeo/datasets/_samples.py
@@ -1,8 +1,8 @@
 """Attribute-addressable access to the curated sample files.
 
 :func:`load_sample_dataset` returns a :class:`SampleDataset` whose attributes
-are the individual sample files, so a file can be opened by dotted name instead
-of a string key::
+are the individual sample files, so a file is opened by dotted name — never by a
+hard-coded string key::
 
     from eeo.datasets import load_sample_dataset
     from eeo import load_raster
@@ -14,11 +14,9 @@ of a string key::
 
 Each attribute is a lazy :class:`SamplePath`: holding it touches no network, and
 the file is downloaded and checksum-verified only when it is actually opened
-(when :func:`eeo.load_raster` resolves the path). This is a thin convenience
-layer over the string-keyed :func:`eeo.datasets.load` / :func:`eeo.datasets.fetch`
-API — those remain the way to load the multi-file ``sentinel2_small_bands``
-stack (with band names *and* acquisition timestamp set) and to describe or list
-datasets.
+(when :func:`eeo.load_raster` resolves the path). Provenance travels with the
+handle — :meth:`SamplePath.info` and :attr:`SamplePath.attribution` carry the
+required Copernicus attribution.
 """
 
 from __future__ import annotations
@@ -27,35 +25,55 @@ import os
 from pathlib import Path
 
 from . import _cache
-from ._registry import SAMPLE_FILES, Asset
+from ._registry import SAMPLE_FILES, SampleFile
 
 
 class SamplePath(os.PathLike):
     """A lazy path to one cached sample file.
 
     The object is inert until its filesystem path is needed: passing it to
-    :func:`eeo.load_raster`, calling :func:`os.fspath` on it, or calling
-    :meth:`fetch` downloads the file (once) and verifies it against its pinned
-    checksum. Because it implements :class:`os.PathLike`, it can be used
-    anywhere a path string is accepted.
+    :func:`eeo.load_raster`, calling :func:`os.fspath` on it, or accessing
+    :attr:`path` downloads the file (once) and verifies it against its pinned
+    checksum. Because it implements :class:`os.PathLike`, it can be used anywhere
+    a path string is accepted (``load_raster``, ``geopandas.read_file``, ...).
 
     Parameters
     ----------
     name : str
         The readable attribute name this file is exposed under.
-    asset : Asset
-        The registry asset this path resolves to.
+    sample : SampleFile
+        The registry entry this handle resolves to (asset + provenance).
     """
 
-    def __init__(self, name: str, asset: Asset) -> None:
+    def __init__(self, name: str, sample: SampleFile) -> None:
         self._name = name
-        self._asset = asset
+        self._sample = sample
         self._resolved: Path | None = None
 
     @property
     def name(self) -> str:
         """The readable attribute name (e.g. ``"copernicus_dem"``)."""
         return self._name
+
+    @property
+    def kind(self) -> str:
+        """``"raster"`` or ``"vector"``."""
+        return self._sample.kind
+
+    @property
+    def description(self) -> str:
+        """One-line description of the file's contents."""
+        return self._sample.description
+
+    @property
+    def attribution(self) -> str:
+        """Data licence/attribution text that must accompany reuse."""
+        return self._sample.attribution
+
+    @property
+    def path(self) -> Path:
+        """The cached file path, downloading and verifying if needed."""
+        return self.fetch()
 
     def fetch(self) -> Path:
         """Download (if needed), verify, and return the cached file path.
@@ -74,8 +92,24 @@ class SamplePath(os.PathLike):
             If the download fails or the bytes fail checksum verification.
         """
         if self._resolved is None:
-            self._resolved = _cache.ensure_asset(self._asset)
+            self._resolved = _cache.ensure_asset(self._sample.asset)
         return self._resolved
+
+    def info(self) -> str:
+        """Return a human-readable description and attribution for this file.
+
+        Returns
+        -------
+        str
+            A multi-line summary: name, kind, description, backing filename, and
+            the data licence/attribution required for reuse.
+        """
+        return (
+            f"{self._name} ({self._sample.kind})\n"
+            f"  {self._sample.description}\n"
+            f"  file: {self._sample.asset.remote}\n"
+            f"  attribution: {self._sample.attribution}"
+        )
 
     def __fspath__(self) -> str:
         return str(self.fetch())
@@ -86,11 +120,11 @@ class SamplePath(os.PathLike):
         # dataset's source in describe() stays cheap and offline.
         if self._resolved is not None:
             return str(self._resolved)
-        return self._asset.remote
+        return self._sample.asset.remote
 
     def __repr__(self) -> str:
         state = "cached" if self._resolved is not None else "not fetched"
-        return f"<SamplePath {self._name} -> {self._asset.remote} ({state})>"
+        return f"<SamplePath {self._name} -> {self._sample.asset.remote} ({state})>"
 
 
 class SampleDataset:
@@ -99,7 +133,8 @@ class SampleDataset:
     Obtain one from :func:`load_sample_dataset`. Every attribute is a
     :class:`SamplePath` — inert until opened — so constructing the namespace
     never touches the network. Attributes are declared explicitly (below) so
-    editors offer autocompletion and type checkers see them.
+    editors offer autocompletion and type checkers see them. The namespace is
+    iterable, yielding its :class:`SamplePath` handles.
 
     Attributes
     ----------
@@ -129,11 +164,18 @@ class SampleDataset:
     boundary: SamplePath
 
     def __init__(self, prefetch: bool = False) -> None:
-        for attr, asset in SAMPLE_FILES.items():
-            setattr(self, attr, SamplePath(attr, asset))
+        for attr, sample in SAMPLE_FILES.items():
+            setattr(self, attr, SamplePath(attr, sample))
         if prefetch:
             for attr in SAMPLE_FILES:
                 getattr(self, attr).fetch()
+
+    def __iter__(self):
+        """Iterate the :class:`SamplePath` handles in registry order."""
+        return (getattr(self, attr) for attr in SAMPLE_FILES)
+
+    def __len__(self) -> int:
+        return len(SAMPLE_FILES)
 
     def __repr__(self) -> str:
         return f"SampleDataset({', '.join(SAMPLE_FILES)})"
@@ -142,10 +184,11 @@ class SampleDataset:
 def load_sample_dataset(prefetch: bool = False) -> SampleDataset:
     """Return the sample files as an attribute-addressable namespace.
 
-    Each attribute of the returned object is a lazy :class:`SamplePath` that can
-    be passed straight to :func:`eeo.load_raster`; the underlying file is
-    downloaded and checksum-verified on first use, then cached. Constructing the
-    namespace itself performs no network access.
+    This is the only supported way to reach the bundled samples: each attribute
+    of the returned object is a lazy :class:`SamplePath` that can be passed
+    straight to :func:`eeo.load_raster`. The underlying file is downloaded and
+    checksum-verified on first use, then cached; constructing the namespace
+    itself performs no network access.
 
     Parameters
     ----------
@@ -160,17 +203,12 @@ def load_sample_dataset(prefetch: bool = False) -> SampleDataset:
         A namespace whose attributes are the individual sample files. See its
         class documentation for the available names.
 
-    See Also
-    --------
-    eeo.datasets.load : Open a dataset by string key, with band names and the
-        acquisition timestamp set (and the multi-file band stack).
-    eeo.datasets.fetch : Get cached file path(s) for a dataset by string key.
-
     Notes
     -----
-    Opening a single file with ``load_raster(sd.<name>)`` reads band names from
-    the file's GDAL descriptions but does *not* set the acquisition timestamp;
-    use :func:`eeo.datasets.load` when you need the timestamp too.
+    Opening a file with ``load_raster(sd.<name>)`` reads band names from the
+    file's GDAL descriptions. Provenance and the required Copernicus attribution
+    are available on each handle via :meth:`SamplePath.info` and
+    :attr:`SamplePath.attribution`.
 
     Examples
     --------
@@ -179,5 +217,6 @@ def load_sample_dataset(prefetch: bool = False) -> SampleDataset:
     >>> sd = load_sample_dataset()
     >>> scene = load_raster(sd.sentinel2_cog_stacked)  # doctest: +SKIP
     >>> dem = load_raster(sd.copernicus_dem)           # doctest: +SKIP
+    >>> print(sd.copernicus_dem.attribution)           # doctest: +SKIP
     """
     return SampleDataset(prefetch=prefetch)

--- a/eeo/datasets/_samples.py
+++ b/eeo/datasets/_samples.py
@@ -1,0 +1,183 @@
+"""Attribute-addressable access to the curated sample files.
+
+:func:`load_sample_dataset` returns a :class:`SampleDataset` whose attributes
+are the individual sample files, so a file can be opened by dotted name instead
+of a string key::
+
+    from eeo.datasets import load_sample_dataset
+    from eeo import load_raster
+
+    sd = load_sample_dataset()                     # instant; no download
+    scene = load_raster(sd.sentinel2_cog_stacked)  # downloads that one file
+    dem = load_raster(sd.copernicus_dem)
+    blue = load_raster(sd.sentinel2_blue)
+
+Each attribute is a lazy :class:`SamplePath`: holding it touches no network, and
+the file is downloaded and checksum-verified only when it is actually opened
+(when :func:`eeo.load_raster` resolves the path). This is a thin convenience
+layer over the string-keyed :func:`eeo.datasets.load` / :func:`eeo.datasets.fetch`
+API — those remain the way to load the multi-file ``sentinel2_small_bands``
+stack (with band names *and* acquisition timestamp set) and to describe or list
+datasets.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from . import _cache
+from ._registry import SAMPLE_FILES, Asset
+
+
+class SamplePath(os.PathLike):
+    """A lazy path to one cached sample file.
+
+    The object is inert until its filesystem path is needed: passing it to
+    :func:`eeo.load_raster`, calling :func:`os.fspath` on it, or calling
+    :meth:`fetch` downloads the file (once) and verifies it against its pinned
+    checksum. Because it implements :class:`os.PathLike`, it can be used
+    anywhere a path string is accepted.
+
+    Parameters
+    ----------
+    name : str
+        The readable attribute name this file is exposed under.
+    asset : Asset
+        The registry asset this path resolves to.
+    """
+
+    def __init__(self, name: str, asset: Asset) -> None:
+        self._name = name
+        self._asset = asset
+        self._resolved: Path | None = None
+
+    @property
+    def name(self) -> str:
+        """The readable attribute name (e.g. ``"copernicus_dem"``)."""
+        return self._name
+
+    def fetch(self) -> Path:
+        """Download (if needed), verify, and return the cached file path.
+
+        The result is memoized, so repeated resolution (``load_raster`` checks
+        existence and then opens the file) verifies the checksum only once.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the verified local file.
+
+        Raises
+        ------
+        DatasetError
+            If the download fails or the bytes fail checksum verification.
+        """
+        if self._resolved is None:
+            self._resolved = _cache.ensure_asset(self._asset)
+        return self._resolved
+
+    def __fspath__(self) -> str:
+        return str(self.fetch())
+
+    def __str__(self) -> str:
+        # Side-effect-free: show the cached path once fetched, else the target
+        # filename. Never triggers a download (unlike __fspath__), so printing a
+        # dataset's source in describe() stays cheap and offline.
+        if self._resolved is not None:
+            return str(self._resolved)
+        return self._asset.remote
+
+    def __repr__(self) -> str:
+        state = "cached" if self._resolved is not None else "not fetched"
+        return f"<SamplePath {self._name} -> {self._asset.remote} ({state})>"
+
+
+class SampleDataset:
+    """A namespace of the curated sample files, one per attribute.
+
+    Obtain one from :func:`load_sample_dataset`. Every attribute is a
+    :class:`SamplePath` — inert until opened — so constructing the namespace
+    never touches the network. Attributes are declared explicitly (below) so
+    editors offer autocompletion and type checkers see them.
+
+    Attributes
+    ----------
+    sentinel2_stacked : SamplePath
+        Sentinel-2 blue/green/red/nir as one 4-band GeoTIFF.
+    sentinel2_cog_stacked : SamplePath
+        Cloud-Optimized GeoTIFF variant of ``sentinel2_stacked``.
+    sentinel2_blue, sentinel2_green, sentinel2_red, sentinel2_nir : SamplePath
+        The four Sentinel-2 bands as separate single-band GeoTIFFs.
+    copernicus_dem : SamplePath
+        Copernicus GLO-30 DEM warped onto the Sentinel-2 grid (float32 metres).
+    copernicus_dem_cog : SamplePath
+        Cloud-Optimized GeoTIFF variant of ``copernicus_dem``.
+    boundary : SamplePath
+        Region-of-interest polygon (GeoPackage). A vector, not a raster: read it
+        with GeoPandas (``gpd.read_file(sd.boundary)``), not ``load_raster``.
+    """
+
+    sentinel2_stacked: SamplePath
+    sentinel2_cog_stacked: SamplePath
+    sentinel2_blue: SamplePath
+    sentinel2_green: SamplePath
+    sentinel2_red: SamplePath
+    sentinel2_nir: SamplePath
+    copernicus_dem: SamplePath
+    copernicus_dem_cog: SamplePath
+    boundary: SamplePath
+
+    def __init__(self, prefetch: bool = False) -> None:
+        for attr, asset in SAMPLE_FILES.items():
+            setattr(self, attr, SamplePath(attr, asset))
+        if prefetch:
+            for attr in SAMPLE_FILES:
+                getattr(self, attr).fetch()
+
+    def __repr__(self) -> str:
+        return f"SampleDataset({', '.join(SAMPLE_FILES)})"
+
+
+def load_sample_dataset(prefetch: bool = False) -> SampleDataset:
+    """Return the sample files as an attribute-addressable namespace.
+
+    Each attribute of the returned object is a lazy :class:`SamplePath` that can
+    be passed straight to :func:`eeo.load_raster`; the underlying file is
+    downloaded and checksum-verified on first use, then cached. Constructing the
+    namespace itself performs no network access.
+
+    Parameters
+    ----------
+    prefetch : bool, default False
+        If ``True``, download and verify every sample file immediately (useful
+        before going offline). If ``False`` (the default), each file is fetched
+        lazily the first time it is opened.
+
+    Returns
+    -------
+    SampleDataset
+        A namespace whose attributes are the individual sample files. See its
+        class documentation for the available names.
+
+    See Also
+    --------
+    eeo.datasets.load : Open a dataset by string key, with band names and the
+        acquisition timestamp set (and the multi-file band stack).
+    eeo.datasets.fetch : Get cached file path(s) for a dataset by string key.
+
+    Notes
+    -----
+    Opening a single file with ``load_raster(sd.<name>)`` reads band names from
+    the file's GDAL descriptions but does *not* set the acquisition timestamp;
+    use :func:`eeo.datasets.load` when you need the timestamp too.
+
+    Examples
+    --------
+    >>> from eeo.datasets import load_sample_dataset
+    >>> from eeo import load_raster
+    >>> sd = load_sample_dataset()
+    >>> scene = load_raster(sd.sentinel2_cog_stacked)  # doctest: +SKIP
+    >>> dem = load_raster(sd.copernicus_dem)           # doctest: +SKIP
+    """
+    return SampleDataset(prefetch=prefetch)

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -172,7 +172,7 @@ def plot_band_array(
     *,
     cmap: str = "gray",
     figsize: tuple[int, int] = (8, 8),
-    stretch: bool = False,
+    stretch: bool = True,
     pmin: float = 2,
     pmax: float = 98,
     title: str | None = None,
@@ -196,8 +196,10 @@ def plot_band_array(
         Matplotlib colormap.
     figsize : tuple of int, default (8, 8)
         Figure size in inches.
-    stretch : bool, default False
-        If True, apply percentile contrast stretching to each band.
+    stretch : bool, default True
+        If True, apply percentile contrast stretching to each band. On by
+        default because the ``pmin``-``pmax`` (2-98) stretch renders most
+        rasters best; pass ``stretch=False`` to display raw values.
     pmin : float, default 2
         Lower percentile for the stretch (used only when ``stretch=True``).
     pmax : float, default 98
@@ -232,7 +234,8 @@ def plot_band_array(
 
     Examples
     --------
-    >>> ds.plot_band_array(bands=[1, 2, 3], stretch=True)
+    >>> ds.plot_band_array(bands=[1, 2, 3])                # 2-98 stretch on by default
+    >>> ds.plot_band_array(bands=[1, 2, 3], stretch=False)  # raw values
     """
     datasets = _as_list(ds)
     bands_list = _normalize_bands(datasets[0], bands)
@@ -268,7 +271,7 @@ def plot_raster(
     *,
     cmap: str = "gray",
     figsize: tuple[int, int] = (10, 5),
-    stretch: bool = False,
+    stretch: bool = True,
     pmin: float = 2,
     pmax: float = 98,
     title: str | None = None,
@@ -292,8 +295,10 @@ def plot_raster(
         Matplotlib colormap.
     figsize : tuple of int, default (10, 5)
         Figure size in inches.
-    stretch : bool, default False
-        If True, apply percentile contrast stretching to each band.
+    stretch : bool, default True
+        If True, apply percentile contrast stretching to each band. On by
+        default because the ``pmin``-``pmax`` (2-98) stretch renders most
+        rasters best; pass ``stretch=False`` to display raw values.
     pmin : float, default 2
         Lower percentile for the stretch (used only when ``stretch=True``).
     pmax : float, default 98
@@ -328,7 +333,8 @@ def plot_raster(
 
     Examples
     --------
-    >>> ds.plot_raster(bands=1, stretch=True)
+    >>> ds.plot_raster(bands=1)                 # 2-98 stretch on by default
+    >>> ds.plot_raster(bands=1, stretch=False)  # raw values
     """
     datasets = _as_list(ds)
     bands_list = _normalize_bands(datasets[0], bands)
@@ -544,7 +550,7 @@ def plot_composite(
     ds: EEORasterDataset,
     bands: Sequence[int | str],
     *,
-    stretch: bool = False,
+    stretch: bool = True,
     figsize: tuple[int, int] = (8, 8),
     pmin: float = 2,
     pmax: float = 98,
@@ -563,8 +569,11 @@ def plot_composite(
     bands : sequence of (int or str)
         Exactly three bands, each a 1-based index or a band name, mapped to
         R, G, B in order.
-    stretch : bool, default False
-        If True, apply percentile contrast stretching to each channel.
+    stretch : bool, default True
+        If True, apply percentile contrast stretching to each channel. On by
+        default because the ``pmin``-``pmax`` (2-98) stretch renders most
+        composites best (and integer rasters such as Sentinel-2 reflectance
+        display as black without it); pass ``stretch=False`` for raw values.
     figsize : tuple of int, default (8, 8)
         Figure size in inches.
     pmin : float, default 2

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -281,6 +281,8 @@ def test_info_and_attribution_travel_with_handle():
     assert "B02.tif" in text
     assert "raster" in text
     assert sd.sentinel2_blue.attribution in text
+    assert sd.sentinel2_blue.description in text
+    assert "blue" in sd.sentinel2_blue.description.lower()
 
 
 def test_boundary_is_vector():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,6 +8,7 @@ integration test is marked ``network`` and skipped unless ``--run-network``.
 from __future__ import annotations
 
 import hashlib
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -18,9 +19,10 @@ from affine import Affine
 from rasterio.crs import CRS
 
 import eeo
-from eeo.datasets import _cache, _registry
+from eeo.datasets import _cache, _registry, _samples
 from eeo.datasets._cache import DatasetError, cache_dir, ensure_asset
 from eeo.datasets._registry import Asset, Dataset
+from eeo.datasets._samples import SampleDataset, SamplePath, load_sample_dataset
 
 UTM = CRS.from_epsg(32633)
 TRANSFORM = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
@@ -321,6 +323,101 @@ def test_sentinel2_small_bands_is_multi_in_band_order():
     ds = _registry.get_dataset("sentinel2_small_bands")
     assert ds.multi and ds.kind == "raster"
     assert [a.band_name for a in ds.assets] == ["blue", "green", "red", "nir"]
+
+
+# --------------------------------------------------------------------------- #
+# load_sample_dataset: attribute-addressable, lazy access
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def fake_ensure(monkeypatch, tmp_path):
+    """Stub ``ensure_asset`` with a real synthetic GeoTIFF per asset name.
+
+    Returns the list of assets ``ensure_asset`` was called with, so tests can
+    assert exactly which (and how many) files were fetched.
+    """
+    calls: list = []
+
+    def _ensure(asset):
+        calls.append(asset)
+        dest = tmp_path / asset.remote
+        if not dest.exists():
+            _write_band(dest, value=1234, name="blue")
+        return dest
+
+    monkeypatch.setattr(_samples._cache, "ensure_asset", _ensure)
+    return calls
+
+
+def test_load_sample_dataset_exposes_all_names():
+    sd = load_sample_dataset()
+    assert isinstance(sd, SampleDataset)
+    for name in _registry.SAMPLE_FILES:
+        assert isinstance(getattr(sd, name), SamplePath)
+
+
+def test_declared_attrs_match_registry():
+    # The explicit class annotations (for autocomplete/type-checkers) must not
+    # drift from the actual SAMPLE_FILES source of truth.
+    assert set(SampleDataset.__annotations__) == set(_registry.SAMPLE_FILES)
+
+
+def test_construction_does_not_fetch(fake_ensure):
+    load_sample_dataset()
+    assert fake_ensure == []  # no network on construction
+
+
+def test_attribute_access_does_not_fetch(fake_ensure):
+    sd = load_sample_dataset()
+    _ = sd.copernicus_dem  # holding the handle must not download
+    assert fake_ensure == []
+
+
+def test_fspath_triggers_fetch_once(fake_ensure):
+    sd = load_sample_dataset()
+    p1 = os.fspath(sd.sentinel2_blue)
+    p2 = os.fspath(sd.sentinel2_blue)  # memoized: no second fetch
+    assert p1 == p2
+    assert len(fake_ensure) == 1
+    assert fake_ensure[0] is _registry.SAMPLE_FILES["sentinel2_blue"]
+
+
+def test_prefetch_downloads_everything(fake_ensure):
+    load_sample_dataset(prefetch=True)
+    assert len(fake_ensure) == len(_registry.SAMPLE_FILES)
+
+
+def test_load_raster_opens_sample_path(fake_ensure):
+    sd = load_sample_dataset()
+    ds = eeo.load_raster(sd.sentinel2_blue)
+    assert ds.get_count() == 1
+    assert ds.to_array().min() == 1234
+    assert len(fake_ensure) == 1  # opened exactly one file
+
+
+def test_sample_path_str_is_side_effect_free(fake_ensure):
+    sd = load_sample_dataset()
+    # Before fetch: shows the target filename, no download.
+    assert str(sd.copernicus_dem) == _registry.SAMPLE_FILES["copernicus_dem"].remote
+    assert fake_ensure == []
+    # After fetch: shows the cached path.
+    resolved = sd.copernicus_dem.fetch()
+    assert str(sd.copernicus_dem) == str(resolved)
+
+
+def test_sample_path_repr_and_name(fake_ensure):
+    sd = load_sample_dataset()
+    assert sd.copernicus_dem.name == "copernicus_dem"
+    assert "not fetched" in repr(sd.copernicus_dem)
+    sd.copernicus_dem.fetch()
+    assert "cached" in repr(sd.copernicus_dem)
+    assert "copernicus_dem" in repr(sd)
+
+
+def test_sample_files_are_single_pinned_assets():
+    for name, asset in _registry.SAMPLE_FILES.items():
+        assert isinstance(asset, Asset), name
+        assert len(asset.sha256) == 64
+        assert asset.nbytes > 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,15 +1,15 @@
-"""Tests for the sample-dataset fetch/cache helpers (:mod:`eeo.datasets`).
+"""Tests for the sample-dataset helpers (:mod:`eeo.datasets`).
 
 Every test in the default run is offline: downloads are redirected to
-locally-built synthetic files via a patched ``_download``. One real-network
-integration test is marked ``network`` and skipped unless ``--run-network``.
+locally-built synthetic files via a patched ``_download`` (or a stubbed
+``ensure_asset``). One real-network integration test is marked ``network`` and
+skipped unless ``--run-network``.
 """
 
 from __future__ import annotations
 
 import hashlib
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -21,7 +21,7 @@ from rasterio.crs import CRS
 import eeo
 from eeo.datasets import _cache, _registry, _samples
 from eeo.datasets._cache import DatasetError, cache_dir, ensure_asset
-from eeo.datasets._registry import Asset, Dataset
+from eeo.datasets._registry import Asset, SampleFile
 from eeo.datasets._samples import SampleDataset, SamplePath, load_sample_dataset
 
 UTM = CRS.from_epsg(32633)
@@ -177,155 +177,6 @@ def test_download_network_error_raises_dataset_error(cache_env, local_asset, mon
 
 
 # --------------------------------------------------------------------------- #
-# fetch / load / info via a synthetic registry
-# --------------------------------------------------------------------------- #
-@pytest.fixture
-def synthetic_registry(cache_env, tmp_path, monkeypatch):
-    """Replace the registry with local synthetic rasters + a vector stand-in."""
-    # Build two single-band rasters and a "vector" blob on disk.
-    red = tmp_path / "red_src.tif"
-    nir = tmp_path / "nir_src.tif"
-    _write_band(red, value=1000, name="red")
-    _write_band(nir, value=4000, name="nir")
-    vec = tmp_path / "roi_src.gpkg"
-    vec.write_bytes(b"fake-geopackage-bytes")
-
-    sources = {"red.tif": red, "nir.tif": nir, "roi.gpkg": vec}
-
-    def sha(p: Path) -> str:
-        return _sha256_bytes(p.read_bytes())
-
-    ts = datetime(2023, 9, 7, 10, 0, 31, tzinfo=timezone.utc)
-    registry = {
-        "s2": Dataset(
-            name="s2",
-            kind="raster",
-            assets=[
-                Asset("red.tif", sha(red), red.stat().st_size, "red"),
-                Asset("nir.tif", sha(nir), nir.stat().st_size, "nir"),
-            ],
-            description="synthetic two-band",
-            attribution="test attribution",
-            timestamp=ts,
-            nodata=0,
-            band_names=["red", "nir"],
-        ),
-        "single": Dataset(
-            name="single",
-            kind="raster",
-            assets=[Asset("red.tif", sha(red), red.stat().st_size, "red")],
-            description="synthetic one-band",
-            attribution="test attribution",
-            timestamp=ts,
-            band_names=["red"],
-        ),
-        "roi": Dataset(
-            name="roi",
-            kind="vector",
-            assets=[Asset("roi.gpkg", sha(vec), vec.stat().st_size)],
-            description="synthetic vector",
-            attribution="test attribution",
-        ),
-    }
-    monkeypatch.setattr(_registry, "_DATASETS", registry)
-
-    def fake_download(url, dest):
-        dest.write_bytes(sources[dest.name].read_bytes())
-
-    monkeypatch.setattr(_cache, "_download", fake_download)
-    return registry, ts
-
-
-def test_fetch_single_returns_path(synthetic_registry):
-    path = eeo.datasets.fetch("single")
-    assert isinstance(path, Path)
-    assert path.name == "red.tif"
-
-
-def test_fetch_multi_returns_list_in_band_order(synthetic_registry):
-    paths = eeo.datasets.fetch("s2")
-    assert isinstance(paths, list)
-    assert [p.name for p in paths] == ["red.tif", "nir.tif"]
-
-
-def test_load_stack_sets_names_timestamp_and_stacks(synthetic_registry):
-    _, ts = synthetic_registry
-    ds = eeo.datasets.load("s2")
-    assert ds.get_count() == 2
-    assert ds.band_names == ["red", "nir"]
-    assert ds.timestamp == ts
-    arr = ds.to_array()
-    assert arr.shape == (2, 4, 4)
-    assert arr[0].min() == 1000 and arr[1].min() == 4000  # band order preserved
-
-
-def test_load_single_raster_is_lazy_with_names(synthetic_registry):
-    ds = eeo.datasets.load("single")
-    assert ds.get_count() == 1
-    assert ds.band_names == ["red"]
-
-
-def test_load_vector_returns_path(synthetic_registry):
-    result = eeo.datasets.load("roi")
-    assert isinstance(result, Path)
-    assert result.name == "roi.gpkg"
-
-
-def test_load_stack_ndvi_by_name(synthetic_registry):
-    ds = eeo.datasets.load("s2")
-    ndvi = ds.ndvi(red="red", nir="nir")
-    a = ndvi.to_array()
-    # (4000 - 1000) / (4000 + 1000) = 0.6 everywhere
-    assert np.allclose(a, 0.6, atol=1e-4)
-    assert a.dtype == np.float32
-
-
-def test_info_includes_attribution(synthetic_registry):
-    text = eeo.datasets.info("s2")
-    assert "test attribution" in text
-    assert "red.tif" in text and "nir.tif" in text
-
-
-# --------------------------------------------------------------------------- #
-# Error handling and registry integrity (no network, real registry)
-# --------------------------------------------------------------------------- #
-def test_unknown_dataset_lists_available():
-    with pytest.raises(KeyError, match="unknown dataset"):
-        eeo.datasets.fetch("does_not_exist")
-
-
-def test_available_matches_registry():
-    names = eeo.datasets.available()
-    assert names == sorted(names)
-    assert "sentinel2_small" in names
-    assert set(names) == set(_registry._DATASETS)
-
-
-def test_real_registry_checksums_are_wellformed():
-    for name in eeo.datasets.available():
-        ds = _registry.get_dataset(name)
-        assert ds.assets, name
-        for asset in ds.assets:
-            assert len(asset.sha256) == 64
-            assert all(c in "0123456789abcdef" for c in asset.sha256)
-            assert asset.nbytes > 0
-
-
-def test_sentinel2_small_is_single_stacked_raster():
-    ds = _registry.get_dataset("sentinel2_small")
-    assert ds.kind == "raster"
-    assert not ds.multi  # a single pre-stacked 4-band file
-    assert len(ds.assets) == 1
-    assert ds.band_names == ["blue", "green", "red", "nir"]
-
-
-def test_sentinel2_small_bands_is_multi_in_band_order():
-    ds = _registry.get_dataset("sentinel2_small_bands")
-    assert ds.multi and ds.kind == "raster"
-    assert [a.band_name for a in ds.assets] == ["blue", "green", "red", "nir"]
-
-
-# --------------------------------------------------------------------------- #
 # load_sample_dataset: attribute-addressable, lazy access
 # --------------------------------------------------------------------------- #
 @pytest.fixture
@@ -378,7 +229,7 @@ def test_fspath_triggers_fetch_once(fake_ensure):
     p2 = os.fspath(sd.sentinel2_blue)  # memoized: no second fetch
     assert p1 == p2
     assert len(fake_ensure) == 1
-    assert fake_ensure[0] is _registry.SAMPLE_FILES["sentinel2_blue"]
+    assert fake_ensure[0] is _registry.SAMPLE_FILES["sentinel2_blue"].asset
 
 
 def test_prefetch_downloads_everything(fake_ensure):
@@ -394,10 +245,18 @@ def test_load_raster_opens_sample_path(fake_ensure):
     assert len(fake_ensure) == 1  # opened exactly one file
 
 
+def test_path_property_fetches(fake_ensure):
+    sd = load_sample_dataset()
+    p = sd.copernicus_dem.path
+    assert isinstance(p, Path)
+    assert p.is_file()
+    assert len(fake_ensure) == 1
+
+
 def test_sample_path_str_is_side_effect_free(fake_ensure):
     sd = load_sample_dataset()
     # Before fetch: shows the target filename, no download.
-    assert str(sd.copernicus_dem) == _registry.SAMPLE_FILES["copernicus_dem"].remote
+    assert str(sd.copernicus_dem) == _registry.SAMPLE_FILES["copernicus_dem"].asset.remote
     assert fake_ensure == []
     # After fetch: shows the cached path.
     resolved = sd.copernicus_dem.fetch()
@@ -413,11 +272,43 @@ def test_sample_path_repr_and_name(fake_ensure):
     assert "copernicus_dem" in repr(sd)
 
 
+def test_info_and_attribution_travel_with_handle():
+    sd = load_sample_dataset()
+    # Attribution is queryable from code without touching the network.
+    assert "Copernicus DEM" in sd.copernicus_dem.attribution
+    assert "Sentinel-2" in sd.sentinel2_blue.attribution
+    text = sd.sentinel2_blue.info()
+    assert "B02.tif" in text
+    assert "raster" in text
+    assert sd.sentinel2_blue.attribution in text
+
+
+def test_boundary_is_vector():
+    sd = load_sample_dataset()
+    assert sd.boundary.kind == "vector"
+    assert all(getattr(sd, n).kind == "raster" for n in _registry.SAMPLE_FILES if n != "boundary")
+
+
+def test_namespace_iterates_all_handles():
+    sd = load_sample_dataset()
+    assert len(sd) == len(_registry.SAMPLE_FILES)
+    assert {h.name for h in sd} == set(_registry.SAMPLE_FILES)
+    assert all(isinstance(h, SamplePath) for h in sd)
+
+
 def test_sample_files_are_single_pinned_assets():
-    for name, asset in _registry.SAMPLE_FILES.items():
-        assert isinstance(asset, Asset), name
-        assert len(asset.sha256) == 64
-        assert asset.nbytes > 0
+    for name, sample in _registry.SAMPLE_FILES.items():
+        assert isinstance(sample, SampleFile), name
+        assert sample.kind in {"raster", "vector"}
+        assert len(sample.asset.sha256) == 64
+        assert all(c in "0123456789abcdef" for c in sample.asset.sha256)
+        assert sample.asset.nbytes > 0
+
+
+def test_string_key_api_is_not_public():
+    # Data is reachable only through the namespace, never by hard-coded string.
+    for removed in ("load", "fetch", "info", "available"):
+        assert not hasattr(eeo.datasets, removed), removed
 
 
 # --------------------------------------------------------------------------- #
@@ -425,11 +316,11 @@ def test_sample_files_are_single_pinned_assets():
 # --------------------------------------------------------------------------- #
 @pytest.mark.network
 def test_real_download_roundtrip(tmp_path, monkeypatch):
-    """Download the smallest real asset and verify checksum + open it."""
+    """Download real assets through the namespace and verify checksum + open."""
     monkeypatch.setenv("EEO_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-    path = eeo.datasets.fetch("sentinel2_small_boundary")
-    assert path.is_file()
-    ds = eeo.datasets.load("sentinel2_small")
-    assert ds.band_names == ["blue", "green", "red", "nir"]
+    sd = load_sample_dataset()
+    assert sd.boundary.fetch().is_file()  # smallest asset, checksum-verified
+    ds = eeo.load_raster(sd.sentinel2_stacked)
     assert ds.get_count() == 4
+    assert ds.band_names == ["blue", "green", "red", "nir"]

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -78,6 +78,26 @@ def test_normalize_bands_iterable(multiband_uint16):
     assert bands == [1, 3]
 
 
+@pytest.mark.parametrize(
+    "func, expected",
+    [
+        (plot_band_array, True),
+        (plot_raster, True),
+        (plot_composite, True),
+        (plot_raster_with_histogram, False),  # keeps raw histogram
+    ],
+    ids=["plot_band_array", "plot_raster", "plot_composite", "plot_raster_with_histogram"],
+)
+def test_stretch_default(func, expected):
+    import inspect
+
+    sig = inspect.signature(func)
+    assert sig.parameters["stretch"].default is expected
+    # The percentile bounds default to the conventional 2-98 everywhere.
+    assert sig.parameters["pmin"].default == 2
+    assert sig.parameters["pmax"].default == 98
+
+
 def test_percentile_stretch_basic():
     arr = np.array([0, 1, 2, 3, 4], dtype=np.float32)
     stretched = _percentile_stretch(arr, 0, 100)


### PR DESCRIPTION
## Summary

This PR replaces the old literal string approach for accessing sample data with a namespace that accepts dot notation, so `load_raster("sentinel2_small")` becomes
```python
sd = load_sample_dataset() 
scene = load_raster(sd.sentinel2_stacked)
```

`stretch` was also set to a default of `True ` for all visualisation functions to improve the visuals

## Related issues / tasks
The example files API


## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [ ] Nodata and dtype behaviour is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer
The old method of accessing the file used string literals to access the files. This update replaces that approach with a namespace approach, which can be accessed with dot notation on `load_sample_dataset() `

