### PR TITLE
STAC Data Access added through optional extra ( easy-eo[stac] )

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      # The optional extras are installed here so their "installed" path is
+      # exercised; the "absent" path is covered by simulating the missing
+      # import, so both cases run in every environment.
       - name: Install locked environment
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen --extra dev --extra stac
 
       - name: Run tests with coverage
         run: uv run pytest --cov-report=xml
@@ -104,7 +107,7 @@ jobs:
       - name: Install lowest supported dependency versions
         run: |
           uv venv --python 3.10 --clear
-          uv pip install --resolution lowest-direct -e ".[dev]"
+          uv pip install --resolution lowest-direct -e ".[dev,stac]"
 
       # Old dependency versions legitimately emit their own deprecation
       # warnings (e.g. matplotlib via pyparsing); this job checks functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: >
           uvx --from numpydoc numpydoc lint
           eeo/ops/*.py eeo/analysis/*.py eeo/preprocessing/*.py eeo/viz/*.py
-          eeo/core/loader.py eeo/_show_versions.py
+          eeo/io/*.py eeo/core/loader.py eeo/_show_versions.py
 
       - name: Core stub freshness
         run: uv run python scripts/generate_core_stub.py --check

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -31,7 +31,7 @@ jobs:
       # `--upgrade` re-resolves to the newest versions within our ranges,
       # ignoring uv.lock, so this tests against fresh upstream releases.
       - name: Install latest dependency versions
-        run: uv sync --upgrade --extra dev
+        run: uv sync --upgrade --extra dev --extra stac
 
       # Newer upstream releases may introduce their own deprecation warnings;
       # this canary tracks functional pass/fail, so they are not fatal here.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist/
 # Data
 data/
 others/
+# ...but the recorded API responses under tests/data are fixtures the suite
+# needs, not scratch data: without them the STAC replay tests fail in CI.
+!tests/data/
 
 # Docs
 docs/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,10 @@ are called out under a **Breaking** heading.
   are mutually exclusive, as the STAC spec requires. The geometry is retained on
   the result (`STACSearchResult.intersects`, `STACItem.search_intersects`), so
   `load()` crops to its bounds by default and `load(..., mask=True)` sets the
-  pixels outside its outline to nodata.
+  pixels outside its outline to nodata — the asset's own nodata value where it
+  declares one, otherwise NaN for floating dtypes and 0 for integer ones,
+  recorded as the result's `nodata` either way so a masked area is never
+  mistaken for data by a later operation.
 - **STAC asset loading (`STACItem.load`).** Turns a search result into an
   `EEORasterDataset`: `results[0].load(["B04", "B08"])`. **Only the area of
   interest is read** — the assets are opened remotely and just the pixels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,17 @@ are called out under a **Breaking** heading.
   multi-asset stacking behave, and the caveats worth knowing (signed URLs
   expire, the cloud filter is the catalog's own, catalogs return reprocessed
   duplicates).
+- **Search by shape (`stac_search(intersects=...)`).** Filter scenes by a real
+  area of interest instead of its bounding rectangle: a GeoDataFrame, GeoSeries,
+  shapely geometry, GeoJSON mapping (geometry, Feature, or FeatureCollection),
+  or a path to any vector file GeoPandas can read. Anything carrying a CRS is
+  reprojected to WGS 84 lon/lat automatically — a projected geometry submitted
+  as-is would match nothing, silently, so one whose coordinates cannot be
+  degrees is rejected with an actionable error instead. `bbox` and `intersects`
+  are mutually exclusive, as the STAC spec requires. The geometry is retained on
+  the result (`STACSearchResult.intersects`, `STACItem.search_intersects`), so
+  `load()` crops to its bounds by default and `load(..., mask=True)` sets the
+  pixels outside its outline to nodata.
 - **STAC asset loading (`STACItem.load`).** Turns a search result into an
   `EEORasterDataset`: `results[0].load(["B04", "B08"])`. **Only the area of
   interest is read** — the assets are opened remotely and just the pixels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **Optional `stac` extra (`pip install "easy-eo[stac]"`).** Installs
+  `pystac-client>=0.8,<1` and `planetary-computer>=1.0,<2`, the dependencies of
+  the forthcoming STAC data access. Features behind an extra import their
+  packages through a shared helper that raises the new
+  `MissingDependencyError` — an `EEOError` that is also an `ImportError`, so
+  `except ImportError` still catches it — whose message names the feature, the
+  missing package, and the exact `pip install 'easy-eo[stac]'` command. A
+  missing *transitive* dependency of an installed extra still surfaces as its
+  own `ModuleNotFoundError` rather than being reported as a missing extra.
 - **Sample-data helper (`eeo.datasets.load_sample_dataset`).** Returns a
   `SampleDataset` namespace whose attributes are the individual bundled files, so
   a curated Sentinel-2 / Copernicus-DEM sample is opened by readable,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **"Loading satellite data" guide** (`docs/source/user_guide/loading_satellite_data.rst`).
+  Quickstart from a STAC archive to a plotted NDVI in under ten lines, then the
+  detail: what each search filter means, how to read a result, which asset keys
+  the common catalogs use for each Sentinel-2 and Landsat 8/9 band, how AOI
+  cropping and
+  multi-asset stacking behave, and the caveats worth knowing (signed URLs
+  expire, the cloud filter is the catalog's own, catalogs return reprocessed
+  duplicates).
 - **STAC asset loading (`STACItem.load`).** Turns a search result into an
   `EEORasterDataset`: `results[0].load(["B04", "B08"])`. **Only the area of
   interest is read** — the assets are opened remotely and just the pixels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,20 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **STAC asset loading (`STACItem.load`).** Turns a search result into an
+  `EEORasterDataset`: `results[0].load(["B04", "B08"])`. **Only the area of
+  interest is read** — the assets are opened remotely and just the pixels
+  covering the AOI are fetched as HTTP range requests against the
+  cloud-optimized GeoTIFF, so a small AOI over a Sentinel-2 tile transfers a
+  fraction of the band and nothing is downloaded whole. The AOI defaults to the
+  `bbox` of the search that produced the item (exposed as
+  `STACItem.search_bbox`); pass `bbox=` to override it or `crop=False` to read
+  the entire scene. Several assets stack into one multi-band dataset with each
+  band named after its asset, ready for `ds.ndvi(red="B04", nir="B08")`; assets
+  that do not share the first one's grid — a 20 m band beside a 10 m one, or a
+  different UTM zone — are resampled onto it (`resampling=`, nearest by
+  default). The result carries the item's acquisition time as `timestamp` and
+  its id, collection, and asset list in `attrs`.
 - **STAC search (`eeo.stac_search`).** Query any STAC API — Microsoft Planetary
   Computer by default — by collection, bounding box (WGS 84 lon/lat), date or
   date range, maximum cloud cover, and result limit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- **STAC search (`eeo.stac_search`).** Query any STAC API — Microsoft Planetary
+  Computer by default — by collection, bounding box (WGS 84 lon/lat), date or
+  date range, maximum cloud cover, and result limit:
+  `eeo.stac_search("sentinel-2-l2a", bbox=..., datetime="2023-06-01/2023-08-31",
+  cloud_cover=20, limit=5)`. Returns a `STACSearchResult`: a sequence of
+  `STACItem`s ordered oldest-first, each carrying its acquisition `timestamp`,
+  `assets`, `cloud_cover`, and STAC `properties`, with the raw `pystac.Item`
+  still reachable at `.item`. The result keeps the search `bbox` as its area of
+  interest. Planetary Computer asset URLs are signed automatically (override
+  with `sign=`). Searching is metadata-only — no pixel data is read and nothing
+  is downloaded. Needs the `stac` extra.
 - **Optional `stac` extra (`pip install "easy-eo[stac]"`).** Installs
   `pystac-client>=0.8,<1` and `planetary-computer>=1.0,<2`, the dependencies of
   the forthcoming STAC data access. Features behind an extra import their

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,31 @@ Coverage is enforced: the run fails if total coverage drops below the
 project threshold. Bug fixes must include a regression test, and new features
 must include tests (see `CODE_STYLE.md`).
 
+#### The default run is offline
+
+No test may reach the network by default — a suite that depends on someone
+else's uptime is a suite that fails for reasons you cannot fix. An autouse
+fixture blocks Python-level socket connections and fails any test that tries,
+so this is enforced rather than merely encouraged.
+
+Work from local files, fakes, or the recorded API responses in
+`tests/data/stac/` (refresh them with `python scripts/record_stac_responses.py`;
+see the README there). A test that genuinely needs the network is marked and
+opted into explicitly:
+
+```python
+@pytest.mark.network
+def test_real_download():
+    ...
+```
+
+```bash
+pytest --run-network          # include the marked tests
+```
+
+Note that GDAL's HTTP stack does not use Python sockets, so the fixture cannot
+catch a remote raster read; keep those out of the default suite by design.
+
 ### pre-commit — step by step
 
 `pre-commit` runs the whitespace, ruff, ruff-format, and mypy hooks so issues

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -48,7 +48,8 @@ install stays small. Install an extra by name:
     * - ``stac``
       - ``pystac-client``, ``planetary-computer``
       - Searching STAC catalogs and loading assets straight into an
-        :class:`~eeo.core.EEORasterDataset`
+        :class:`~eeo.core.EEORasterDataset` — see
+        :doc:`user_guide/loading_satellite_data`
 
 Using a feature without its extra installed raises
 :class:`~eeo.MissingDependencyError` — an ``ImportError`` whose message names

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -18,12 +18,50 @@ scientific libraries, including:
 - **NumPy** for numerical and array operations.
 - **Matplotlib** for visualization of rasters and histograms.
 
-Installing Easy-EO (this current version) automatically installs these dependencies with compatible versions:
+Installing Easy-EO automatically installs these dependencies within the tested
+version ranges:
 
-- `rasterio>=1.4,<1.5`
-- `geopandas>=1.1,<1.2`
-- `numpy>=1.26,<2.2`
-- `matplotlib>=3.10,<3.11`
+- ``rasterio>=1.4,<2``
+- ``geopandas>=1.1,<2``
+- ``numpy>=1.26,<3``
+- ``matplotlib>=3.8``
+
+----
+
+Optional extras
+^^^^^^^^^^^^^^^
+
+Heavier, feature-specific dependencies live behind optional extras so the base
+install stays small. Install an extra by name:
+
+.. code-block:: bash
+
+    pip install "easy-eo[stac]"
+
+.. list-table::
+    :header-rows: 1
+    :widths: 15 40 45
+
+    * - Extra
+      - Installs
+      - Enables
+    * - ``stac``
+      - ``pystac-client``, ``planetary-computer``
+      - Searching STAC catalogs and loading assets straight into an
+        :class:`~eeo.core.EEORasterDataset`
+
+Using a feature without its extra installed raises
+:class:`~eeo.MissingDependencyError` — an ``ImportError`` whose message names
+the exact install command:
+
+.. code-block:: text
+
+    MissingDependencyError: STAC search requires the optional 'pystac_client'
+    package, which is not installed. Install the 'stac' extra with:
+    pip install 'easy-eo[stac]'
+
+``eeo.show_versions()`` reports which extras are present, which is worth
+pasting into any bug report.
 
 ----
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ arithmetic, computing indices, and visualizing results.
    getting_started
    user_guide/core_dataset
    user_guide/sample_data
+   user_guide/loading_satellite_data
    user_guide/band_names
    user_guide/ops
    user_guide/spectral_indices

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ arithmetic, computing indices, and visualizing results.
    modules/adapters
    modules/analysis
    modules/datasets
+   modules/io
    modules/ops
    modules/preprocessing
    modules/viz

--- a/docs/source/modules/core.rst
+++ b/docs/source/modules/core.rst
@@ -5,7 +5,7 @@ Core Module
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: EEOError, ValidationError, CRSMismatchError, AlignmentError, BackendError
+    :exclude-members: EEOError, ValidationError, CRSMismatchError, AlignmentError, BackendError, MissingDependencyError
 
 Utilities
 ---------
@@ -37,7 +37,9 @@ propagate:
 For backward compatibility, each subclass also derives from the built-in
 exception it historically replaced: :class:`~eeo.ValidationError`,
 :class:`~eeo.CRSMismatchError`, and :class:`~eeo.AlignmentError` are
-``ValueError``\ s, and :class:`~eeo.BackendError` is a ``RuntimeError``. Two
+``ValueError``\ s, :class:`~eeo.BackendError` is a ``RuntimeError``, and
+:class:`~eeo.MissingDependencyError` — raised when a feature's optional extra
+is not installed — is an ``ImportError``. Two
 failure modes intentionally keep their standard-library exceptions rather than
 joining the hierarchy: a missing raster file raises ``FileNotFoundError``, and
 an out-of-range band index raises ``IndexError``.

--- a/docs/source/modules/io.rst
+++ b/docs/source/modules/io.rst
@@ -7,7 +7,9 @@ Data access beyond the local filesystem. STAC search needs the optional
 install command.
 
 :func:`eeo.stac_search` finds scenes and :meth:`eeo.io.STACItem.load` reads
-them. A load returns only the area of interest by default — the assets are read
+them. Searches go to Microsoft Planetary Computer
+(:data:`eeo.io.PLANETARY_COMPUTER_STAC_URL`) unless a different ``catalog=`` is
+given. A load returns only the area of interest by default — the assets are read
 remotely over HTTP range requests, so a small AOI over a Sentinel-2 tile
 transfers a fraction of the band instead of downloading the scene:
 

--- a/docs/source/modules/io.rst
+++ b/docs/source/modules/io.rst
@@ -1,0 +1,20 @@
+IO Module
+=========
+
+Data access beyond the local filesystem. STAC search needs the optional
+``stac`` extra (``pip install "easy-eo[stac]"``); without it, calling
+:func:`eeo.stac_search` raises :class:`~eeo.MissingDependencyError` with the
+install command.
+
+STAC search
+-----------
+
+.. autofunction:: eeo.stac_search
+
+.. autoclass:: eeo.io.STACSearchResult
+    :members:
+
+.. autoclass:: eeo.io.STACItem
+    :members:
+
+.. autodata:: eeo.io.PLANETARY_COMPUTER_STAC_URL

--- a/docs/source/modules/io.rst
+++ b/docs/source/modules/io.rst
@@ -6,6 +6,25 @@ Data access beyond the local filesystem. STAC search needs the optional
 :func:`eeo.stac_search` raises :class:`~eeo.MissingDependencyError` with the
 install command.
 
+:func:`eeo.stac_search` finds scenes and :meth:`eeo.io.STACItem.load` reads
+them. A load returns only the area of interest by default — the assets are read
+remotely over HTTP range requests, so a small AOI over a Sentinel-2 tile
+transfers a fraction of the band instead of downloading the scene:
+
+.. code-block:: python
+
+    import eeo
+
+    results = eeo.stac_search(
+        "sentinel-2-l2a",
+        bbox=(11.0, 46.5, 11.2, 46.7),
+        datetime="2023-06-01/2023-08-31",
+        cloud_cover=20,
+        limit=1,
+    )
+    scene = results[0].load(["B04", "B08"])   # cropped to the search bbox
+    ndvi = scene.ndvi(red="B04", nir="B08")
+
 STAC search
 -----------
 

--- a/docs/source/user_guide/loading_satellite_data.rst
+++ b/docs/source/user_guide/loading_satellite_data.rst
@@ -80,6 +80,11 @@ Searching a catalog
    Your area of interest, ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
    degrees** — the STAC API expects degrees regardless of the imagery's own
    projection. It is also remembered as the default crop for loading (below).
+   Mutually exclusive with ``intersects``.
+
+``intersects``
+   The same idea, but as a shape rather than a rectangle — see
+   :ref:`searching-by-shape` below. Mutually exclusive with ``bbox``.
 
 ``datetime``
    A single instant, an interval string such as ``"2023-06-01/2023-08-31"``, or
@@ -328,6 +333,75 @@ follows:
 
 -----
 
+.. _searching-by-shape:
+
+Searching by shape
+------------------
+
+Real areas of interest are rarely rectangles. A catchment, a coastline, a
+national boundary, a set of field parcels — the bounding box around any of
+these covers far more ground than the shape itself, and every extra tile it
+pulls in is a scene you search, sort, and possibly load for nothing.
+
+Pass the shape instead. ``intersects`` accepts a GeoDataFrame, a GeoSeries, a
+shapely geometry, a GeoJSON mapping, or a path to any vector file GeoPandas can
+read. This example runs as-is — it uses the boundary from the bundled
+:doc:`sample dataset <sample_data>`:
+
+.. code-block:: python
+
+   import geopandas as gpd
+   import eeo
+   from eeo.datasets import load_sample_dataset
+
+   sd = load_sample_dataset()
+   catchment = gpd.read_file(sd.boundary)
+
+   results = eeo.stac_search("sentinel-2-l2a", intersects=catchment, cloud_cover=20)
+   shaped = results[0].load("B04", mask=True)
+
+Scenes whose footprint touches the shape are returned. A path works directly
+too, so the file you clip with is the file you search with — and since the
+sample handles are path-like, they can be passed straight in:
+
+.. code-block:: python
+
+   results = eeo.stac_search("sentinel-2-l2a", intersects="catchment.geojson")
+   results = eeo.stac_search("sentinel-2-l2a", intersects=sd.boundary)
+
+**Your CRS is handled for you.** STAC expects lon/lat degrees, and a
+GeoDataFrame in a projected CRS submitted as-is matches *nothing* — with no
+error, because the coordinates are perfectly valid numbers in the wrong units.
+Easy-EO reprojects anything that carries a CRS, and rejects a geometry whose
+coordinates cannot be degrees rather than letting you wonder why your search
+came back empty. A geometry with no CRS attached (a bare shapely object, for
+example) is taken to be lon/lat already.
+
+``bbox`` and ``intersects`` are mutually exclusive — the STAC spec treats them
+that way and servers disagree about which wins — so passing both raises
+``ValidationError``. To search the overlap of two areas, intersect them
+yourself and pass the result.
+
+Cropping to a shape
+^^^^^^^^^^^^^^^^^^^
+
+Loading crops to the geometry's **bounding window**, which is what keeps the
+transfer small. To follow the outline itself, and set the pixels outside it to
+nodata, ask for a mask:
+
+.. code-block:: python
+
+   rectangle = results[0].load("B04")              # cropped to the bounds
+   shaped = results[0].load("B04", mask=True)      # ...and outside pixels blanked
+
+The two steps are separate on purpose: cropping decides what crosses the
+network, masking is an analytical choice about what counts as data. ``mask=True``
+needs a search made with ``intersects`` — with only a bounding box there is no
+outline to follow. An already-loaded raster can be masked at any time with
+:meth:`~eeo.core.EEORasterDataset.clip_raster_with_vector`.
+
+-----
+
 Using a different catalog
 -------------------------
 
@@ -355,6 +429,22 @@ alone. Pass ``sign=False`` to skip signing, or ``sign=True`` to force it.
 
 Things worth knowing
 --------------------
+
+**A search returns every scene that *touches* your area, not every scene that
+covers it.** Tiles that graze the edge of your AOI match too, so
+``results[0]`` can be a scene overlapping it by a sliver — load that one and
+you get a handful of pixels rather than your area. When you need full
+coverage, say so:
+
+.. code-block:: python
+
+   import shapely
+
+   area = shapely.geometry.box(*results.bbox)     # or shape(results.intersects)
+   covering = [
+       item for item in results
+       if shapely.geometry.shape(item.item.geometry).contains(area)
+   ]
 
 **Signed URLs expire.** Planetary Computer signatures are short-lived, so
 search and load in the same session rather than storing search results for

--- a/docs/source/user_guide/loading_satellite_data.rst
+++ b/docs/source/user_guide/loading_satellite_data.rst
@@ -1,0 +1,381 @@
+Loading Satellite Data
+======================
+
+Most Earth-observation work starts the same way: find the scenes covering your
+area over some period, then get the bands you need out of them. Easy-EO does
+both against any **STAC** catalog — Microsoft Planetary Computer by default —
+without downloading a single full scene.
+
+:func:`~eeo.stac_search` finds the scenes. :meth:`~eeo.io.STACItem.load` reads
+them, **cropped to your area of interest**, straight into an
+:class:`~eeo.core.EEORasterDataset` you can chain operations onto.
+
+This needs the optional ``stac`` extra:
+
+.. code-block:: bash
+
+   pip install "easy-eo[stac]"
+
+.. note::
+
+   **Which service is contacted.** :func:`~eeo.stac_search` defaults to
+   ``catalog="https://planetarycomputer.microsoft.com/api/stac/v1"`` — Microsoft
+   Planetary Computer. That is the only catalog Easy-EO ever queries unless you
+   pass a different ``catalog=`` yourself; the value is also available as
+   :data:`eeo.io.PLANETARY_COMPUTER_STAC_URL`.
+
+   Loading pixels then reads from wherever the catalog says its assets live
+   (for Planetary Computer, its Azure blob storage). Easy-EO does not choose
+   that host — it is whatever URL the scene's metadata published.
+
+.. seealso::
+
+   :doc:`spectral_indices` for the indices computed here, :doc:`band_names` for
+   addressing bands by name, and :doc:`sample_data` for working offline from a
+   bundled sample instead.
+
+-----
+
+Quickstart: NDVI from a satellite archive
+-----------------------------------------
+
+Search, load, compute, plot — nothing downloaded but the pixels you asked for:
+
+.. code-block:: python
+
+   import eeo
+
+   results = eeo.stac_search(
+       "sentinel-2-l2a",
+       bbox=(11.0, 46.5, 11.2, 46.7),
+       datetime="2023-06-01/2023-08-31",
+       cloud_cover=20,
+       limit=1,
+   )
+   scene = results[0].load(["B04", "B08"])
+   ndvi = scene.ndvi(red="B04", nir="B08")
+   ndvi.plot_raster()
+
+That is the whole workflow. The scene it reads is a Sentinel-2 tile of roughly
+11,000 × 11,000 pixels per band — around 240 MB — but only the window covering
+your bounding box is fetched, so the load moves a few megabytes and finishes in
+seconds.
+
+-----
+
+Searching a catalog
+-------------------
+
+.. code-block:: python
+
+   results = eeo.stac_search(
+       "sentinel-2-l2a",
+       bbox=(11.0, 46.5, 11.2, 46.7),
+       datetime="2023-06-01/2023-08-31",
+       cloud_cover=20,
+       limit=10,
+   )
+
+``bbox``
+   Your area of interest, ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+   degrees** — the STAC API expects degrees regardless of the imagery's own
+   projection. It is also remembered as the default crop for loading (below).
+
+``datetime``
+   A single instant, an interval string such as ``"2023-06-01/2023-08-31"``, or
+   a ``(start, end)`` pair. Use ``".."`` to leave an end open
+   (``"2023-06-01/.."``). A bare date covers its whole day, so the closing date
+   is inclusive.
+
+``cloud_cover``
+   Maximum scene cloud cover in percent.
+
+``limit``
+   Maximum number of scenes to return. Without it you get every match, which
+   can be thousands.
+
+``catalog``
+   Which STAC API to search. **Defaults to Microsoft Planetary Computer**
+   (``https://planetarycomputer.microsoft.com/api/stac/v1``); pass another
+   endpoint to search somewhere else.
+
+``sign``
+   Whether to sign asset URLs. Left alone, it signs when — and only when —
+   ``catalog`` is a Planetary Computer endpoint, which is what makes its assets
+   readable; other catalogs are untouched.
+
+The result is an ordered, timestamped sequence — oldest first, undated scenes
+last — so it indexes, slices, and iterates like a list:
+
+.. code-block:: python
+
+   len(results)          # how many scenes matched
+   results[0]            # the oldest
+   results[-1]           # the most recent
+   results[:3]           # another result holding the first three
+   results.timestamps    # acquisition times, in order
+
+Each entry describes one scene:
+
+.. code-block:: python
+
+   item = results[0]
+
+   item.id            # the catalog's scene id
+   item.timestamp     # acquisition time (timezone-aware)
+   item.cloud_cover   # scene cloud cover, in percent
+   item.asset_names   # the bands and products this scene offers
+   item.properties    # everything else the catalog published
+   item.item          # the underlying pystac Item, if you need the full API
+
+Searching is metadata-only: it makes HTTP requests to the catalog but reads no
+pixels, so scanning a long time series costs almost nothing.
+
+-----
+
+Choosing bands
+--------------
+
+``item.asset_names`` always lists exactly what a scene offers, and it is the
+authority — asset keys are a property of the catalog, not of the satellite.
+
+Sentinel-2 (``sentinel-2-l2a``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The two catalogs disagree here: Planetary Computer keys assets by the
+Sentinel-2 band number, Earth Search by common name.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 25 25
+
+   * - Band
+     - Sentinel-2
+     - Planetary Computer
+     - Earth Search
+   * - Blue
+     - B02
+     - ``B02``
+     - ``blue``
+   * - Green
+     - B03
+     - ``B03``
+     - ``green``
+   * - Red
+     - B04
+     - ``B04``
+     - ``red``
+   * - NIR
+     - B08
+     - ``B08``
+     - ``nir``
+   * - NIR (narrow)
+     - B8A
+     - ``B8A``
+     - ``nir08``
+   * - SWIR 1.6 µm
+     - B11
+     - ``B11``
+     - ``swir16``
+   * - SWIR 2.2 µm
+     - B12
+     - ``B12``
+     - ``swir22``
+   * - Scene classification
+     - SCL
+     - ``SCL``
+     - ``scl``
+
+Landsat 8/9 (``landsat-c2-l2``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both catalogs serve Landsat Collection 2 Level-2 under the same collection id
+and — unlike Sentinel-2 — with the same common-name asset keys, so one set of
+names works on either (though see the note on credentials below):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 26 40
+
+   * - Band
+     - Landsat 8/9 (OLI/TIRS)
+     - Asset key (both catalogs)
+   * - Coastal / aerosol
+     - B1
+     - ``coastal``
+   * - Blue
+     - B2
+     - ``blue``
+   * - Green
+     - B3
+     - ``green``
+   * - Red
+     - B4
+     - ``red``
+   * - NIR
+     - B5
+     - ``nir08``
+   * - SWIR 1.6 µm
+     - B6
+     - ``swir16``
+   * - SWIR 2.2 µm
+     - B7
+     - ``swir22``
+   * - Thermal (surface temperature)
+     - B10
+     - ``lwir11`` (Planetary Computer only)
+   * - QA / cloud mask
+     - QA_PIXEL
+     - ``qa_pixel``
+
+Mind the band numbers when translating a formula between missions — Landsat's
+NIR is B5 where Sentinel-2's is B8 — but the asset keys spare you that
+arithmetic entirely. All Landsat Level-2 optical bands share a 30 m grid, so
+stacking them needs no resampling:
+
+.. code-block:: python
+
+   results = eeo.stac_search(
+       "landsat-c2-l2",
+       bbox=(11.0, 46.5, 11.2, 46.7),
+       datetime="2023-06-01/2023-08-31",
+       cloud_cover=20,
+       limit=10,
+   )
+   scene = results[0].load(["red", "nir08"])
+   ndvi = scene.ndvi(red="red", nir="nir08")
+
+**The collection is not only Landsat 8 and 9.** ``landsat-c2-l2`` spans the
+whole Landsat archive, so a search over a recent summer happily returns
+Landsat 7 scenes alongside 8 and 9. The asset keys stay the same — which is
+precisely their value, since Landsat 7's red band is B3 where Landsat 8/9's is
+B4 — but the sensors are not interchangeable, and Landsat 7 imagery after 2003
+carries scan-line-corrector gaps. Filter by platform when the mission matters:
+
+.. code-block:: python
+
+   modern = [
+       item
+       for item in results
+       if item.properties.get("platform") in ("landsat-8", "landsat-9")
+   ]
+   scene = modern[0].load(["red", "nir08"])
+
+**Landsat on Earth Search needs AWS credentials.** Its assets are ``s3://``
+hrefs into the requester-pays ``usgs-landsat`` bucket, so a load fails with a
+GDAL credentials error unless your environment is configured for it. Planetary
+Computer serves the same scenes over HTTPS and signs them automatically, which
+makes it the path of least resistance for Landsat.
+
+.. seealso::
+
+   :doc:`spectral_indices` lists the band each index expects, per mission.
+
+-----
+
+Loading, cropped to your area
+-----------------------------
+
+A load returns only the area of interest. The assets are read remotely as HTTP
+range requests against the cloud-optimized GeoTIFFs, so the pixels outside your
+box are never transferred:
+
+.. code-block:: python
+
+   scene = results[0].load(["B04", "B08"])
+
+By default it crops to the ``bbox`` you searched with — the item remembers it as
+``item.search_bbox``, so you never repeat yourself. Override or opt out per
+load:
+
+.. code-block:: python
+
+   # A different (usually smaller) area
+   field = results[0].load("B04", bbox=(11.05, 46.55, 11.08, 46.58))
+
+   # The entire scene - a full Sentinel-2 band, so expect hundreds of MB
+   whole_tile = results[0].load("B04", crop=False)
+
+Ask for several assets and they come back as one multi-band dataset, each band
+named after the asset it came from, ready to address by name:
+
+.. code-block:: python
+
+   scene = results[0].load(["B04", "B08", "B11"])
+
+   scene.band_names            # ['B04', 'B08', 'B11']
+   scene.timestamp             # the scene's acquisition time
+   scene.attrs["stac_item"]    # which catalog scene it came from
+
+Sentinel-2 bands do not share a resolution — B11 is 20 m where B04 and B08 are
+10 m — so assets that do not match the **first** asset's grid are resampled onto
+it (nearest neighbour by default, ``resampling="bilinear"`` and friends if you
+prefer). List your finest band first to keep full resolution, or a coarser one
+first to downsample everything cheaply.
+
+The loaded dataset is an ordinary Easy-EO raster, so the rest of the library
+follows:
+
+.. code-block:: python
+
+   result = (
+       results[0]
+       .load(["B04", "B08"])
+       .ndvi(red="B04", nir="B08")
+       .normalize_min_max()
+   )
+   result.save_raster("ndvi.tif")
+
+-----
+
+Using a different catalog
+-------------------------
+
+Searches go to Microsoft Planetary Computer unless you say otherwise. To use
+another archive, name it — any STAC API works. Earth Search (AWS Open Data)
+needs no account:
+
+.. code-block:: python
+
+   results = eeo.stac_search(
+       "sentinel-2-l2a",
+       bbox=(11.0, 46.5, 11.2, 46.7),
+       datetime="2023-06-01/2023-08-31",
+       cloud_cover=20,
+       limit=1,
+       catalog="https://earth-search.aws.element84.com/v1",
+   )
+   scene = results[0].load(["red", "nir"])
+   ndvi = scene.ndvi(red="red", nir="nir")
+
+Planetary Computer asset URLs are signed automatically; other catalogs are left
+alone. Pass ``sign=False`` to skip signing, or ``sign=True`` to force it.
+
+-----
+
+Things worth knowing
+--------------------
+
+**Signed URLs expire.** Planetary Computer signatures are short-lived, so
+search and load in the same session rather than storing search results for
+later.
+
+**The cloud filter is the catalog's, not ours.** Some catalogs match against
+their own indexed value, so a returned scene can sit slightly above your
+threshold. When an exact cut-off matters, filter the result yourself:
+
+.. code-block:: python
+
+   clear = [item for item in results if item.cloud_cover <= 20]
+
+**Catalogs return reprocessed duplicates.** One acquisition can appear as
+several scenes with the same timestamp and different processing baselines.
+They are kept as separate items; pick by ``item.id`` if it matters.
+
+**Catalog outages surface as errors.** A search hits somebody else's service.
+If it is down you will see the client's transport error, not an Easy-EO one —
+retry later, or point ``catalog=`` elsewhere.
+
+**Memory.** Only the window you asked for is held in memory, which is exactly
+why cropping is the default. ``crop=False`` on a Sentinel-2 band means a
+full-resolution band in RAM.

--- a/docs/source/user_guide/sample_data.rst
+++ b/docs/source/user_guide/sample_data.rst
@@ -11,8 +11,10 @@ corrupt data. Downloading uses only the Python standard library, so it adds
 
 .. seealso::
 
-   :doc:`band_names` for how the loaded bands are addressed by name, and
-   :doc:`spectral_indices` for computing NDVI and friends on the sample.
+   :doc:`band_names` for how the loaded bands are addressed by name,
+   :doc:`spectral_indices` for computing NDVI and friends on the sample, and
+   :doc:`loading_satellite_data` for pulling your own scenes from a satellite
+   archive instead.
 
 -----
 

--- a/docs/source/user_guide/spectral_indices.rst
+++ b/docs/source/user_guide/spectral_indices.rst
@@ -10,8 +10,10 @@ the same algebra primitives you can use directly.
 .. seealso::
 
    :doc:`nodata_and_dtype` for how every index treats nodata pixels and why
-   the output is always float32, and :doc:`band_names` for addressing bands by
-   name and for why an index result is never auto-named after its operation.
+   the output is always float32, :doc:`band_names` for addressing bands by
+   name and for why an index result is never auto-named after its operation,
+   and :doc:`loading_satellite_data` for computing these straight off a
+   satellite archive.
 
 -----
 

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -12,6 +12,7 @@ from .core import (
     BackendError,
     CRSMismatchError,
     EEOError,
+    MissingDependencyError,
     ValidationError,
     load_array,
     load_raster,
@@ -31,6 +32,7 @@ __all__ = [
     "CRSMismatchError",
     "AlignmentError",
     "BackendError",
+    "MissingDependencyError",
 ]
 
 __version__ = "0.1.0b1"

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -18,6 +18,7 @@ from .core import (
     load_raster,
 )
 from .core.adapters import *
+from .io import stac_search
 from .ops import *
 from .preprocessing import *
 from .viz import *
@@ -26,6 +27,7 @@ __all__ = [
     "datasets",
     "load_raster",
     "load_array",
+    "stac_search",
     "show_versions",
     "EEOError",
     "ValidationError",

--- a/eeo/_optional.py
+++ b/eeo/_optional.py
@@ -1,0 +1,65 @@
+"""Import helper for the packages behind Easy-EO's optional extras.
+
+Heavier capabilities — STAC data access, xarray interop, the lazy backend —
+live behind optional extras so that a plain ``pip install easy-eo`` stays
+small. The modules implementing them import their third-party packages through
+:func:`import_optional`, which turns a missing package into a
+:class:`~eeo.MissingDependencyError` naming the exact install command instead
+of a bare ``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+from .core.exceptions import MissingDependencyError
+
+
+def import_optional(module: str, *, extra: str, purpose: str) -> ModuleType:
+    """Import a module provided by an optional extra.
+
+    Parameters
+    ----------
+    module : str
+        Importable module name (e.g. ``"pystac_client"``), not the
+        distribution name.
+    extra : str
+        Name of the Easy-EO extra that provides the module (e.g. ``"stac"``),
+        used to build the ``pip install`` hint.
+    purpose : str
+        Short description of the feature needing the module (e.g. ``"STAC
+        search"``), used to open the error message.
+
+    Returns
+    -------
+    ModuleType
+        The imported module.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the module is not installed. The message names the feature, the
+        missing package, and the ``pip install 'easy-eo[<extra>]'`` command
+        that provides it.
+
+    Examples
+    --------
+    >>> from eeo._optional import import_optional
+    >>> np = import_optional("numpy", extra="stac", purpose="STAC search")
+    >>> np.__name__
+    'numpy'
+    """
+    try:
+        return importlib.import_module(module)
+    except ModuleNotFoundError as err:
+        # A ModuleNotFoundError raised *inside* the optional package (one of
+        # its own dependencies missing) is a different problem; report it as-is
+        # rather than blaming the package the user did install.
+        if err.name is not None and err.name.split(".")[0] != module.split(".")[0]:
+            raise
+        raise MissingDependencyError(
+            f"{purpose} requires the optional '{module}' package, which is not "
+            f"installed. Install the '{extra}' extra with: "
+            f"pip install 'easy-eo[{extra}]'"
+        ) from err

--- a/eeo/core/__init__.py
+++ b/eeo/core/__init__.py
@@ -6,6 +6,7 @@ from .exceptions import (
     BackendError,
     CRSMismatchError,
     EEOError,
+    MissingDependencyError,
     ValidationError,
 )
 from .loader import load_array, load_raster
@@ -22,4 +23,5 @@ __all__ = [
     "CRSMismatchError",
     "AlignmentError",
     "BackendError",
+    "MissingDependencyError",
 ]

--- a/eeo/core/exceptions.py
+++ b/eeo/core/exceptions.py
@@ -4,8 +4,9 @@ Every error Easy-EO raises for its own failure modes derives from
 :class:`EEOError`, so callers can catch any library-specific problem with a
 single ``except EEOError`` while letting unrelated exceptions propagate. Each
 subclass additionally derives from the built-in exception it historically
-replaced (``ValueError`` or ``RuntimeError``), so existing
-``except ValueError`` / ``except RuntimeError`` handlers keep working.
+replaced or stands in for (``ValueError``, ``RuntimeError``, or
+``ImportError``), so existing ``except ValueError`` / ``except RuntimeError`` /
+``except ImportError`` handlers keep working.
 
 Two failure modes intentionally keep their standard-library exceptions rather
 than joining this hierarchy, because remapping them would break universal
@@ -40,6 +41,15 @@ class AlignmentError(EEOError, ValueError):
     Signals a mismatch in shape and/or affine transform between rasters that an
     operation requires to share a grid. Subclasses :class:`ValueError` for
     backward compatibility.
+    """
+
+
+class MissingDependencyError(EEOError, ImportError):
+    """Raised when a feature's optional dependency is not installed.
+
+    Carries the exact ``pip install`` command for the extra that provides the
+    missing package. Subclasses :class:`ImportError` so ``except ImportError``
+    handlers around an optional feature keep working.
     """
 
 

--- a/eeo/io/__init__.py
+++ b/eeo/io/__init__.py
@@ -1,0 +1,16 @@
+"""Data access beyond the local filesystem.
+
+Currently holds STAC catalog access (:mod:`eeo.io.stac`), which needs the
+optional ``stac`` extra (``pip install "easy-eo[stac]"``). Importing this
+package pulls in no optional dependency; the extra is only required when a
+search actually runs.
+"""
+
+from .stac import PLANETARY_COMPUTER_STAC_URL, STACItem, STACSearchResult, stac_search
+
+__all__ = [
+    "stac_search",
+    "STACItem",
+    "STACSearchResult",
+    "PLANETARY_COMPUTER_STAC_URL",
+]

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -48,7 +48,8 @@ from eeo.core.exceptions import ValidationError
 from eeo.core.loader import load_array
 from eeo.core.types import ResamplingMethod
 
-#: STAC API endpoint used when no ``catalog`` is given.
+#: Microsoft Planetary Computer's STAC API — the default ``catalog`` for
+#: :func:`stac_search`, and the only catalog contacted unless another is given.
 PLANETARY_COMPUTER_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
 
 # Catalogs whose asset URLs must be signed before they can be read. Signing is
@@ -763,7 +764,10 @@ def stac_search(
         Maximum number of items to return. None returns every match, which
         may be many pages of results.
     catalog : str, default :data:`PLANETARY_COMPUTER_STAC_URL`
-        STAC API endpoint to search. Any STAC API works, e.g. Earth Search.
+        STAC API endpoint to search. Defaults to Microsoft Planetary Computer
+        (``https://planetarycomputer.microsoft.com/api/stac/v1``), which is the
+        only catalog contacted unless another endpoint is given here. Any STAC
+        API works, e.g. Earth Search.
     sign : bool or None, default None
         Whether to sign asset URLs with ``planetary-computer``. None signs
         automatically when ``catalog`` is a Planetary Computer endpoint and

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -30,11 +30,23 @@ Examples
 from __future__ import annotations
 
 import datetime as dt
+import math
 from collections.abc import Mapping, Sequence
-from typing import Any, overload
+from typing import Any, NamedTuple, overload
+
+import numpy as np
+import rasterio as rio
+from rasterio import windows as rio_windows
+from rasterio.transform import array_bounds
+from rasterio.vrt import WarpedVRT
+from rasterio.warp import transform_bounds
 
 from eeo._optional import import_optional
+from eeo.common import normalize_resampling_method
+from eeo.core.core import EEORasterDataset
 from eeo.core.exceptions import ValidationError
+from eeo.core.loader import load_array
+from eeo.core.types import ResamplingMethod
 
 #: STAC API endpoint used when no ``catalog`` is given.
 PLANETARY_COMPUTER_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
@@ -84,6 +96,131 @@ def _sort_key(item: STACItem) -> tuple[bool, dt.datetime]:
     return (False, timestamp)
 
 
+# GDAL settings for reading a remote COG efficiently. Object stores answer a
+# directory probe by listing the whole container, which costs far more than the
+# read itself; HTTP/2 multiplexing and the VSI cache keep the range requests for
+# the tiles we actually want.
+_GDAL_HTTP_ENV = {
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "GDAL_HTTP_MULTIPLEX": "YES",
+    "GDAL_HTTP_VERSION": "2",
+    "VSI_CACHE": "TRUE",
+}
+
+
+class _Grid(NamedTuple):
+    """The output grid every asset of one load is read onto."""
+
+    crs: Any
+    transform: Any
+    width: int
+    height: int
+
+
+def _crop_window(src: Any, bbox: Sequence[float]) -> Any:
+    """Return the pixel window of ``src`` covering a WGS 84 lon/lat bbox."""
+    if src.crs is None:
+        raise ValidationError(
+            "cropping needs a georeferenced asset; this asset declares no CRS. "
+            "Pass crop=False to read it whole."
+        )
+
+    bounds = transform_bounds("EPSG:4326", src.crs, *bbox, densify_pts=21)
+    window = rio_windows.from_bounds(*bounds, transform=src.transform)
+
+    # Round outward to whole pixels so the AOI is fully covered.
+    col_off = math.floor(window.col_off)
+    row_off = math.floor(window.row_off)
+    requested = rio_windows.Window(
+        col_off,
+        row_off,
+        max(math.ceil(window.col_off + window.width) - col_off, 1),
+        max(math.ceil(window.row_off + window.height) - row_off, 1),
+    )
+
+    scene = rio_windows.Window(0, 0, src.width, src.height)
+    if not rio_windows.intersect(requested, scene):
+        raise ValidationError(
+            f"the requested area does not overlap this scene; got bbox {tuple(bbox)!r} "
+            f"in WGS 84 lon/lat, while the scene covers "
+            f"{transform_bounds(src.crs, 'EPSG:4326', *src.bounds, densify_pts=21)!r}"
+        )
+    return rio_windows.intersection(requested, scene)
+
+
+def _aligned_window(src: Any, grid: _Grid) -> Any | None:
+    """Return an exact pixel window onto ``grid``, or None if a warp is needed.
+
+    An asset sharing the target grid's CRS and resolution can be read directly,
+    which is both cheaper and exact; anything else goes through a warp.
+    """
+    if src.crs is None or src.crs != grid.crs:
+        return None
+    bounds = array_bounds(grid.height, grid.width, grid.transform)
+    window = rio_windows.from_bounds(*bounds, transform=src.transform)
+
+    tol = 1e-6
+    if abs(window.width - grid.width) > tol or abs(window.height - grid.height) > tol:
+        return None
+    if abs(window.col_off - round(window.col_off)) > tol:
+        return None
+    if abs(window.row_off - round(window.row_off)) > tol:
+        return None
+
+    col_off, row_off = round(window.col_off), round(window.row_off)
+    # A window running off the edge would come back short and break the grid;
+    # let the warp path fill those pixels with nodata instead.
+    if col_off < 0 or row_off < 0:
+        return None
+    if col_off + grid.width > src.width or row_off + grid.height > src.height:
+        return None
+    return rio_windows.Window(col_off, row_off, grid.width, grid.height)
+
+
+def _asset_band_names(src: Any, asset: str) -> list[str | None]:
+    """Name a single-band asset after itself; number the bands of a stack."""
+    if src.count == 1:
+        return [asset]
+    descriptions = list(src.descriptions or ())
+    names: list[str | None] = []
+    for index in range(src.count):
+        description = descriptions[index] if index < len(descriptions) else None
+        names.append(description or f"{asset}_{index + 1}")
+    return names
+
+
+def _read_first_asset(href: str, asset: str, bbox: Sequence[float] | None) -> tuple:
+    """Read the leading asset, which defines the grid the rest are read onto."""
+    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
+        window = None if bbox is None else _crop_window(src, bbox)
+        array = src.read(window=window)
+        transform = src.transform if window is None else src.window_transform(window)
+        grid = _Grid(src.crs, transform, array.shape[-1], array.shape[-2])
+        return array, grid, src.nodata, _asset_band_names(src, asset)
+
+
+def _read_onto_grid(href: str, asset: str, grid: _Grid, resampling: Any) -> tuple:
+    """Read a further asset onto ``grid``, warping only when it does not fit."""
+    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
+        window = _aligned_window(src, grid)
+        if window is not None:
+            return src.read(window=window), _asset_band_names(src, asset)
+
+        # Different CRS, resolution, or sub-pixel offset: let GDAL resample
+        # straight onto the target grid rather than reading and fixing up after.
+        with WarpedVRT(
+            src,
+            crs=grid.crs,
+            transform=grid.transform,
+            width=grid.width,
+            height=grid.height,
+            resampling=resampling,
+            src_nodata=src.nodata,
+            nodata=src.nodata,
+        ) as vrt:
+            return vrt.read(), _asset_band_names(src, asset)
+
+
 class STACItem:
     """One scene from a STAC search, with its acquisition time.
 
@@ -95,11 +232,15 @@ class STACItem:
     ----------
     item : pystac.Item
         The item returned by the STAC client.
+    search_bbox : sequence of float or None, default None
+        Area of interest of the search that produced the item, in WGS 84
+        lon/lat. :meth:`load` crops to it by default.
     """
 
-    def __init__(self, item: Any) -> None:
+    def __init__(self, item: Any, *, search_bbox: Sequence[float] | None = None) -> None:
         self._item = item
         self._timestamp = _item_timestamp(item)
+        self._search_bbox = None if search_bbox is None else tuple(float(v) for v in search_bbox)
 
     @property
     def item(self) -> Any:
@@ -208,6 +349,155 @@ class STACItem:
         """
         value = self.properties.get("eo:cloud_cover")
         return None if value is None else float(value)
+
+    @property
+    def search_bbox(self) -> tuple[float, ...] | None:
+        """Return the area of interest :meth:`load` crops to by default.
+
+        Returns
+        -------
+        tuple of float or None
+            ``(minx, miny, maxx, maxy)`` in WGS 84 lon/lat degrees, taken from
+            the search that produced this item, or None if the search set no
+            spatial filter.
+        """
+        return self._search_bbox
+
+    def load(
+        self,
+        assets: str | Sequence[str],
+        *,
+        bbox: Sequence[float] | None = None,
+        crop: bool = True,
+        resampling: ResamplingMethod | Any = "nearest",
+    ) -> EEORasterDataset:
+        """Read one or more of the item's assets into a raster dataset.
+
+        Reads only the area of interest by default: the asset is opened
+        remotely and only the pixels covering the AOI are fetched, as HTTP
+        range requests against the cloud-optimized GeoTIFF, so a small AOI over
+        a full Sentinel-2 tile transfers a fraction of the band. Several assets
+        are stacked into one multi-band dataset, each band named after the
+        asset it came from.
+
+        Parameters
+        ----------
+        assets : str or sequence of str
+            Asset key (e.g. ``"B04"``, ``"nir08"``) or several keys to stack,
+            in the order they should become bands. See
+            :attr:`STACItem.asset_names` for what this item offers.
+        bbox : sequence of float or None, default None
+            Area to read, as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+            degrees**. None uses :attr:`search_bbox`, the AOI of the search
+            that produced this item; if that is also None, the whole scene is
+            read.
+        crop : bool, default True
+            Whether to crop at all. False reads the entire scene and cannot be
+            combined with ``bbox``.
+        resampling : str or rasterio.enums.Resampling, default "nearest"
+            Method used when an asset has to be resampled onto the first
+            asset's grid — a Sentinel-2 20 m band stacked with a 10 m one, for
+            instance. Nearest neighbour by default so values are never blended.
+
+        Returns
+        -------
+        EEORasterDataset
+            Rasterio-backed dataset holding the requested window, with the
+            asset's CRS, a transform matching the cropped window, the first
+            asset's nodata value, band names taken from the asset keys, the
+            item's acquisition time as ``timestamp``, and the item id,
+            collection, and asset list in ``attrs``. The dtype is the asset's
+            own; stacking assets of different dtypes promotes to their common
+            NumPy dtype.
+
+        Raises
+        ------
+        ValidationError
+            If ``assets`` is empty or names an asset the item does not have,
+            if ``bbox`` is not four ordered lon/lat values, if ``bbox`` is
+            combined with ``crop=False``, or if the AOI does not overlap the
+            scene.
+
+        Notes
+        -----
+        Holds the requested window in memory — the AOI crop is what keeps that
+        small, so reading a full scene with ``crop=False`` costs a full band in
+        RAM. Assets after the first are read onto the first asset's grid, by a
+        plain windowed read when they already share it and a warp otherwise.
+
+        Reading a signed Planetary Computer URL must happen while the signature
+        is still valid; search, then load, rather than storing items for later.
+
+        Examples
+        --------
+        >>> results = eeo.stac_search(
+        ...     "sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7), limit=1
+        ... )  # doctest: +SKIP
+        >>> scene = results[0].load(["B04", "B08"])  # doctest: +SKIP
+        >>> ndvi = scene.ndvi(red="B04", nir="B08")  # doctest: +SKIP
+        """
+        keys = self._resolve_assets(assets)
+
+        if crop is False and bbox is not None:
+            raise ValidationError(
+                "crop=False reads the whole scene and cannot be combined with a bbox; "
+                "pass one or the other"
+            )
+        aoi: Sequence[float] | None = None
+        if crop:
+            aoi = _validate_bbox(bbox) if bbox is not None else self._search_bbox
+
+        resampling_enum = normalize_resampling_method(resampling)
+
+        array, grid, nodata, band_names = _read_first_asset(self._href(keys[0]), keys[0], aoi)
+        arrays = [array]
+        for key in keys[1:]:
+            other, other_names = _read_onto_grid(self._href(key), key, grid, resampling_enum)
+            arrays.append(other)
+            band_names.extend(other_names)
+
+        stacked = arrays[0] if len(arrays) == 1 else np.concatenate(arrays, axis=0)
+
+        dataset = load_array(
+            stacked,
+            transform=grid.transform,
+            crs=grid.crs,
+            nodata=nodata,
+            timestamp=self._timestamp,
+            attrs={
+                "stac_item": self.id,
+                "stac_collection": self.collection,
+                "stac_assets": list(keys),
+            },
+            band_names=band_names,
+        )
+        return dataset.to_rasterio()
+
+    def _resolve_assets(self, assets: str | Sequence[str]) -> list[str]:
+        """Normalize the asset argument to a list of keys this item has."""
+        if isinstance(assets, str):
+            keys = [assets]
+        elif isinstance(assets, Sequence):
+            keys = [str(key) for key in assets]
+        else:
+            raise ValidationError(
+                f"assets must be an asset key or a sequence of keys; got {assets!r}"
+            )
+        if not keys:
+            raise ValidationError("name at least one asset to load; got an empty sequence")
+
+        available = self.asset_names
+        missing = [key for key in keys if key not in available]
+        if missing:
+            raise ValidationError(
+                f"item {self.id!r} has no asset {missing[0]!r}; "
+                f"available assets are {', '.join(available) or 'none'}"
+            )
+        return keys
+
+    def _href(self, asset: str) -> str:
+        """Return the URL or path of one of the item's assets."""
+        return str(self.assets[asset].href)
 
     def __repr__(self) -> str:
         """Return a one-line summary: id, acquisition time, and asset count."""
@@ -538,7 +828,7 @@ def stac_search(
     found = client.search(**params)
 
     return STACSearchResult(
-        [STACItem(item) for item in found.items()],
+        [STACItem(item, search_bbox=params.get("bbox")) for item in found.items()],
         collections=collections,
         catalog=catalog,
         bbox=params.get("bbox"),

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -263,6 +263,22 @@ def _aligned_window(src: Any, grid: _Grid) -> Any | None:
     return rio_windows.Window(col_off, row_off, grid.width, grid.height)
 
 
+def _mask_fill(dataset: EEORasterDataset, nodata: float | None) -> float:
+    """Choose the value masked-out pixels take, and that gets recorded as nodata.
+
+    An asset's own nodata value is used when it declares one. Many STAC assets
+    declare none, and masking must still write *something* outside the
+    geometry — so it falls back to the library's representation for the dtype
+    (NaN for floats, 0 for integers) and records it, rather than filling with a
+    value that reads back as valid data.
+    """
+    if nodata is not None:
+        return float(nodata)
+    if np.issubdtype(np.dtype(dataset.get_metadata()["dtype"]), np.floating):
+        return float("nan")
+    return 0.0
+
+
 def _asset_band_names(src: Any, asset: str) -> list[str | None]:
     """Name a single-band asset after itself; number the bands of a stack."""
     if src.count == 1:
@@ -511,7 +527,10 @@ class STACItem:
             the result follows the geometry's outline rather than its bounding
             rectangle. Requires a search made with ``intersects``. Cropping
             decides what is transferred; masking is a separate analytical
-            choice, which is why it is off by default.
+            choice, which is why it is off by default. Masked pixels take the
+            asset's nodata value, or — for the many assets that declare none —
+            NaN for floating dtypes and 0 for integer ones, recorded as the
+            result's ``nodata`` either way so they are not mistaken for data.
         resampling : str or rasterio.enums.Resampling, default "nearest"
             Method used when an asset has to be resampled onto the first
             asset's grid — a Sentinel-2 20 m band stacked with a 10 m one, for
@@ -618,11 +637,11 @@ class STACItem:
 
         if mask:
             # Reuse the vector clip, which reprojects the geometry onto the
-            # raster's CRS and fills outside pixels with its nodata value.
+            # raster's CRS and fills outside pixels with a nodata value.
             geometry = gpd.GeoDataFrame(
                 geometry=[shapely.geometry.shape(self._search_intersects)], crs="EPSG:4326"
             )
-            dataset = dataset.clip_raster_with_vector(geometry)
+            dataset = dataset.clip_raster_with_vector(geometry, nodata=_mask_fill(dataset, nodata))
         return dataset
 
     def _resolve_assets(self, assets: str | Sequence[str]) -> list[str]:

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -752,7 +752,8 @@ def stac_search(
     datetime : str or datetime.datetime or tuple, default None
         Time filter, passed through to the catalog: a single instant, an
         interval string such as ``"2023-06-01/2023-08-31"`` (``".."`` leaves an
-        end open), or a ``(start, end)`` pair. None searches all times.
+        end open), or a ``(start, end)`` pair. A bare date covers its whole
+        day, so a closing date is inclusive. None searches all times.
     cloud_cover : float or None, default None
         Maximum scene cloud cover in percent (0-100), applied by the catalog
         against each scene's ``eo:cloud_cover``. None applies no cloud filter.

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -31,11 +31,14 @@ from __future__ import annotations
 
 import datetime as dt
 import math
+import os
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple, overload
 
+import geopandas as gpd
 import numpy as np
 import rasterio as rio
+import shapely
 from rasterio import windows as rio_windows
 from rasterio.transform import array_bounds
 from rasterio.vrt import WarpedVRT
@@ -61,7 +64,89 @@ _SIGNED_CATALOG_HOSTS = ("planetarycomputer.microsoft.com",)
 # (start, end) pair. Passed through to pystac-client unchanged.
 DatetimeSpec = str | dt.datetime | tuple[str | dt.datetime | None, str | dt.datetime | None] | list
 
+# Accepted forms for the ``intersects`` argument. Anything with a CRS is
+# reprojected to WGS 84 lon/lat; anything without one is assumed to be in it.
+IntersectsSpec = Any
+
 _EPOCH = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+# STAC's spatial filters are lon/lat degrees, so a geometry whose coordinates
+# fall outside these bounds is projected and would silently match nothing.
+_LON_LIMIT, _LAT_LIMIT = 180.0, 90.0
+
+
+def _geometry_from_mapping(value: Mapping[str, Any]) -> Any:
+    """Build a shapely geometry from a GeoJSON geometry, Feature, or collection."""
+    kind = value.get("type")
+    try:
+        if kind == "FeatureCollection":
+            features = [feature["geometry"] for feature in value.get("features", [])]
+            return shapely.union_all([shapely.geometry.shape(part) for part in features])
+        if kind == "Feature":
+            return shapely.geometry.shape(value["geometry"])
+        return shapely.geometry.shape(value)
+    # shapely.errors.ShapelyError covers an unknown geometry type; the built-ins
+    # cover a mapping missing the keys shapely expects.
+    except (shapely.errors.ShapelyError, AttributeError, KeyError, ValueError, TypeError) as err:
+        raise ValidationError(
+            f"intersects must be a GeoJSON geometry, Feature, or FeatureCollection; "
+            f"got a mapping of type {kind!r}"
+        ) from err
+
+
+def _geometry_from_geopandas(value: gpd.GeoDataFrame | gpd.GeoSeries) -> Any:
+    """Merge a GeoDataFrame/GeoSeries into one geometry in WGS 84 lon/lat."""
+    if value.crs is not None and value.crs.to_epsg() != 4326:
+        # The CRS travels with the data, so the reprojection needs no guesswork.
+        value = value.to_crs(4326)
+    return value.union_all()
+
+
+def _normalize_intersects(value: IntersectsSpec) -> dict[str, Any]:
+    """Normalize an area of interest to a GeoJSON mapping in WGS 84 lon/lat.
+
+    Accepts a GeoDataFrame, GeoSeries, shapely geometry, GeoJSON mapping, or a
+    path to any vector file GeoPandas can read.
+    """
+    if isinstance(value, (str, os.PathLike)):
+        try:
+            value = gpd.read_file(value)
+        except Exception as err:
+            raise ValidationError(
+                f"intersects could not be read as a vector file; got {value!r}"
+            ) from err
+
+    # GeoDataFrame/GeoSeries first: they also expose __geo_interface__, but only
+    # they carry the CRS that makes reprojection possible.
+    if isinstance(value, (gpd.GeoDataFrame, gpd.GeoSeries)):
+        geometry = _geometry_from_geopandas(value)
+    elif isinstance(value, Mapping):
+        geometry = _geometry_from_mapping(value)
+    elif hasattr(value, "__geo_interface__"):
+        geometry = _geometry_from_mapping(value.__geo_interface__)
+    else:
+        raise ValidationError(
+            "intersects must be a GeoDataFrame, GeoSeries, shapely geometry, GeoJSON "
+            f"mapping, or a path to a vector file; got {type(value).__name__}"
+        )
+
+    if geometry is None or geometry.is_empty:
+        raise ValidationError("intersects must contain at least one geometry; got an empty one")
+
+    minx, miny, maxx, maxy = geometry.bounds
+    if minx < -_LON_LIMIT or maxx > _LON_LIMIT:
+        raise ValidationError(
+            "intersects must be in WGS 84 lon/lat degrees; got longitudes "
+            f"{minx:.1f}..{maxx:.1f}. Pass a GeoDataFrame carrying its CRS, or "
+            "reproject the geometry with .to_crs(4326) first."
+        )
+    if miny < -_LAT_LIMIT or maxy > _LAT_LIMIT:
+        raise ValidationError(
+            "intersects must be in WGS 84 lon/lat degrees; got latitudes "
+            f"{miny:.1f}..{maxy:.1f}. Pass a GeoDataFrame carrying its CRS, or "
+            "reproject the geometry with .to_crs(4326) first."
+        )
+    return dict(shapely.geometry.mapping(geometry))
 
 
 def _parse_timestamp(value: Any) -> dt.datetime | None:
@@ -236,12 +321,23 @@ class STACItem:
     search_bbox : sequence of float or None, default None
         Area of interest of the search that produced the item, in WGS 84
         lon/lat. :meth:`load` crops to it by default.
+    search_intersects : mapping or None, default None
+        Area of interest as a GeoJSON geometry in WGS 84 lon/lat, when the
+        search used ``intersects``. :meth:`load` crops to its bounds by
+        default, and can mask to its outline.
     """
 
-    def __init__(self, item: Any, *, search_bbox: Sequence[float] | None = None) -> None:
+    def __init__(
+        self,
+        item: Any,
+        *,
+        search_bbox: Sequence[float] | None = None,
+        search_intersects: Mapping[str, Any] | None = None,
+    ) -> None:
         self._item = item
         self._timestamp = _item_timestamp(item)
         self._search_bbox = None if search_bbox is None else tuple(float(v) for v in search_bbox)
+        self._search_intersects = None if search_intersects is None else dict(search_intersects)
 
     @property
     def item(self) -> Any:
@@ -360,9 +456,22 @@ class STACItem:
         tuple of float or None
             ``(minx, miny, maxx, maxy)`` in WGS 84 lon/lat degrees, taken from
             the search that produced this item, or None if the search set no
-            spatial filter.
+            bounding box.
         """
         return self._search_bbox
+
+    @property
+    def search_intersects(self) -> dict[str, Any] | None:
+        """Return the search geometry :meth:`load` crops to by default.
+
+        Returns
+        -------
+        dict or None
+            GeoJSON geometry mapping in WGS 84 lon/lat, taken from the search
+            that produced this item, or None if the search used a bounding box
+            or no spatial filter at all.
+        """
+        return None if self._search_intersects is None else dict(self._search_intersects)
 
     def load(
         self,
@@ -370,6 +479,7 @@ class STACItem:
         *,
         bbox: Sequence[float] | None = None,
         crop: bool = True,
+        mask: bool = False,
         resampling: ResamplingMethod | Any = "nearest",
     ) -> EEORasterDataset:
         """Read one or more of the item's assets into a raster dataset.
@@ -389,12 +499,19 @@ class STACItem:
             :attr:`STACItem.asset_names` for what this item offers.
         bbox : sequence of float or None, default None
             Area to read, as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
-            degrees**. None uses :attr:`search_bbox`, the AOI of the search
-            that produced this item; if that is also None, the whole scene is
-            read.
+            degrees**. None uses the AOI of the search that produced this item
+            — :attr:`search_bbox`, or the bounds of :attr:`search_intersects`
+            when the search used a geometry; if there is none, the whole scene
+            is read.
         crop : bool, default True
             Whether to crop at all. False reads the entire scene and cannot be
             combined with ``bbox``.
+        mask : bool, default False
+            If True, set pixels outside :attr:`search_intersects` to nodata, so
+            the result follows the geometry's outline rather than its bounding
+            rectangle. Requires a search made with ``intersects``. Cropping
+            decides what is transferred; masking is a separate analytical
+            choice, which is why it is off by default.
         resampling : str or rasterio.enums.Resampling, default "nearest"
             Method used when an asset has to be resampled onto the first
             asset's grid — a Sentinel-2 20 m band stacked with a 10 m one, for
@@ -416,8 +533,8 @@ class STACItem:
         ValidationError
             If ``assets`` is empty or names an asset the item does not have,
             if ``bbox`` is not four ordered lon/lat values, if ``bbox`` is
-            combined with ``crop=False``, or if the AOI does not overlap the
-            scene.
+            combined with ``crop=False``, if ``mask=True`` without a search
+            geometry, or if the AOI does not overlap the scene.
 
         Notes
         -----
@@ -436,6 +553,17 @@ class STACItem:
         ... )  # doctest: +SKIP
         >>> scene = results[0].load(["B04", "B08"])  # doctest: +SKIP
         >>> ndvi = scene.ndvi(red="B04", nir="B08")  # doctest: +SKIP
+
+        Follow an area's outline rather than its bounding box:
+
+        >>> import geopandas as gpd
+        >>> from eeo.datasets import load_sample_dataset
+        >>> sd = load_sample_dataset()
+        >>> boundary = gpd.read_file(sd.boundary)  # doctest: +SKIP
+        >>> results = eeo.stac_search(
+        ...     "sentinel-2-l2a", intersects=boundary, limit=1
+        ... )  # doctest: +SKIP
+        >>> scene = results[0].load("B04", mask=True)  # doctest: +SKIP
         """
         keys = self._resolve_assets(assets)
 
@@ -444,9 +572,23 @@ class STACItem:
                 "crop=False reads the whole scene and cannot be combined with a bbox; "
                 "pass one or the other"
             )
+        if mask and self._search_intersects is None:
+            raise ValidationError(
+                "mask=True needs the geometry to mask with; this item came from a "
+                "search without intersects. Search with intersects=<geometry>, or "
+                "clip the result yourself with .clip_raster_with_vector(...)"
+            )
+
         aoi: Sequence[float] | None = None
         if crop:
-            aoi = _validate_bbox(bbox) if bbox is not None else self._search_bbox
+            if bbox is not None:
+                aoi = _validate_bbox(bbox)
+            elif self._search_bbox is not None:
+                aoi = self._search_bbox
+            elif self._search_intersects is not None:
+                # Crop to the geometry's bounding window; `mask` decides whether
+                # the pixels outside its outline are then blanked.
+                aoi = shapely.geometry.shape(self._search_intersects).bounds
 
         resampling_enum = normalize_resampling_method(resampling)
 
@@ -472,7 +614,16 @@ class STACItem:
             },
             band_names=band_names,
         )
-        return dataset.to_rasterio()
+        dataset = dataset.to_rasterio()
+
+        if mask:
+            # Reuse the vector clip, which reprojects the geometry onto the
+            # raster's CRS and fills outside pixels with its nodata value.
+            geometry = gpd.GeoDataFrame(
+                geometry=[shapely.geometry.shape(self._search_intersects)], crs="EPSG:4326"
+            )
+            dataset = dataset.clip_raster_with_vector(geometry)
+        return dataset
 
     def _resolve_assets(self, assets: str | Sequence[str]) -> list[str]:
         """Normalize the asset argument to a list of keys this item has."""
@@ -525,6 +676,9 @@ class STACSearchResult(Sequence[STACItem]):
     bbox : sequence of float or None, default None
         The area of interest the search was restricted to, in WGS 84 lon/lat.
         Retained so that loading an asset can crop to it.
+    intersects : mapping or None, default None
+        The search geometry, as a GeoJSON mapping in WGS 84 lon/lat, when the
+        search used ``intersects`` instead of a bounding box.
     """
 
     def __init__(
@@ -534,11 +688,13 @@ class STACSearchResult(Sequence[STACItem]):
         collections: Sequence[str],
         catalog: str,
         bbox: Sequence[float] | None = None,
+        intersects: Mapping[str, Any] | None = None,
     ) -> None:
         self._items: list[STACItem] = sorted(items, key=_sort_key)
         self._collections = list(collections)
         self._catalog = catalog
         self._bbox = None if bbox is None else tuple(float(value) for value in bbox)
+        self._intersects = None if intersects is None else dict(intersects)
 
     @property
     def bbox(self) -> tuple[float, ...] | None:
@@ -548,9 +704,21 @@ class STACSearchResult(Sequence[STACItem]):
         -------
         tuple of float or None
             ``(minx, miny, maxx, maxy)`` in WGS 84 lon/lat degrees, or None if
-            the search set no spatial filter.
+            the search used a geometry or set no spatial filter.
         """
         return self._bbox
+
+    @property
+    def intersects(self) -> dict[str, Any] | None:
+        """Return the geometry the search was restricted to.
+
+        Returns
+        -------
+        dict or None
+            GeoJSON geometry mapping in WGS 84 lon/lat degrees, or None if the
+            search used a bounding box or set no spatial filter.
+        """
+        return None if self._intersects is None else dict(self._intersects)
 
     @property
     def collections(self) -> list[str]:
@@ -621,6 +789,7 @@ class STACSearchResult(Sequence[STACItem]):
                 collections=self._collections,
                 catalog=self._catalog,
                 bbox=self._bbox,
+                intersects=self._intersects,
             )
         return self._items[index]
 
@@ -676,6 +845,7 @@ def _validate_bbox(bbox: Sequence[float]) -> list[float]:
 def _search_parameters(
     collections: list[str],
     bbox: Sequence[float] | None,
+    intersects: IntersectsSpec | None,
     datetime: DatetimeSpec | None,
     cloud_cover: float | None,
     limit: int | None,
@@ -683,8 +853,19 @@ def _search_parameters(
     """Validate the query arguments and build the pystac-client parameters."""
     params: dict[str, Any] = {"collections": collections}
 
+    # STAC declares the two spatial filters mutually exclusive, and servers
+    # differ on which one they honour when both arrive - so refuse both here.
+    if bbox is not None and intersects is not None:
+        raise ValidationError(
+            "pass either bbox or intersects, not both; to search their overlap, "
+            "intersect the two yourself and pass the result as intersects"
+        )
+
     if bbox is not None:
         params["bbox"] = _validate_bbox(bbox)
+
+    if intersects is not None:
+        params["intersects"] = _normalize_intersects(intersects)
 
     if datetime is not None:
         params["datetime"] = datetime
@@ -729,6 +910,7 @@ def stac_search(
     collection: str | Sequence[str],
     *,
     bbox: Sequence[float] | None = None,
+    intersects: IntersectsSpec | None = None,
     datetime: DatetimeSpec | None = None,
     cloud_cover: float | None = None,
     limit: int | None = None,
@@ -749,7 +931,16 @@ def stac_search(
     bbox : sequence of float or None, default None
         Area of interest as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
         degrees** (EPSG:4326), which is what the STAC API expects regardless of
-        the imagery's own CRS. None searches the whole catalog extent.
+        the imagery's own CRS. None searches the whole catalog extent. Cannot
+        be combined with ``intersects``.
+    intersects : geometry or None, default None
+        Area of interest as a shape rather than a rectangle: a GeoDataFrame,
+        GeoSeries, shapely geometry, GeoJSON mapping (geometry, Feature, or
+        FeatureCollection), or a path to any vector file GeoPandas can read.
+        Scenes whose footprint intersects it are returned. A GeoDataFrame or
+        GeoSeries is reprojected to WGS 84 lon/lat automatically; anything
+        without a CRS is assumed to be in it already. Cannot be combined with
+        ``bbox``.
     datetime : str or datetime.datetime or tuple, default None
         Time filter, passed through to the catalog: a single instant, an
         interval string such as ``"2023-06-01/2023-08-31"`` (``".."`` leaves an
@@ -778,8 +969,8 @@ def stac_search(
     STACSearchResult
         Matching items, ordered oldest to newest (undated items last), each
         exposing its ``timestamp``, ``assets``, and STAC ``properties``. The
-        result also retains the search's ``bbox`` as its area of interest.
-        Empty when nothing matches — that is not an error.
+        result also retains the search's ``bbox`` or ``intersects`` as its
+        area of interest. Empty when nothing matches — that is not an error.
 
     Raises
     ------
@@ -787,8 +978,9 @@ def stac_search(
         If the ``stac`` extra is not installed.
     ValidationError
         If ``collection`` is empty, ``bbox`` is not four ordered lon/lat
-        values, ``cloud_cover`` is outside 0-100, or ``limit`` is not a
-        positive integer.
+        values, ``intersects`` is not a usable geometry or is not in lon/lat
+        degrees, both ``bbox`` and ``intersects`` are given, ``cloud_cover`` is
+        outside 0-100, or ``limit`` is not a positive integer.
 
     Notes
     -----
@@ -813,6 +1005,17 @@ def stac_search(
     (the same tile reprocessed under different baselines); they share a
     timestamp and are kept as separate items.
 
+    A spatial filter matches every scene whose footprint *touches* the area, so
+    results include tiles that merely graze it and would load as a sliver.
+    Keep only the scenes that cover the area when that matters::
+
+        area = shapely.geometry.shape(results.intersects)
+        covering = [
+            item
+            for item in results
+            if shapely.geometry.shape(item.item.geometry).contains(area)
+        ]
+
     Examples
     --------
     >>> import eeo
@@ -825,16 +1028,34 @@ def stac_search(
     ... )  # doctest: +SKIP
     >>> len(results), results[0].id  # doctest: +SKIP
     (5, 'S2A_MSIL2A_20230605T100031_R122_T32TPS_20230605T173940')
+
+    Search by shape instead of by rectangle:
+
+    >>> import geopandas as gpd
+    >>> from eeo.datasets import load_sample_dataset
+    >>> sd = load_sample_dataset()
+    >>> boundary = gpd.read_file(sd.boundary)  # doctest: +SKIP
+    >>> results = eeo.stac_search(
+    ...     "sentinel-2-l2a", intersects=boundary, datetime="2023-06-01/.."
+    ... )  # doctest: +SKIP
     """
     collections = _validate_collection(collection)
-    params = _search_parameters(collections, bbox, datetime, cloud_cover, limit)
+    params = _search_parameters(collections, bbox, intersects, datetime, cloud_cover, limit)
 
     client = _open_catalog(catalog, sign)
     found = client.search(**params)
 
     return STACSearchResult(
-        [STACItem(item, search_bbox=params.get("bbox")) for item in found.items()],
+        [
+            STACItem(
+                item,
+                search_bbox=params.get("bbox"),
+                search_intersects=params.get("intersects"),
+            )
+            for item in found.items()
+        ],
         collections=collections,
         catalog=catalog,
         bbox=params.get("bbox"),
+        intersects=params.get("intersects"),
     )

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -1,0 +1,545 @@
+"""Search SpatioTemporal Asset Catalogs (STAC) for imagery.
+
+:func:`stac_search` queries a STAC API — Microsoft Planetary Computer by default —
+and returns the matching scenes as a :class:`STACSearchResult`: an ordered,
+timestamped sequence of :class:`STACItem` wrappers. Ordering is chronological
+and every item carries its acquisition time, which is what lets a search
+result stand in directly for a time series later on.
+
+Searching is metadata-only. It performs HTTP requests against the catalog but
+reads no pixel data, so a search over thousands of scenes stays cheap.
+
+This module needs the optional ``stac`` extra::
+
+    pip install "easy-eo[stac]"
+
+Examples
+--------
+>>> import eeo
+>>> results = eeo.stac_search(
+...     "sentinel-2-l2a",
+...     bbox=(11.0, 46.5, 11.2, 46.7),
+...     datetime="2023-06-01/2023-08-31",
+...     cloud_cover=20,
+...     limit=5,
+... )  # doctest: +SKIP
+>>> [item.timestamp for item in results]  # doctest: +SKIP
+[datetime.datetime(2023, 6, 5, 10, 6, 21, tzinfo=datetime.timezone.utc), ...]
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping, Sequence
+from typing import Any, overload
+
+from eeo._optional import import_optional
+from eeo.core.exceptions import ValidationError
+
+#: STAC API endpoint used when no ``catalog`` is given.
+PLANETARY_COMPUTER_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
+
+# Catalogs whose asset URLs must be signed before they can be read. Signing is
+# applied automatically for these hosts unless the caller overrides ``sign``.
+_SIGNED_CATALOG_HOSTS = ("planetarycomputer.microsoft.com",)
+
+# Accepted forms for the ``datetime`` argument: a single instant, an
+# RFC 3339 / ISO 8601 interval string ("start/end", open-ended with ".."), or a
+# (start, end) pair. Passed through to pystac-client unchanged.
+DatetimeSpec = str | dt.datetime | tuple[str | dt.datetime | None, str | dt.datetime | None] | list
+
+_EPOCH = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    """Coerce a STAC datetime value to a datetime, or None if unusable."""
+    if isinstance(value, dt.datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        # STAC timestamps are RFC 3339; Python < 3.11 cannot parse the "Z".
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _item_timestamp(item: Any) -> dt.datetime | None:
+    """Return an item's acquisition time, falling back to its range start."""
+    timestamp = _parse_timestamp(getattr(item, "datetime", None))
+    if timestamp is not None:
+        return timestamp
+    properties = getattr(item, "properties", None) or {}
+    return _parse_timestamp(properties.get("start_datetime"))
+
+
+def _sort_key(item: STACItem) -> tuple[bool, dt.datetime]:
+    """Order items chronologically, placing undated ones last."""
+    timestamp = item.timestamp
+    if timestamp is None:
+        return (True, _EPOCH)
+    if timestamp.tzinfo is None:
+        # A catalog that omits the offset is reporting UTC by STAC convention.
+        timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
+    return (False, timestamp)
+
+
+class STACItem:
+    """One scene from a STAC search, with its acquisition time.
+
+    Wraps the underlying ``pystac.Item`` with a stable, documented surface;
+    the raw item stays reachable through :attr:`item` for anything this
+    wrapper does not expose.
+
+    Parameters
+    ----------
+    item : pystac.Item
+        The item returned by the STAC client.
+    """
+
+    def __init__(self, item: Any) -> None:
+        self._item = item
+        self._timestamp = _item_timestamp(item)
+
+    @property
+    def item(self) -> Any:
+        """Return the underlying ``pystac.Item``.
+
+        Returns
+        -------
+        pystac.Item
+            The unwrapped item, for access to the full STAC API.
+        """
+        return self._item
+
+    @property
+    def id(self) -> str:
+        """Return the item's catalog identifier.
+
+        Returns
+        -------
+        str
+            The STAC item id (e.g. a Sentinel-2 product name).
+        """
+        return str(getattr(self._item, "id", ""))
+
+    @property
+    def collection(self) -> str | None:
+        """Return the collection the item belongs to.
+
+        Returns
+        -------
+        str or None
+            The collection id, or None if the item declares none.
+        """
+        collection = getattr(self._item, "collection_id", None)
+        return None if collection is None else str(collection)
+
+    @property
+    def timestamp(self) -> dt.datetime | None:
+        """Return the acquisition time of the scene.
+
+        Returns
+        -------
+        datetime.datetime or None
+            The item's ``datetime``, falling back to ``start_datetime`` for
+            items that describe a range. None when the catalog reports neither
+            or reports an unparseable value.
+        """
+        return self._timestamp
+
+    @property
+    def properties(self) -> Mapping[str, Any]:
+        """Return the item's STAC properties.
+
+        Returns
+        -------
+        Mapping
+            The raw properties mapping (cloud cover, platform, projection
+            metadata, and so on).
+        """
+        return getattr(self._item, "properties", None) or {}
+
+    @property
+    def assets(self) -> Mapping[str, Any]:
+        """Return the item's assets keyed by name.
+
+        Returns
+        -------
+        Mapping
+            Mapping of asset name (e.g. ``"B04"``, ``"visual"``) to the STAC
+            asset object, whose ``href`` points at the data.
+        """
+        return getattr(self._item, "assets", None) or {}
+
+    @property
+    def asset_names(self) -> list[str]:
+        """Return the names of the assets this item offers.
+
+        Returns
+        -------
+        list of str
+            Asset keys in catalog order.
+        """
+        return list(self.assets)
+
+    @property
+    def bbox(self) -> tuple[float, ...] | None:
+        """Return the item's bounding box in WGS 84 lon/lat.
+
+        Returns
+        -------
+        tuple of float or None
+            ``(minx, miny, maxx, maxy)`` in degrees, or None if the item
+            declares no bounding box.
+        """
+        bbox = getattr(self._item, "bbox", None)
+        return None if bbox is None else tuple(float(value) for value in bbox)
+
+    @property
+    def cloud_cover(self) -> float | None:
+        """Return the scene's cloud cover percentage.
+
+        Returns
+        -------
+        float or None
+            The ``eo:cloud_cover`` property (0-100), or None when the item
+            does not report it.
+        """
+        value = self.properties.get("eo:cloud_cover")
+        return None if value is None else float(value)
+
+    def __repr__(self) -> str:
+        """Return a one-line summary: id, acquisition time, and asset count."""
+        when = "no date" if self._timestamp is None else self._timestamp.isoformat()
+        return f"<STACItem {self.id} {when} ({len(self.assets)} assets)>"
+
+
+class STACSearchResult(Sequence[STACItem]):
+    """An ordered, timestamped sequence of :class:`STACItem` results.
+
+    Behaves like a list of items sorted from oldest to newest (undated items
+    last), so it can be indexed, sliced, iterated, and measured with ``len()``.
+    The chronological ordering and per-item timestamps are what allow a search
+    result to be handed straight to a time-series layer.
+
+    Parameters
+    ----------
+    items : iterable of STACItem
+        Items to hold; sorted chronologically on construction.
+    collections : sequence of str
+        Collection ids the search covered.
+    catalog : str
+        URL of the catalog that was searched.
+    bbox : sequence of float or None, default None
+        The area of interest the search was restricted to, in WGS 84 lon/lat.
+        Retained so that loading an asset can crop to it.
+    """
+
+    def __init__(
+        self,
+        items: Sequence[STACItem],
+        *,
+        collections: Sequence[str],
+        catalog: str,
+        bbox: Sequence[float] | None = None,
+    ) -> None:
+        self._items: list[STACItem] = sorted(items, key=_sort_key)
+        self._collections = list(collections)
+        self._catalog = catalog
+        self._bbox = None if bbox is None else tuple(float(value) for value in bbox)
+
+    @property
+    def bbox(self) -> tuple[float, ...] | None:
+        """Return the area of interest the search was restricted to.
+
+        Returns
+        -------
+        tuple of float or None
+            ``(minx, miny, maxx, maxy)`` in WGS 84 lon/lat degrees, or None if
+            the search set no spatial filter.
+        """
+        return self._bbox
+
+    @property
+    def collections(self) -> list[str]:
+        """Return the collections the search covered.
+
+        Returns
+        -------
+        list of str
+            Collection ids passed to :func:`stac_search`.
+        """
+        return list(self._collections)
+
+    @property
+    def catalog(self) -> str:
+        """Return the catalog URL that was searched.
+
+        Returns
+        -------
+        str
+            The STAC API endpoint.
+        """
+        return self._catalog
+
+    @property
+    def timestamps(self) -> list[dt.datetime | None]:
+        """Return the acquisition times of the results, in order.
+
+        Returns
+        -------
+        list of (datetime.datetime or None)
+            One timestamp per item, oldest first; None for an undated item.
+        """
+        return [item.timestamp for item in self._items]
+
+    def __len__(self) -> int:
+        """Return the number of items in the result.
+
+        Returns
+        -------
+        int
+            Count of matching items.
+        """
+        return len(self._items)
+
+    @overload
+    def __getitem__(self, index: int) -> STACItem: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> STACSearchResult: ...
+
+    def __getitem__(self, index: int | slice) -> STACItem | STACSearchResult:
+        """Return the item at ``index``, or a sliced result for a slice.
+
+        Parameters
+        ----------
+        index : int or slice
+            Position of a single item, or a slice of positions.
+
+        Returns
+        -------
+        STACItem or STACSearchResult
+            The item at ``index``, or a new result holding the sliced items
+            and the same collection/catalog metadata.
+        """
+        if isinstance(index, slice):
+            return STACSearchResult(
+                self._items[index],
+                collections=self._collections,
+                catalog=self._catalog,
+                bbox=self._bbox,
+            )
+        return self._items[index]
+
+    def __repr__(self) -> str:
+        """Return a one-line summary: item count, time span, and collections."""
+        collections = ", ".join(self._collections) or "no collection"
+        if not self._items:
+            return f"<STACSearchResult: 0 items ({collections})>"
+        dated = [ts for ts in self.timestamps if ts is not None]
+        span = ""
+        if dated:
+            span = f" from {dated[0].date()} to {dated[-1].date()}"
+        return f"<STACSearchResult: {len(self._items)} items{span} ({collections})>"
+
+
+def _validate_collection(collection: str | Sequence[str]) -> list[str]:
+    """Normalize the collection argument to a non-empty list of ids."""
+    if isinstance(collection, str):
+        collections = [collection]
+    elif isinstance(collection, Sequence):
+        collections = [str(name) for name in collection]
+    else:
+        raise ValidationError(
+            f"collection must be a collection id or a sequence of ids; got {collection!r}"
+        )
+    if not collections or any(not name for name in collections):
+        raise ValidationError(
+            f"collection must name at least one non-empty collection id; got {collection!r}"
+        )
+    return collections
+
+
+def _validate_bbox(bbox: Sequence[float]) -> list[float]:
+    """Validate a WGS 84 lon/lat bounding box and return it as a list."""
+    if isinstance(bbox, str) or not isinstance(bbox, Sequence):
+        raise ValidationError(
+            f"bbox must be (minx, miny, maxx, maxy) in WGS 84 lon/lat degrees; got {bbox!r}"
+        )
+    if len(bbox) != 4:
+        raise ValidationError(
+            "bbox must be (minx, miny, maxx, maxy) in WGS 84 lon/lat degrees; "
+            f"got {len(bbox)} values"
+        )
+    minx, miny, maxx, maxy = (float(value) for value in bbox)
+    if minx >= maxx or miny >= maxy:
+        raise ValidationError(
+            "bbox must have minx < maxx and miny < maxy in WGS 84 lon/lat degrees; "
+            f"got {tuple(bbox)!r}"
+        )
+    return [minx, miny, maxx, maxy]
+
+
+def _search_parameters(
+    collections: list[str],
+    bbox: Sequence[float] | None,
+    datetime: DatetimeSpec | None,
+    cloud_cover: float | None,
+    limit: int | None,
+) -> dict[str, Any]:
+    """Validate the query arguments and build the pystac-client parameters."""
+    params: dict[str, Any] = {"collections": collections}
+
+    if bbox is not None:
+        params["bbox"] = _validate_bbox(bbox)
+
+    if datetime is not None:
+        params["datetime"] = datetime
+
+    if cloud_cover is not None:
+        if not 0 <= float(cloud_cover) <= 100:
+            raise ValidationError(
+                f"cloud_cover must be a percentage between 0 and 100; got {cloud_cover!r}"
+            )
+        # STAC's query extension; "lte" makes cloud_cover=20 mean "at most 20%".
+        params["query"] = {"eo:cloud_cover": {"lte": float(cloud_cover)}}
+
+    if limit is not None:
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            raise ValidationError(f"limit must be a positive integer; got {limit!r}")
+        # pystac-client's `limit` is a page size; `max_items` caps the total.
+        params["max_items"] = limit
+
+    return params
+
+
+def _open_catalog(catalog: str, sign: bool | None) -> Any:
+    """Open a STAC client for ``catalog``, signing asset URLs when required."""
+    pystac_client = import_optional("pystac_client", extra="stac", purpose="STAC search")
+
+    if sign is None:
+        sign = any(host in catalog for host in _SIGNED_CATALOG_HOSTS)
+
+    modifier = None
+    if sign:
+        planetary_computer = import_optional(
+            "planetary_computer",
+            extra="stac",
+            purpose="signing Planetary Computer asset URLs",
+        )
+        modifier = planetary_computer.sign_inplace
+
+    return pystac_client.Client.open(catalog, modifier=modifier)
+
+
+def stac_search(
+    collection: str | Sequence[str],
+    *,
+    bbox: Sequence[float] | None = None,
+    datetime: DatetimeSpec | None = None,
+    cloud_cover: float | None = None,
+    limit: int | None = None,
+    catalog: str = PLANETARY_COMPUTER_STAC_URL,
+    sign: bool | None = None,
+) -> STACSearchResult:
+    """Search a STAC catalog for scenes matching a place, time, and cloudiness.
+
+    Queries the catalog's search endpoint and returns the matching items in
+    chronological order, each carrying its acquisition timestamp. Only
+    metadata is fetched — no pixels are read and nothing is downloaded.
+
+    Parameters
+    ----------
+    collection : str or sequence of str
+        Collection id to search (e.g. ``"sentinel-2-l2a"``,
+        ``"landsat-c2-l2"``), or several ids to search at once.
+    bbox : sequence of float or None, default None
+        Area of interest as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+        degrees** (EPSG:4326), which is what the STAC API expects regardless of
+        the imagery's own CRS. None searches the whole catalog extent.
+    datetime : str or datetime.datetime or tuple, default None
+        Time filter, passed through to the catalog: a single instant, an
+        interval string such as ``"2023-06-01/2023-08-31"`` (``".."`` leaves an
+        end open), or a ``(start, end)`` pair. None searches all times.
+    cloud_cover : float or None, default None
+        Maximum scene cloud cover in percent (0-100), applied by the catalog
+        against each scene's ``eo:cloud_cover``. None applies no cloud filter.
+        How scenes that do not report cloud cover are treated is up to the
+        catalog; see the note below on the filter's exactness.
+    limit : int or None, default None
+        Maximum number of items to return. None returns every match, which
+        may be many pages of results.
+    catalog : str, default :data:`PLANETARY_COMPUTER_STAC_URL`
+        STAC API endpoint to search. Any STAC API works, e.g. Earth Search.
+    sign : bool or None, default None
+        Whether to sign asset URLs with ``planetary-computer``. None signs
+        automatically when ``catalog`` is a Planetary Computer endpoint and
+        leaves other catalogs untouched.
+
+    Returns
+    -------
+    STACSearchResult
+        Matching items, ordered oldest to newest (undated items last), each
+        exposing its ``timestamp``, ``assets``, and STAC ``properties``. The
+        result also retains the search's ``bbox`` as its area of interest.
+        Empty when nothing matches — that is not an error.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the ``stac`` extra is not installed.
+    ValidationError
+        If ``collection`` is empty, ``bbox`` is not four ordered lon/lat
+        values, ``cloud_cover`` is outside 0-100, or ``limit`` is not a
+        positive integer.
+
+    Notes
+    -----
+    Performs network requests against the catalog and holds only item metadata
+    in memory; no pixel data is read (see :meth:`STACItem.assets` for the URLs
+    a later read would use). Errors raised by the catalog itself — an
+    unreachable endpoint, an unknown collection — propagate from pystac-client
+    as ``pystac_client.exceptions.APIError``.
+
+    Signed Planetary Computer asset URLs are time-limited, so a search result
+    is best used soon after it is created rather than stored and reused.
+
+    ``cloud_cover`` is evaluated by the catalog, not by Easy-EO, and some
+    catalogs (Planetary Computer among them) match against their own indexed
+    value rather than the item's reported ``eo:cloud_cover``. A returned scene
+    can therefore sit a little above the threshold. Filter the result yourself
+    when an exact cut-off matters::
+
+        clear = [item for item in results if item.cloud_cover <= 20]
+
+    Catalogs may also return several near-identical scenes for one acquisition
+    (the same tile reprocessed under different baselines); they share a
+    timestamp and are kept as separate items.
+
+    Examples
+    --------
+    >>> import eeo
+    >>> results = eeo.stac_search(
+    ...     "sentinel-2-l2a",
+    ...     bbox=(11.0, 46.5, 11.2, 46.7),
+    ...     datetime="2023-06-01/2023-08-31",
+    ...     cloud_cover=20,
+    ...     limit=5,
+    ... )  # doctest: +SKIP
+    >>> len(results), results[0].id  # doctest: +SKIP
+    (5, 'S2A_MSIL2A_20230605T100031_R122_T32TPS_20230605T173940')
+    """
+    collections = _validate_collection(collection)
+    params = _search_parameters(collections, bbox, datetime, cloud_cover, limit)
+
+    client = _open_catalog(catalog, sign)
+    found = client.search(**params)
+
+    return STACSearchResult(
+        [STACItem(item) for item in found.items()],
+        collections=collections,
+        catalog=catalog,
+        bbox=params.get("bbox"),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,10 @@ filterwarnings = [
     # numpy 2.5 deprecated that. Out of our control until rasterio ships a
     # fix — ignore the specific message rather than weakening the gate.
     "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
+    # planetary-computer (the [stac] extra) still declares its pydantic models
+    # with a class-based Config, which pydantic 2 deprecates on import. Out of
+    # our control until planetary-computer migrates.
+    "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
 ]
 
 # ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# STAC data access (eeo.io.stac). pystac-client drives the search; the
+# planetary-computer helper signs Microsoft Planetary Computer asset URLs.
+# Both are capped below their next major version: pystac-client is pre-1.0 and
+# still changes its client API between minors.
+stac = [
+    "pystac-client>=0.8,<1",
+    "planetary-computer>=1.0,<2",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,14 +152,17 @@ warn_unused_ignores = true
 no_implicit_optional = true
 check_untyped_defs = true
 
-# The geospatial stack ships no type information (no py.typed, no stub
-# packages), so mypy cannot analyze it. Suppress the resulting
-# import-untyped noise rather than annotating third-party internals.
+# The geospatial stack ships no type information of its own, so mypy cannot
+# analyze it. Suppress the resulting import-untyped noise rather than
+# annotating third-party internals. (shapely has a community stub package,
+# types-shapely, which we deliberately do not adopt: it would type one corner
+# of a stack that is otherwise unanalyzable either way.)
 [[tool.mypy.overrides]]
 module = [
     "rasterio",
     "rasterio.*",
     "geopandas",
+    "shapely",
     "affine",
     "pyproj",
     "pyproj.*",

--- a/scripts/record_stac_responses.py
+++ b/scripts/record_stac_responses.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Record trimmed STAC API responses for the offline test suite.
+
+Maintainer tool. The STAC tests replay these recordings through the real
+pystac-client, so the fixtures must stay faithful to what the catalogs
+actually serve - hand-editing them defeats the point. Refresh with:
+
+    python scripts/record_stac_responses.py
+
+Each catalog yields two files in ``tests/data/stac/``: the landing page
+(``*_root.json``, which pystac-client reads to discover the search endpoint and
+conformance classes) and one page of search results (``*_search_page.json``).
+
+Responses are trimmed - a handful of assets and properties per item - to keep
+the fixtures readable in review and small in the repo. Hrefs are left exactly as
+served; catalog hrefs are unsigned, so no credentials end up in the repo.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "tests" / "data" / "stac"
+
+# Links worth keeping on a landing page: pystac-client needs "search" to find
+# the endpoint and "self"/"root" to resolve relative hrefs. Dropping "child"
+# links removes one entry per collection (over a hundred on some catalogs).
+KEPT_ROOT_RELS = {"self", "root", "search", "data", "conformance"}
+
+# Properties kept on each item: the ones Easy-EO reads, plus enough context for
+# a fixture to still look like a real scene in review.
+KEPT_PROPERTIES = (
+    "datetime",
+    "start_datetime",
+    "end_datetime",
+    "eo:cloud_cover",
+    "platform",
+    "constellation",
+    "instruments",
+    "gsd",
+    "proj:epsg",
+    "proj:code",
+)
+
+CATALOGS: dict[str, dict[str, Any]] = {
+    "pc": {
+        "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
+        "collection": "sentinel-2-l2a",
+        # Two 10 m bands and one 20 m band, so a fixture can exercise both the
+        # aligned read and the resample-onto-the-grid path.
+        "assets": ["B04", "B08", "B11", "SCL"],
+    },
+    "earthsearch": {
+        "url": "https://earth-search.aws.element84.com/v1",
+        "collection": "sentinel-2-l2a",
+        "assets": ["red", "nir", "swir16", "scl"],
+    },
+}
+
+BBOX = [11.0, 46.5, 11.2, 46.7]
+FEATURE_COUNT = 2
+
+
+def _get(url: str, payload: dict | None = None) -> dict:
+    """Fetch JSON, POSTing ``payload`` when given."""
+    data = None if payload is None else json.dumps(payload).encode()
+    headers = {"Accept": "application/json"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers)
+    with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+        return json.load(response)
+
+
+def trim_root(document: dict) -> dict:
+    """Drop the per-collection child links from a landing page."""
+    trimmed = dict(document)
+    trimmed["links"] = [
+        link for link in document.get("links", []) if link.get("rel") in KEPT_ROOT_RELS
+    ]
+    return trimmed
+
+
+def trim_feature(feature: dict, assets: list[str]) -> dict:
+    """Keep a few assets and properties; drop links and per-asset extras."""
+    properties = {
+        key: value for key, value in feature.get("properties", {}).items() if key in KEPT_PROPERTIES
+    }
+    kept_assets = {}
+    for name in assets:
+        asset = feature.get("assets", {}).get(name)
+        if asset is None:
+            continue
+        kept_assets[name] = {
+            key: value for key, value in asset.items() if key in ("href", "type", "title", "roles")
+        }
+    return {
+        "type": feature.get("type", "Feature"),
+        "stac_version": feature.get("stac_version", "1.0.0"),
+        "id": feature["id"],
+        "collection": feature.get("collection"),
+        "geometry": feature.get("geometry"),
+        "bbox": feature.get("bbox"),
+        "properties": properties,
+        "assets": kept_assets,
+        "links": [],
+    }
+
+
+def fetch_page(catalog: dict) -> dict:
+    """Fetch one page of results, preferring the search endpoint."""
+    url, collection = catalog["url"], catalog["collection"]
+    body = {"collections": [collection], "bbox": BBOX, "limit": FEATURE_COUNT}
+    try:
+        page = _get(f"{url}/search", body)
+    except urllib.error.HTTPError as err:
+        # The items endpoint returns the same FeatureCollection shape and is a
+        # usable stand-in while a catalog's search backend is unavailable.
+        print(f"  search endpoint returned HTTP {err.code}; falling back to /items")
+        query = f"?limit={FEATURE_COUNT}&bbox={','.join(str(v) for v in BBOX)}"
+        page = _get(f"{url}/collections/{collection}/items{query}")
+
+    features = [trim_feature(feature, catalog["assets"]) for feature in page["features"]]
+    return {
+        "type": "FeatureCollection",
+        "stac_version": page.get("stac_version", "1.0.0"),
+        "features": features,
+        # No "next" link: one page, so a replay terminates.
+        "links": [],
+    }
+
+
+def main() -> None:
+    """Record every catalog's landing page and one page of results."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for name, catalog in CATALOGS.items():
+        print(f"recording {name} ({catalog['url']})")
+        for suffix, document in (
+            ("root", trim_root(_get(catalog["url"]))),
+            ("search_page", fetch_page(catalog)),
+        ):
+            path = OUTPUT_DIR / f"{name}_{suffix}.json"
+            path.write_text(json.dumps(document, indent=2) + "\n")
+            print(f"  wrote {path.relative_to(OUTPUT_DIR.parent.parent.parent)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ CRS-mismatch partner raster uses EPSG:4326. Pixel values are deterministic
 gradients (``0..n-1``) so tests can assert against hand-computed results.
 """
 
+import socket
 import warnings
 
 import matplotlib
@@ -55,6 +56,36 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "network" in item.keywords:
             item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def _block_network(request, monkeypatch):
+    """Fail any unmarked test that opens a network connection.
+
+    The default run must be offline: STAC, sample-data, and remote-raster
+    tests all work from recordings, fakes, or local files. This turns a test
+    that quietly starts reaching a real service into an immediate, obvious
+    failure rather than a slow or flaky one.
+
+    Tests marked ``@pytest.mark.network`` are exempt (they only run under
+    ``--run-network``). The guard covers Python-level sockets, which is what
+    ``requests`` and ``urllib`` use; GDAL's own HTTP stack does not go through
+    them, so a remote raster read is kept out of the default suite by review
+    rather than by this fixture.
+    """
+    if request.node.get_closest_marker("network"):
+        return
+
+    def blocked(*args, **kwargs):
+        raise RuntimeError(
+            "this test tried to open a network connection, which the default "
+            "test run forbids; use a recorded response or a local file, or "
+            "mark the test with @pytest.mark.network"
+        )
+
+    monkeypatch.setattr(socket.socket, "connect", blocked)
+    monkeypatch.setattr(socket.socket, "connect_ex", blocked)
+    monkeypatch.setattr(socket, "create_connection", blocked)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/data/stac/README.md
+++ b/tests/data/stac/README.md
@@ -1,0 +1,26 @@
+# Recorded STAC responses
+
+Real responses from live STAC APIs, trimmed for size, replayed by
+`tests/test_stac_recorded.py` so the search path can be exercised through the
+actual `pystac-client` without touching the network.
+
+| File | Source |
+|---|---|
+| `pc_root.json` | `GET https://planetarycomputer.microsoft.com/api/stac/v1` |
+| `pc_search_page.json` | `POST .../api/stac/v1/search` (sentinel-2-l2a, 2 items) |
+| `earthsearch_root.json` | `GET https://earth-search.aws.element84.com/v1` |
+| `earthsearch_search_page.json` | `POST .../v1/search` (sentinel-2-l2a, 2 items) |
+
+Recorded 2026-07-26 over the bbox `(11.0, 46.5, 11.2, 46.7)`.
+
+Trimming keeps a few assets and properties per item and drops the landing
+pages' per-collection `child` links; everything kept is byte-for-byte what the
+catalog served, including asset hrefs (catalog hrefs are unsigned, so no
+credentials live here). Both pages are ordered newest-first, as the catalogs
+return them, which is what lets the tests prove Easy-EO re-orders results
+chronologically.
+
+Do not hand-edit these files — a fixture that drifts from what the catalogs
+actually serve stops being evidence. Refresh them with:
+
+    python scripts/record_stac_responses.py

--- a/tests/data/stac/earthsearch_root.json
+++ b/tests/data/stac/earthsearch_root.json
@@ -1,0 +1,57 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Catalog",
+  "id": "earth-search-aws",
+  "title": "Earth Search by Element 84",
+  "description": "A STAC API of public datasets on AWS",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1"
+    },
+    {
+      "rel": "conformance",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1/conformance"
+    },
+    {
+      "rel": "data",
+      "type": "application/json",
+      "href": "https://earth-search.aws.element84.com/v1/collections"
+    },
+    {
+      "rel": "search",
+      "type": "application/geo+json",
+      "href": "https://earth-search.aws.element84.com/v1/search",
+      "method": "GET"
+    },
+    {
+      "rel": "search",
+      "type": "application/geo+json",
+      "href": "https://earth-search.aws.element84.com/v1/search",
+      "method": "POST"
+    }
+  ],
+  "conformsTo": [
+    "https://api.stacspec.org/v1.0.0/core",
+    "https://api.stacspec.org/v1.0.0/collections",
+    "https://api.stacspec.org/v1.0.0/ogcapi-features",
+    "https://api.stacspec.org/v1.0.0/item-search",
+    "https://api.stacspec.org/v1.0.0/ogcapi-features#fields",
+    "https://api.stacspec.org/v1.0.0/ogcapi-features#sort",
+    "https://api.stacspec.org/v1.0.0/ogcapi-features#query",
+    "https://api.stacspec.org/v1.0.0/item-search#fields",
+    "https://api.stacspec.org/v1.0.0/item-search#sort",
+    "https://api.stacspec.org/v1.0.0/item-search#query",
+    "https://api.stacspec.org/v0.3.0/aggregation",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"
+  ]
+}

--- a/tests/data/stac/earthsearch_search_page.json
+++ b/tests/data/stac/earthsearch_search_page.json
@@ -1,0 +1,189 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_32TPS_20260724_0_L2A",
+      "collection": "sentinel-2-l2a",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.314048196991166,
+              46.94615910623302
+            ],
+            [
+              10.290518071717258,
+              45.95917318941413
+            ],
+            [
+              11.356014731996964,
+              45.942705622589436
+            ],
+            [
+              11.732807139367111,
+              46.815569603350575
+            ],
+            [
+              11.7542593536663,
+              46.92055930939089
+            ],
+            [
+              10.314048196991166,
+              46.94615910623302
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.290518,
+        45.942706,
+        11.754259,
+        46.946159
+      ],
+      "properties": {
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 0.236745,
+        "proj:epsg": 32632,
+        "datetime": "2026-07-24T10:27:56.072000Z"
+      },
+      "assets": {
+        "red": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2B_32TPS_20260724_0_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2B_32TPS_20260724_0_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2B_32TPS_20260724_0_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6\u03bcm - 20m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2B_32TPS_20260724_0_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "roles": [
+            "data"
+          ]
+        }
+      },
+      "links": []
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_32TPS_20260721_1_L2A",
+      "collection": "sentinel-2-l2a",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              10.314048196991166,
+              46.94615910623302
+            ],
+            [
+              10.290518071585979,
+              45.95917318376023
+            ],
+            [
+              11.360429117059908,
+              45.94216669305363
+            ],
+            [
+              11.741212722719865,
+              46.82606376309557
+            ],
+            [
+              11.755571336057699,
+              46.92052771524623
+            ],
+            [
+              10.314048196991166,
+              46.94615910623302
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.290518,
+        45.942167,
+        11.755571,
+        46.946159
+      ],
+      "properties": {
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": [
+          "msi"
+        ],
+        "eo:cloud_cover": 40.672112,
+        "proj:epsg": 32632,
+        "datetime": "2026-07-21T10:28:12.920000Z"
+      },
+      "assets": {
+        "red": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2A_32TPS_20260721_1_L2A/B04.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Red - 10m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "nir": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2A_32TPS_20260721_1_L2A/B08.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "NIR 1 - 10m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "swir16": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2A_32TPS_20260721_1_L2A/B11.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "SWIR 1.6\u03bcm - 20m",
+          "roles": [
+            "data",
+            "reflectance"
+          ]
+        },
+        "scl": {
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/PS/2026/7/S2A_32TPS_20260721_1_L2A/SCL.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "title": "Scene classification map (SCL)",
+          "roles": [
+            "data"
+          ]
+        }
+      },
+      "links": []
+    }
+  ],
+  "links": []
+}

--- a/tests/data/stac/pc_root.json
+++ b/tests/data/stac/pc_root.json
@@ -1,0 +1,62 @@
+{
+  "type": "Catalog",
+  "id": "microsoft-pc",
+  "title": "Microsoft Planetary Computer STAC API",
+  "description": "Searchable spatiotemporal metadata describing Earth science datasets hosted by the Microsoft Planetary Computer",
+  "stac_version": "1.0.0",
+  "conformsTo": [
+    "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+    "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
+    "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+    "https://api.stacspec.org/v1.0.0-rc.2/item-search#filter",
+    "https://api.stacspec.org/v1.0.0/collections",
+    "https://api.stacspec.org/v1.0.0/core",
+    "https://api.stacspec.org/v1.0.0/item-search",
+    "https://api.stacspec.org/v1.0.0/item-search#fields",
+    "https://api.stacspec.org/v1.0.0/item-search#query",
+    "https://api.stacspec.org/v1.0.0/item-search#sort",
+    "https://api.stacspec.org/v1.0.0/ogcapi-features"
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+    },
+    {
+      "rel": "data",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections"
+    },
+    {
+      "rel": "conformance",
+      "type": "application/json",
+      "title": "STAC/OGC conformance classes implemented by this server",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/conformance"
+    },
+    {
+      "rel": "search",
+      "type": "application/geo+json",
+      "title": "STAC search",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/search",
+      "method": "GET"
+    },
+    {
+      "rel": "search",
+      "type": "application/geo+json",
+      "title": "STAC search",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/search",
+      "method": "POST"
+    }
+  ],
+  "stac_extensions": []
+}

--- a/tests/data/stac/pc_search_page.json
+++ b/tests/data/stac/pc_search_page.json
@@ -1,0 +1,235 @@
+{
+  "type": "FeatureCollection",
+  "stac_version": "1.0.0",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2B_MSIL2A_20260724T101559_R065_T32TPS_20260724T141313",
+      "collection": "sentinel-2-l2a",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              11.7522421,
+              46.8536513
+            ],
+            [
+              11.7402881,
+              46.8244969
+            ],
+            [
+              11.676864,
+              46.6793838
+            ],
+            [
+              11.6127394,
+              46.5345436
+            ],
+            [
+              11.5498542,
+              46.3894991
+            ],
+            [
+              11.4883187,
+              46.2441422
+            ],
+            [
+              11.4274416,
+              46.0986829
+            ],
+            [
+              11.3659159,
+              45.9533961
+            ],
+            [
+              11.3602957,
+              45.9395488
+            ],
+            [
+              10.2904841,
+              45.9582645
+            ],
+            [
+              10.3140353,
+              46.9461683
+            ],
+            [
+              11.7555849,
+              46.9205364
+            ],
+            [
+              11.7522421,
+              46.8536513
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.2904841,
+        45.9395488,
+        11.7555849,
+        46.9461683
+      ],
+      "properties": {
+        "datetime": "2026-07-24T10:15:59.024000Z",
+        "platform": "Sentinel-2B",
+        "proj:epsg": 32632,
+        "instruments": [
+          "msi"
+        ],
+        "constellation": "Sentinel 2",
+        "eo:cloud_cover": 0.236745
+      },
+      "assets": {
+        "B04": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/24/S2B_MSIL2A_20260724T101559_N0512_R065_T32TPS_20260724T141313.SAFE/GRANULE/L2A_T32TPS_A048997_20260724T101659/IMG_DATA/R10m/T32TPS_20260724T101559_B04_10m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 4 - Red - 10m"
+        },
+        "B08": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/24/S2B_MSIL2A_20260724T101559_N0512_R065_T32TPS_20260724T141313.SAFE/GRANULE/L2A_T32TPS_A048997_20260724T101659/IMG_DATA/R10m/T32TPS_20260724T101559_B08_10m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 8 - NIR - 10m"
+        },
+        "B11": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/24/S2B_MSIL2A_20260724T101559_N0512_R065_T32TPS_20260724T141313.SAFE/GRANULE/L2A_T32TPS_A048997_20260724T101659/IMG_DATA/R20m/T32TPS_20260724T101559_B11_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 11 - SWIR (1.6) - 20m"
+        },
+        "SCL": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/24/S2B_MSIL2A_20260724T101559_N0512_R065_T32TPS_20260724T141313.SAFE/GRANULE/L2A_T32TPS_A048997_20260724T101659/IMG_DATA/R20m/T32TPS_20260724T101559_SCL_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Scene classfication map (SCL)"
+        }
+      },
+      "links": []
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "S2A_MSIL2A_20260721T102041_R065_T32TPS_20260721T170018",
+      "collection": "sentinel-2-l2a",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              11.7520578,
+              46.8499638
+            ],
+            [
+              11.7322141,
+              46.8023352
+            ],
+            [
+              11.6688017,
+              46.6570808
+            ],
+            [
+              11.6042266,
+              46.512161
+            ],
+            [
+              11.5412425,
+              46.3669454
+            ],
+            [
+              11.4782469,
+              46.2219063
+            ],
+            [
+              11.4189441,
+              46.0761062
+            ],
+            [
+              11.3613475,
+              45.9395304
+            ],
+            [
+              10.2904841,
+              45.9582645
+            ],
+            [
+              10.3140353,
+              46.9461683
+            ],
+            [
+              11.7555849,
+              46.9205364
+            ],
+            [
+              11.7520578,
+              46.8499638
+            ]
+          ]
+        ]
+      },
+      "bbox": [
+        10.2904841,
+        45.9395304,
+        11.7555849,
+        46.9461683
+      ],
+      "properties": {
+        "datetime": "2026-07-21T10:20:41.024000Z",
+        "platform": "Sentinel-2A",
+        "proj:epsg": 32632,
+        "instruments": [
+          "msi"
+        ],
+        "constellation": "Sentinel 2",
+        "eo:cloud_cover": 40.672112
+      },
+      "assets": {
+        "B04": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/21/S2A_MSIL2A_20260721T102041_N0512_R065_T32TPS_20260721T170018.SAFE/GRANULE/L2A_T32TPS_A057863_20260721T102042/IMG_DATA/R10m/T32TPS_20260721T102041_B04_10m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 4 - Red - 10m"
+        },
+        "B08": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/21/S2A_MSIL2A_20260721T102041_N0512_R065_T32TPS_20260721T170018.SAFE/GRANULE/L2A_T32TPS_A057863_20260721T102042/IMG_DATA/R10m/T32TPS_20260721T102041_B08_10m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 8 - NIR - 10m"
+        },
+        "B11": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/21/S2A_MSIL2A_20260721T102041_N0512_R065_T32TPS_20260721T170018.SAFE/GRANULE/L2A_T32TPS_A057863_20260721T102042/IMG_DATA/R20m/T32TPS_20260721T102041_B11_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Band 11 - SWIR (1.6) - 20m"
+        },
+        "SCL": {
+          "href": "https://sentinel2l2a01.blob.core.windows.net/sentinel2-l2/32/T/PS/2026/07/21/S2A_MSIL2A_20260721T102041_N0512_R065_T32TPS_20260721T170018.SAFE/GRANULE/L2A_T32TPS_A057863_20260721T102042/IMG_DATA/R20m/T32TPS_20260721T102041_SCL_20m.tif",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+            "data"
+          ],
+          "title": "Scene classfication map (SCL)"
+        }
+      },
+      "links": []
+    }
+  ],
+  "links": []
+}

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,88 @@
+"""Tests for the optional-extra import helper (eeo._optional)."""
+
+import importlib
+import importlib.util
+
+import pytest
+
+import eeo
+from eeo._optional import import_optional
+
+# Modules provided by the optional extras, paired with the extra that
+# installs them. Kept in sync with [project.optional-dependencies].
+EXTRA_MODULES = [
+    ("pystac_client", "stac"),
+    ("planetary_computer", "stac"),
+]
+
+
+def test_import_optional_returns_installed_module():
+    # numpy is a core dependency, so the success path is exercised without
+    # requiring any extra to be installed.
+    module = import_optional("numpy", extra="stac", purpose="STAC search")
+
+    assert module is importlib.import_module("numpy")
+
+
+@pytest.mark.parametrize(("module", "extra"), EXTRA_MODULES)
+def test_extra_module_is_importable_or_raises_helpful_error(module, extra):
+    """Whether or not the extra is installed, the outcome is documented."""
+    if importlib.util.find_spec(module) is not None:
+        assert import_optional(module, extra=extra, purpose="STAC search") is not None
+        return
+
+    with pytest.raises(eeo.MissingDependencyError) as excinfo:
+        import_optional(module, extra=extra, purpose="STAC search")
+
+    assert f"pip install 'easy-eo[{extra}]'" in str(excinfo.value)
+
+
+def test_missing_module_raises_missing_dependency_error():
+    with pytest.raises(eeo.MissingDependencyError) as excinfo:
+        import_optional(
+            "eeo_not_a_real_package",
+            extra="stac",
+            purpose="STAC search",
+        )
+
+    message = str(excinfo.value)
+    assert "STAC search" in message
+    assert "eeo_not_a_real_package" in message
+    assert "pip install 'easy-eo[stac]'" in message
+
+
+def test_missing_dependency_error_is_catchable_as_import_error():
+    with pytest.raises(ImportError):
+        import_optional("eeo_not_a_real_package", extra="stac", purpose="STAC search")
+
+    with pytest.raises(eeo.EEOError):
+        import_optional("eeo_not_a_real_package", extra="stac", purpose="STAC search")
+
+
+def test_simulated_absence_of_an_installed_package(monkeypatch):
+    """The absent case is reported even when the package is installed."""
+
+    def fake_import_module(name):
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(eeo.MissingDependencyError, match=r"pip install 'easy-eo\[stac\]'"):
+        import_optional("pystac_client", extra="stac", purpose="STAC search")
+
+
+def test_error_inside_the_optional_package_propagates_unchanged(monkeypatch):
+    """A missing *transitive* dependency is not blamed on the extra."""
+
+    def fake_import_module(name):
+        raise ModuleNotFoundError(
+            "No module named 'some_transitive_dep'", name="some_transitive_dep"
+        )
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        import_optional("pystac_client", extra="stac", purpose="STAC search")
+
+    assert not isinstance(excinfo.value, eeo.MissingDependencyError)
+    assert excinfo.value.name == "some_transitive_dep"

--- a/tests/test_stac_intersects.py
+++ b/tests/test_stac_intersects.py
@@ -1,0 +1,342 @@
+"""Tests for the ``intersects`` spatial filter on eeo.stac_search.
+
+The catalog is faked (as in test_stac_search.py) and the assets are local
+GeoTIFFs (as in test_stac_load.py), so geometry normalisation, the query sent
+to the catalog, and geometry-aware cropping are all exercised offline.
+"""
+
+import sys
+import types
+
+import geopandas as gpd
+import numpy as np
+import pytest
+import rasterio as rio
+import shapely
+from rasterio.transform import from_origin
+from rasterio.warp import transform_bounds
+
+import eeo
+
+SCENE_CRS = "EPSG:32633"
+SCENE_ORIGIN = (500000.0, 5000000.0)
+SCENE_SIZE = 200
+SCENE_RES = 10.0
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+class FakeAsset:
+    def __init__(self, href):
+        self.href = str(href)
+
+
+class FakeItem:
+    def __init__(self, assets=None):
+        self.id = "S2A_TEST"
+        self.datetime = None
+        self.collection_id = "sentinel-2-l2a"
+        self.properties = {}
+        self.assets = {k: FakeAsset(v) for k, v in (assets or {}).items()}
+        self.bbox = [11.0, 46.5, 11.2, 46.7]
+
+
+class FakeSearch:
+    def __init__(self, items):
+        self._items = items
+
+    def items(self):
+        return iter(self._items)
+
+
+class FakeClient:
+    searched = []
+    items_to_return = []
+
+    @classmethod
+    def open(cls, url, modifier=None):
+        return cls()
+
+    def search(self, **params):
+        FakeClient.searched.append(params)
+        return FakeSearch(list(FakeClient.items_to_return))
+
+
+@pytest.fixture
+def fake_stac(monkeypatch):
+    FakeClient.searched = []
+    FakeClient.items_to_return = []
+    module = types.ModuleType("pystac_client")
+    module.Client = FakeClient
+    # The default catalog is Planetary Computer, so the signer is imported too;
+    # fake it as well, or the real one would try to import the fake client.
+    signer = types.ModuleType("planetary_computer")
+    signer.sign_inplace = lambda item: item
+
+    monkeypatch.setitem(sys.modules, "pystac_client", module)
+    monkeypatch.setitem(sys.modules, "planetary_computer", signer)
+    return FakeClient
+
+
+# --------------------------------------------------------------------------
+# Geometry fixtures
+# --------------------------------------------------------------------------
+def utm_box(minx, miny, maxx, maxy):
+    """A rectangle in the scene's UTM CRS."""
+    return shapely.geometry.box(minx, miny, maxx, maxy)
+
+
+@pytest.fixture
+def triangle_utm():
+    """A non-rectangular AOI inside the scene, in UTM 33N."""
+    left, top = SCENE_ORIGIN
+    return shapely.geometry.Polygon(
+        [(left + 200, top - 200), (left + 600, top - 200), (left + 200, top - 600)]
+    )
+
+
+@pytest.fixture
+def triangle_wgs84(triangle_utm):
+    """The same triangle in WGS 84 lon/lat."""
+    gdf = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    return gdf.geometry.iloc[0]
+
+
+@pytest.fixture
+def scene_asset(tmp_path):
+    """A 200 x 200, 10 m GeoTIFF covering the scene, all pixels valued 500."""
+    path = tmp_path / "B04.tif"
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=SCENE_SIZE,
+        width=SCENE_SIZE,
+        count=1,
+        dtype="uint16",
+        crs=SCENE_CRS,
+        transform=from_origin(SCENE_ORIGIN[0], SCENE_ORIGIN[1], SCENE_RES, SCENE_RES),
+        nodata=0,
+    ) as dst:
+        dst.write(np.full((1, SCENE_SIZE, SCENE_SIZE), 500, dtype="uint16"))
+    return path
+
+
+# --------------------------------------------------------------------------
+# What reaches the catalog
+# --------------------------------------------------------------------------
+def test_shapely_geometry_is_sent_as_geojson(fake_stac, triangle_wgs84):
+    eeo.stac_search("sentinel-2-l2a", intersects=triangle_wgs84)
+
+    sent = fake_stac.searched[0]["intersects"]
+    assert sent["type"] == "Polygon"
+    assert "bbox" not in sent
+    assert shapely.geometry.shape(sent).equals(triangle_wgs84)
+
+
+def test_geodataframe_is_reprojected_to_lon_lat(fake_stac, triangle_utm, triangle_wgs84):
+    projected = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS)
+
+    eeo.stac_search("sentinel-2-l2a", intersects=projected)
+
+    sent = shapely.geometry.shape(fake_stac.searched[0]["intersects"])
+    # Sent in degrees, not metres - the CRS travelled with the data.
+    assert sent.bounds == pytest.approx(triangle_wgs84.bounds, abs=1e-9)
+
+
+def test_geoseries_is_accepted(fake_stac, triangle_utm):
+    series = gpd.GeoSeries([triangle_utm], crs=SCENE_CRS)
+
+    eeo.stac_search("sentinel-2-l2a", intersects=series)
+
+    assert fake_stac.searched[0]["intersects"]["type"] == "Polygon"
+
+
+def test_several_geometries_are_merged(fake_stac):
+    left, right = utm_box(11.0, 46.5, 11.1, 46.6), utm_box(11.3, 46.5, 11.4, 46.6)
+    gdf = gpd.GeoDataFrame(geometry=[left, right], crs="EPSG:4326")
+
+    eeo.stac_search("sentinel-2-l2a", intersects=gdf)
+
+    sent = shapely.geometry.shape(fake_stac.searched[0]["intersects"])
+    assert sent.geom_type == "MultiPolygon"
+    assert sent.bounds == pytest.approx((11.0, 46.5, 11.4, 46.6))
+
+
+def test_geojson_mapping_feature_and_collection_are_accepted(fake_stac, triangle_wgs84):
+    geometry = shapely.geometry.mapping(triangle_wgs84)
+    feature = {"type": "Feature", "properties": {}, "geometry": geometry}
+    collection = {"type": "FeatureCollection", "features": [feature]}
+
+    for value in (geometry, feature, collection):
+        eeo.stac_search("sentinel-2-l2a", intersects=value)
+
+    for params in fake_stac.searched:
+        assert shapely.geometry.shape(params["intersects"]).equals(triangle_wgs84)
+
+
+def test_vector_file_path_is_read(fake_stac, tmp_path, triangle_utm, triangle_wgs84):
+    path = tmp_path / "aoi.geojson"
+    gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_file(path)
+
+    eeo.stac_search("sentinel-2-l2a", intersects=str(path))
+
+    sent = shapely.geometry.shape(fake_stac.searched[0]["intersects"])
+    assert sent.bounds == pytest.approx(triangle_wgs84.bounds, abs=1e-6)
+
+
+def test_bbox_is_still_sent_as_bbox(fake_stac):
+    eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7))
+
+    assert "intersects" not in fake_stac.searched[0]
+    assert fake_stac.searched[0]["bbox"] == [11.0, 46.5, 11.2, 46.7]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_bbox_and_intersects_together_raise_validation_error(fake_stac, triangle_wgs84):
+    with pytest.raises(eeo.ValidationError, match="either bbox or intersects"):
+        eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7), intersects=triangle_wgs84)
+
+    assert fake_stac.searched == []
+
+
+def test_projected_geometry_without_a_crs_is_rejected(fake_stac, triangle_utm):
+    # Metres, no CRS to reproject from: the catalog would match nothing at all.
+    with pytest.raises(eeo.ValidationError, match="WGS 84 lon/lat"):
+        eeo.stac_search("sentinel-2-l2a", intersects=triangle_utm)
+
+
+def test_out_of_range_latitudes_are_rejected(fake_stac):
+    # Plausible longitudes, projected northings: caught on the latitude check.
+    strip = shapely.geometry.box(10.0, 5_000_000.0, 11.0, 5_000_100.0)
+
+    with pytest.raises(eeo.ValidationError, match="latitudes"):
+        eeo.stac_search("sentinel-2-l2a", intersects=strip)
+
+
+def test_geodataframe_without_a_crs_is_taken_as_lon_lat(fake_stac, triangle_wgs84):
+    gdf = gpd.GeoDataFrame(geometry=[triangle_wgs84])  # no crs set
+    assert gdf.crs is None
+
+    eeo.stac_search("sentinel-2-l2a", intersects=gdf)
+
+    assert fake_stac.searched[0]["intersects"]["type"] == "Polygon"
+
+
+def test_empty_geometry_is_rejected(fake_stac):
+    empty = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+
+    with pytest.raises(eeo.ValidationError, match="at least one geometry"):
+        eeo.stac_search("sentinel-2-l2a", intersects=empty)
+
+
+@pytest.mark.parametrize("bad", [42, object(), {"type": "Nonsense", "coordinates": []}])
+def test_unusable_intersects_raises_validation_error(fake_stac, bad):
+    with pytest.raises(eeo.ValidationError, match="intersects"):
+        eeo.stac_search("sentinel-2-l2a", intersects=bad)
+
+
+def test_unreadable_vector_path_raises_validation_error(fake_stac, tmp_path):
+    with pytest.raises(eeo.ValidationError, match="vector file"):
+        eeo.stac_search("sentinel-2-l2a", intersects=str(tmp_path / "missing.geojson"))
+
+
+# --------------------------------------------------------------------------
+# Retention on the result
+# --------------------------------------------------------------------------
+def test_result_and_items_retain_the_geometry(fake_stac, triangle_wgs84):
+    fake_stac.items_to_return = [FakeItem()]
+
+    results = eeo.stac_search("sentinel-2-l2a", intersects=triangle_wgs84)
+
+    assert results.bbox is None
+    assert shapely.geometry.shape(results.intersects).equals(triangle_wgs84)
+    assert shapely.geometry.shape(results[0].search_intersects).equals(triangle_wgs84)
+    assert results[0].search_bbox is None
+    # ...and it survives slicing, like the bbox does.
+    assert results[:1].intersects == results.intersects
+
+
+def test_bbox_search_leaves_the_geometry_unset(fake_stac):
+    fake_stac.items_to_return = [FakeItem()]
+
+    results = eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7))
+
+    assert results.intersects is None
+    assert results[0].search_intersects is None
+
+
+# --------------------------------------------------------------------------
+# Loading against a geometry
+# --------------------------------------------------------------------------
+def test_load_crops_to_the_geometry_bounds(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    results = eeo.stac_search("sentinel-2-l2a", intersects=triangle)
+    ds = results[0].load("B04")
+
+    # The triangle spans 400 m of a 2 km scene: 40 pixels, not 200.
+    height, width = ds.get_shape()
+    assert 40 <= height <= 43
+    assert 40 <= width <= 43
+
+
+def test_load_without_mask_keeps_the_bounding_rectangle(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04")
+
+    # Every pixel of the rectangle is data; nothing has been blanked.
+    assert np.all(ds.to_array() == 500)
+
+
+def test_load_with_mask_follows_the_geometry_outline(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04", mask=True)
+
+    values = ds.to_array()
+    inside = (values == 500).sum()
+    outside = (values == 0).sum()
+    assert inside > 0 and outside > 0
+    # A right triangle keeps about half of its bounding rectangle.
+    assert 0.35 < inside / values.size < 0.65
+
+
+def test_mask_without_a_search_geometry_raises_validation_error(fake_stac, scene_asset):
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    results = eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7))
+
+    with pytest.raises(eeo.ValidationError, match="mask=True needs"):
+        results[0].load("B04", mask=True)
+
+
+def test_explicit_bbox_still_wins_over_the_search_geometry(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+    left, top = SCENE_ORIGIN
+    smaller = transform_bounds(
+        SCENE_CRS, "EPSG:4326", left + 200, top - 400, left + 400, top - 200, densify_pts=21
+    )
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04", bbox=smaller)
+
+    height, width = ds.get_shape()
+    assert 20 <= height <= 23
+    assert 20 <= width <= 23
+
+
+def test_crop_false_reads_the_whole_scene_despite_a_geometry(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04", crop=False)
+
+    assert ds.get_shape() == (SCENE_SIZE, SCENE_SIZE)

--- a/tests/test_stac_intersects.py
+++ b/tests/test_stac_intersects.py
@@ -309,6 +309,53 @@ def test_load_with_mask_follows_the_geometry_outline(fake_stac, scene_asset, tri
     assert 0.35 < inside / values.size < 0.65
 
 
+def test_mask_records_the_assets_own_nodata(fake_stac, scene_asset, triangle_utm):
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04", mask=True)
+
+    assert ds.get_metadata()["nodata"] == 0  # the asset declares nodata=0
+    assert (ds.to_array() == 0).any()
+
+
+@pytest.mark.parametrize(("dtype", "expected"), [("uint16", 0), ("float32", float("nan"))])
+def test_mask_records_a_fill_when_the_asset_declares_no_nodata(
+    fake_stac, tmp_path, triangle_utm, dtype, expected
+):
+    # Many STAC assets declare no nodata; the masked-out pixels must still be
+    # marked, or they read back as ordinary values.
+    path = tmp_path / f"no_nodata_{dtype}.tif"
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=SCENE_SIZE,
+        width=SCENE_SIZE,
+        count=1,
+        dtype=dtype,
+        crs=SCENE_CRS,
+        transform=from_origin(SCENE_ORIGIN[0], SCENE_ORIGIN[1], SCENE_RES, SCENE_RES),
+    ) as dst:  # note: no nodata=
+        dst.write(np.full((1, SCENE_SIZE, SCENE_SIZE), 500, dtype=dtype))
+
+    triangle = gpd.GeoDataFrame(geometry=[triangle_utm], crs=SCENE_CRS).to_crs(4326)
+    fake_stac.items_to_return = [FakeItem({"B04": path})]
+
+    ds = eeo.stac_search("sentinel-2-l2a", intersects=triangle)[0].load("B04", mask=True)
+
+    recorded = ds.get_metadata()["nodata"]
+    values = ds.to_array()
+    if np.isnan(expected):
+        assert np.isnan(recorded)
+        assert np.isnan(values).any()
+    else:
+        assert recorded == expected
+        assert (values == expected).any()
+    # Whatever the fill, it is declared - not silently mixed in with the data.
+    assert recorded is not None
+
+
 def test_mask_without_a_search_geometry_raises_validation_error(fake_stac, scene_asset):
     fake_stac.items_to_return = [FakeItem({"B04": scene_asset})]
 

--- a/tests/test_stac_load.py
+++ b/tests/test_stac_load.py
@@ -1,0 +1,381 @@
+"""Tests for STACItem.load (eeo/io/stac.py).
+
+The STAC metadata is faked, but the raster reads are real: assets point at
+GeoTIFFs written to a temporary directory, so the cropping, grid alignment, and
+warping code runs exactly as it would against a remote COG — without touching
+the network.
+"""
+
+import datetime as dt
+
+import numpy as np
+import pytest
+import rasterio as rio
+from rasterio.transform import from_origin
+from rasterio.warp import transform_bounds
+
+import eeo
+
+UTC = dt.timezone.utc
+
+# A synthetic scene in UTM 33N: 200 x 200 pixels of 10 m, so 2 km on a side.
+SCENE_CRS = "EPSG:32633"
+SCENE_ORIGIN = (500000.0, 5000000.0)
+SCENE_SIZE = 200
+SCENE_RES = 10.0
+TIMESTAMP = dt.datetime(2023, 6, 5, 10, 6, 21, tzinfo=UTC)
+
+
+def write_asset(path, *, size=SCENE_SIZE, res=SCENE_RES, nodata=0, fill=None, count=1):
+    """Write a synthetic single- or multi-band GeoTIFF and return its path."""
+    transform = from_origin(SCENE_ORIGIN[0], SCENE_ORIGIN[1], res, res)
+    if fill is None:
+        band = np.arange(size * size, dtype="uint16").reshape(size, size)
+        data = np.stack([band + offset for offset in range(count)])
+    else:
+        data = np.full((count, size, size), fill, dtype="uint16")
+
+    profile = {
+        "driver": "GTiff",
+        "height": size,
+        "width": size,
+        "count": count,
+        "dtype": "uint16",
+        "crs": SCENE_CRS,
+        "transform": transform,
+    }
+    if nodata is not None:
+        profile["nodata"] = nodata
+    with rio.open(path, "w", **profile) as dst:
+        dst.write(data)
+    return path
+
+
+def utm_to_wgs84(minx, miny, maxx, maxy):
+    """Convert scene-CRS bounds to the WGS 84 lon/lat bbox the API expects."""
+    return transform_bounds(SCENE_CRS, "EPSG:4326", minx, miny, maxx, maxy, densify_pts=21)
+
+
+class FakeAsset:
+    def __init__(self, href):
+        self.href = str(href)
+
+
+class FakeItem:
+    """Minimal stand-in for a pystac Item."""
+
+    def __init__(self, assets, *, timestamp=TIMESTAMP):
+        self.id = "S2A_TEST"
+        self.datetime = timestamp
+        self.collection_id = "sentinel-2-l2a"
+        self.properties = {"eo:cloud_cover": 4.2}
+        self.assets = {name: FakeAsset(href) for name, href in assets.items()}
+        self.bbox = list(utm_to_wgs84(*scene_bounds()))
+
+
+def scene_bounds():
+    """Full extent of the synthetic scene in its own CRS."""
+    left, top = SCENE_ORIGIN
+    span = SCENE_SIZE * SCENE_RES
+    return (left, top - span, left + span, top)
+
+
+@pytest.fixture
+def scene(tmp_path):
+    """A one-band 10 m asset, plus a second 10 m band and a 20 m band."""
+    return {
+        "B04": write_asset(tmp_path / "B04.tif"),
+        "B08": write_asset(tmp_path / "B08.tif", fill=1000),
+        "B11": write_asset(tmp_path / "B11.tif", size=100, res=20.0, fill=500),
+    }
+
+
+@pytest.fixture
+def aoi():
+    """A 400 m box (40 pixels at 10 m) inset from the scene's top-left corner."""
+    left, top = SCENE_ORIGIN
+    return utm_to_wgs84(left + 200.0, top - 600.0, left + 600.0, top - 200.0)
+
+
+def make_item(scene, *, search_bbox=None, assets=None, timestamp=TIMESTAMP):
+    hrefs = scene if assets is None else {name: scene[name] for name in assets}
+    return eeo.io.STACItem(FakeItem(hrefs, timestamp=timestamp), search_bbox=search_bbox)
+
+
+# --------------------------------------------------------------------------
+# Cropping
+# --------------------------------------------------------------------------
+def test_load_crops_to_the_search_aoi_by_default(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load("B04")
+
+    # The AOI is 40x40 pixels of the 200x200 scene; projecting a lon/lat box
+    # into UTM can add a pixel of margin, never a whole tile.
+    height, width = ds.get_shape()
+    assert 40 <= height <= 43
+    assert 40 <= width <= 43
+    assert ds.get_count() == 1
+
+
+def test_cropped_window_covers_the_requested_area(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load("B04")
+
+    left, bottom, right, top = ds.to_rasterio().ds.bounds
+    want = transform_bounds("EPSG:4326", SCENE_CRS, *aoi, densify_pts=21)
+    assert left <= want[0] and bottom <= want[1]
+    assert right >= want[2] and top >= want[3]
+    assert ds.get_crs().to_epsg() == 32633
+
+
+def test_explicit_bbox_overrides_the_search_aoi(scene, aoi):
+    left, top = SCENE_ORIGIN
+    smaller = utm_to_wgs84(left + 200.0, top - 400.0, left + 400.0, top - 200.0)
+
+    ds = make_item(scene, search_bbox=aoi).load("B04", bbox=smaller)
+
+    height, width = ds.get_shape()
+    assert 20 <= height <= 23
+    assert 20 <= width <= 23
+
+
+def test_crop_false_reads_the_whole_scene(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load("B04", crop=False)
+
+    assert ds.get_shape() == (SCENE_SIZE, SCENE_SIZE)
+
+
+def test_no_aoi_anywhere_reads_the_whole_scene(scene):
+    ds = make_item(scene).load("B04")
+
+    assert ds.get_shape() == (SCENE_SIZE, SCENE_SIZE)
+
+
+def test_cropped_values_match_the_source_window(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load("B04")
+
+    with rio.open(scene["B04"]) as src:
+        window = rio.windows.from_bounds(
+            *transform_bounds("EPSG:4326", SCENE_CRS, *aoi, densify_pts=21),
+            transform=src.transform,
+        )
+        expected_corner = src.read(1)[int(window.row_off) + 1, int(window.col_off) + 1]
+
+    assert ds.to_array()[0, 1, 1] == expected_corner
+
+
+def test_aoi_outside_the_scene_raises_validation_error(scene):
+    far_away = (0.0, 0.0, 0.1, 0.1)  # Gulf of Guinea; the scene is in the Alps
+
+    with pytest.raises(eeo.ValidationError, match="does not overlap"):
+        make_item(scene).load("B04", bbox=far_away)
+
+
+def test_aoi_partly_outside_the_scene_is_clipped(scene):
+    left, top = SCENE_ORIGIN
+    overhanging = utm_to_wgs84(left - 1000.0, top - 400.0, left + 400.0, top + 1000.0)
+
+    ds = make_item(scene).load("B04", bbox=overhanging)
+
+    height, width = ds.get_shape()
+    assert height <= SCENE_SIZE and width <= SCENE_SIZE
+    assert height > 0 and width > 0
+
+
+# --------------------------------------------------------------------------
+# Stacking several assets
+# --------------------------------------------------------------------------
+def test_several_assets_stack_into_one_dataset(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load(["B04", "B08"])
+
+    assert ds.get_count() == 2
+    assert ds.band_names == ["B04", "B08"]
+    values = ds.to_array()
+    assert np.all(values[1] == 1000)  # B08 was filled with a constant
+
+
+def test_coarser_asset_is_resampled_onto_the_first_grid(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load(["B04", "B11"])
+
+    # B11 is 20 m; it must come back on B04's 10 m grid, not its own.
+    assert ds.get_count() == 2
+    assert ds.get_shape() == make_item(scene, search_bbox=aoi).load("B04").get_shape()
+    assert np.all(ds.to_array()[1] == 500)
+
+
+def test_first_asset_defines_the_grid(scene, aoi):
+    coarse_first = make_item(scene, search_bbox=aoi).load(["B11", "B04"])
+    fine_first = make_item(scene, search_bbox=aoi).load(["B04", "B11"])
+
+    assert coarse_first.get_shape() != fine_first.get_shape()
+    assert coarse_first.band_names == ["B11", "B04"]
+
+
+def test_multiband_asset_names_its_bands_after_the_asset(tmp_path, aoi):
+    href = write_asset(tmp_path / "visual.tif", count=3)
+    item = eeo.io.STACItem(FakeItem({"visual": href}), search_bbox=aoi)
+
+    ds = item.load("visual")
+
+    assert ds.get_count() == 3
+    assert ds.band_names == ["visual_1", "visual_2", "visual_3"]
+
+
+def test_asset_in_another_crs_is_reprojected_onto_the_first_grid(tmp_path, scene, aoi):
+    # Same ground, UTM zone 32 instead of 33 - a real possibility for assets
+    # from different collections.
+    left, bottom, right, top = transform_bounds(SCENE_CRS, "EPSG:32632", *scene_bounds())
+    other = tmp_path / "zone32.tif"
+    with rio.open(
+        other,
+        "w",
+        driver="GTiff",
+        height=200,
+        width=200,
+        count=1,
+        dtype="uint16",
+        crs="EPSG:32632",
+        transform=from_origin(left, top, (right - left) / 200, (top - bottom) / 200),
+        nodata=0,
+    ) as dst:
+        dst.write(np.full((1, 200, 200), 777, dtype="uint16"))
+
+    item = eeo.io.STACItem(FakeItem({"B04": scene["B04"], "other": other}), search_bbox=aoi)
+    ds = item.load(["B04", "other"])
+
+    assert ds.get_crs().to_epsg() == 32633
+    assert ds.get_count() == 2
+    # The reprojected band lands on the first asset's grid, values intact.
+    assert np.all(ds.to_array()[1] == 777)
+
+
+def test_asset_covering_less_ground_is_filled_with_nodata(tmp_path, scene, aoi):
+    # 300 m asset against a 2 km scene: the AOI only partly overlaps it.
+    partial = write_asset(tmp_path / "partial.tif", size=30, fill=42)
+
+    item = eeo.io.STACItem(FakeItem({"B04": scene["B04"], "partial": partial}), search_bbox=aoi)
+    ds = item.load(["B04", "partial"])
+
+    band = ds.to_array()[1]
+    assert ds.get_shape() == make_item(scene, search_bbox=aoi).load("B04").get_shape()
+    assert (band == 42).any()  # the overlapping part
+    assert (band == 0).any()  # the rest, filled with the asset's nodata
+
+
+def test_cropping_an_unreferenced_asset_raises_validation_error(tmp_path, aoi):
+    plain = tmp_path / "no_crs.tif"
+    with rio.open(
+        plain,
+        "w",
+        driver="GTiff",
+        height=10,
+        width=10,
+        count=1,
+        dtype="uint16",
+        transform=from_origin(0, 10, 1, 1),  # placed, but in no known CRS
+    ) as dst:
+        dst.write(np.ones((1, 10, 10), dtype="uint16"))
+
+    item = eeo.io.STACItem(FakeItem({"plain": plain}), search_bbox=aoi)
+
+    with pytest.raises(eeo.ValidationError, match="no CRS"):
+        item.load("plain")
+
+    # ...but it still reads whole.
+    assert item.load("plain", crop=False).get_shape() == (10, 10)
+
+
+# --------------------------------------------------------------------------
+# Metadata carried onto the dataset
+# --------------------------------------------------------------------------
+def test_load_carries_timestamp_nodata_and_provenance(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load(["B04", "B08"])
+
+    assert ds.timestamp == TIMESTAMP
+    assert ds.get_metadata()["nodata"] == 0
+    assert ds.attrs["stac_item"] == "S2A_TEST"
+    assert ds.attrs["stac_collection"] == "sentinel-2-l2a"
+    assert ds.attrs["stac_assets"] == ["B04", "B08"]
+
+
+def test_loaded_dataset_is_rasterio_backed_and_chainable(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load(["B04", "B08"])
+
+    ndvi = ds.ndvi(red="B04", nir="B08")
+
+    assert ndvi.get_count() == 1
+    assert ndvi.to_array().dtype == np.float32
+    # Provenance survives the chain (the timestamp is what a time series needs).
+    assert ndvi.timestamp == TIMESTAMP
+
+
+def test_dtype_is_the_assets_own(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi).load("B04")
+
+    assert ds.to_array().dtype == np.dtype("uint16")
+
+
+def test_undated_item_loads_without_a_timestamp(scene, aoi):
+    ds = make_item(scene, search_bbox=aoi, timestamp=None).load("B04")
+
+    assert ds.timestamp is None
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_unknown_asset_raises_validation_error_listing_the_available_ones(scene):
+    with pytest.raises(eeo.ValidationError, match="no asset 'B99'"):
+        make_item(scene).load("B99")
+
+    with pytest.raises(eeo.ValidationError, match="B04"):
+        make_item(scene).load("B99")
+
+
+@pytest.mark.parametrize("bad", [[], (), 7])
+def test_invalid_assets_argument_raises_validation_error(scene, bad):
+    with pytest.raises(eeo.ValidationError, match="asset"):
+        make_item(scene).load(bad)
+
+
+def test_bbox_with_crop_false_raises_validation_error(scene, aoi):
+    with pytest.raises(eeo.ValidationError, match="crop=False"):
+        make_item(scene).load("B04", bbox=aoi, crop=False)
+
+
+def test_invalid_bbox_raises_validation_error(scene):
+    with pytest.raises(eeo.ValidationError, match="bbox"):
+        make_item(scene).load("B04", bbox=(1.0, 2.0, 3.0))
+
+
+def test_invalid_resampling_method_raises_validation_error(scene, aoi):
+    with pytest.raises(eeo.ValidationError, match="resampling"):
+        make_item(scene, search_bbox=aoi).load(["B04", "B11"], resampling="teleport")
+
+
+# --------------------------------------------------------------------------
+# Search integration
+# --------------------------------------------------------------------------
+def test_search_result_items_inherit_the_search_aoi(scene, aoi, monkeypatch):
+    import sys
+    import types
+
+    class FakeSearch:
+        def items(self):
+            return iter([FakeItem(scene)])
+
+    class FakeClient:
+        @classmethod
+        def open(cls, url, modifier=None):
+            return cls()
+
+        def search(self, **params):
+            return FakeSearch()
+
+    module = types.ModuleType("pystac_client")
+    module.Client = FakeClient
+    monkeypatch.setitem(sys.modules, "pystac_client", module)
+
+    results = eeo.stac_search("sentinel-2-l2a", bbox=aoi, sign=False)
+
+    assert results[0].search_bbox == pytest.approx(aoi)
+    # ...and loading from the search result crops to it without repeating it.
+    assert results[0].load("B04").get_shape() < (SCENE_SIZE, SCENE_SIZE)

--- a/tests/test_stac_recorded.py
+++ b/tests/test_stac_recorded.py
@@ -1,0 +1,208 @@
+"""Replay recorded STAC responses through the real pystac-client.
+
+``tests/test_stac_search.py`` covers Easy-EO's own logic against a fake client.
+These tests go one layer deeper: real ``pystac_client`` and real ``pystac``
+objects, driven by responses recorded from live catalogs (see
+``tests/data/stac/README.md``), with only the HTTP transport replaced. That is
+what catches a wrong request body or an attribute Easy-EO reads that real STAC
+items do not have — without any network access.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio as rio
+from rasterio.transform import from_origin
+
+import eeo
+from eeo.io import PLANETARY_COMPUTER_STAC_URL
+
+requests = pytest.importorskip("requests", reason="needs the stac extra")
+pytest.importorskip("pystac_client", reason="needs the stac extra")
+
+RECORDINGS = Path(__file__).parent / "data" / "stac"
+EARTH_SEARCH_URL = "https://earth-search.aws.element84.com/v1"
+
+
+def recording(name):
+    return json.loads((RECORDINGS / f"{name}.json").read_text())
+
+
+class ReplayTransport:
+    """Serves recorded documents in place of requests' HTTP transport."""
+
+    def __init__(self, root, page, *, page_status=200):
+        self.root = root
+        self.page = page
+        self.page_status = page_status
+        self.requests = []
+
+    # Assigned onto the Session class; an instance is not a descriptor, so no
+    # `self` for the session is passed in - only the prepared request.
+    def __call__(self, prepared, **kwargs):
+        self.requests.append(prepared)
+        if "/search" in prepared.url:
+            return self._response(self.page, prepared.url, self.page_status)
+        return self._response(self.root, prepared.url)
+
+    @staticmethod
+    def _response(payload, url, status=200):
+        response = requests.Response()
+        response.status_code = status
+        response._content = json.dumps(payload).encode()
+        response.url = url
+        response.headers["Content-Type"] = "application/json"
+        return response
+
+    @property
+    def search_request(self):
+        return next(request for request in self.requests if "/search" in request.url)
+
+
+@pytest.fixture
+def planetary_computer(monkeypatch):
+    transport = ReplayTransport(recording("pc_root"), recording("pc_search_page"))
+    monkeypatch.setattr(requests.Session, "send", transport)
+    return transport
+
+
+@pytest.fixture
+def earth_search(monkeypatch):
+    transport = ReplayTransport(recording("earthsearch_root"), recording("earthsearch_search_page"))
+    monkeypatch.setattr(requests.Session, "send", transport)
+    return transport
+
+
+# --------------------------------------------------------------------------
+# What Easy-EO puts on the wire
+# --------------------------------------------------------------------------
+def test_search_sends_the_filters_the_stac_api_expects(planetary_computer):
+    eeo.stac_search(
+        "sentinel-2-l2a",
+        bbox=(11.0, 46.5, 11.2, 46.7),
+        datetime="2026-07-01/2026-07-31",
+        cloud_cover=20,
+        sign=False,
+    )
+
+    request = planetary_computer.search_request
+    assert request.method == "POST"
+    body = json.loads(request.body)
+    assert body["collections"] == ["sentinel-2-l2a"]
+    assert body["bbox"] == [11.0, 46.5, 11.2, 46.7]
+    # pystac-client expands a bare date range into a full RFC 3339 interval,
+    # and the closing date covers its whole day - so the end is inclusive.
+    assert body["datetime"] == "2026-07-01T00:00:00Z/2026-07-31T23:59:59Z"
+    assert body["query"] == {"eo:cloud_cover": {"lte": 20.0}}
+
+
+def test_search_reaches_the_catalogs_search_endpoint(planetary_computer):
+    eeo.stac_search("sentinel-2-l2a", sign=False)
+
+    assert planetary_computer.search_request.url.startswith(PLANETARY_COMPUTER_STAC_URL)
+    assert planetary_computer.search_request.url.endswith("/search")
+
+
+def test_limit_caps_the_items_returned_not_the_page_size(planetary_computer):
+    # The recorded page holds two items; `limit` has to cut the result to one.
+    results = eeo.stac_search("sentinel-2-l2a", limit=1, sign=False)
+
+    assert len(results) == 1
+
+
+# --------------------------------------------------------------------------
+# What Easy-EO reads back off real pystac items
+# --------------------------------------------------------------------------
+def test_real_items_are_wrapped_and_ordered_oldest_first(planetary_computer):
+    results = eeo.stac_search("sentinel-2-l2a", sign=False)
+
+    assert len(results) == 2
+    # The catalog served these newest-first; Easy-EO re-orders them.
+    assert results.timestamps == sorted(results.timestamps)
+    assert results[0].id == "S2A_MSIL2A_20260721T102041_R065_T32TPS_20260721T170018"
+    assert results[1].id == "S2B_MSIL2A_20260724T101559_R065_T32TPS_20260724T141313"
+
+
+def test_real_item_metadata_is_read_correctly(planetary_computer):
+    item = eeo.stac_search("sentinel-2-l2a", sign=False)[0]
+
+    assert item.collection == "sentinel-2-l2a"
+    assert item.timestamp.tzinfo is not None
+    assert item.timestamp.year == 2026
+    assert item.asset_names == ["B04", "B08", "B11", "SCL"]
+    assert isinstance(item.cloud_cover, float)
+    assert item.bbox is not None and len(item.bbox) == 4
+    # The wrapper does not hide the real thing.
+    assert type(item.item).__name__ == "Item"
+
+
+def test_a_different_catalog_parses_the_same_way(earth_search):
+    results = eeo.stac_search("sentinel-2-l2a", catalog=EARTH_SEARCH_URL)
+
+    assert len(results) == 2
+    assert results.catalog == EARTH_SEARCH_URL
+    assert results[0].asset_names == ["red", "nir", "swir16", "scl"]
+    assert results.timestamps == sorted(results.timestamps)
+
+
+def test_recorded_asset_hrefs_are_usable_urls(planetary_computer):
+    item = eeo.stac_search("sentinel-2-l2a", sign=False)[0]
+
+    href = item.assets["B04"].href
+    assert href.startswith("https://")
+    # Recordings must never carry credentials into the repo.
+    assert "?" not in href
+
+
+# --------------------------------------------------------------------------
+# Loading from a real item
+# --------------------------------------------------------------------------
+def test_load_reads_assets_of_a_real_item(planetary_computer, tmp_path):
+    item = eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7), sign=False)[0]
+
+    # Point the real pystac assets at local rasters: the remote read itself
+    # needs the network, everything around it does not.
+    transform = from_origin(660000.0, 5180000.0, 10.0, 10.0)
+    for name, value in (("B04", 1200), ("B08", 3400)):
+        path = tmp_path / f"{name}.tif"
+        with rio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=100,
+            width=100,
+            count=1,
+            dtype="uint16",
+            crs="EPSG:32632",
+            transform=transform,
+            nodata=0,
+        ) as dst:
+            dst.write(np.full((1, 100, 100), value, dtype="uint16"))
+        item.assets[name].href = str(path)
+
+    scene = item.load(["B04", "B08"], crop=False)
+
+    assert scene.band_names == ["B04", "B08"]
+    assert scene.get_count() == 2
+    assert scene.timestamp == item.timestamp
+    assert scene.attrs["stac_item"] == item.id
+    assert np.all(scene.to_array()[1] == 3400)
+
+
+# --------------------------------------------------------------------------
+# Catalog failures
+# --------------------------------------------------------------------------
+def test_a_failing_catalog_surfaces_the_clients_error(monkeypatch):
+    # Documents today's contract: transport errors propagate from
+    # pystac-client rather than being swallowed.
+    transport = ReplayTransport(
+        recording("pc_root"), {"message": "Gateway Timeout"}, page_status=504
+    )
+    monkeypatch.setattr(requests.Session, "send", transport)
+
+    from pystac_client.exceptions import APIError
+
+    with pytest.raises(APIError):
+        eeo.stac_search("sentinel-2-l2a", sign=False)

--- a/tests/test_stac_search.py
+++ b/tests/test_stac_search.py
@@ -1,0 +1,382 @@
+"""Tests for eeo.stac_search (eeo/io/stac.py).
+
+Every test runs against an injected fake ``pystac_client`` / ``planetary_computer``
+module, so the suite exercises the real search code path with zero network
+access and works whether or not the ``stac`` extra is installed.
+"""
+
+import datetime as dt
+import importlib
+import sys
+import types
+
+import pytest
+
+import eeo
+from eeo.io import PLANETARY_COMPUTER_STAC_URL, STACItem, STACSearchResult
+
+UTC = dt.timezone.utc
+
+
+# --------------------------------------------------------------------------
+# Fake STAC catalog
+# --------------------------------------------------------------------------
+class FakeAsset:
+    def __init__(self, href):
+        self.href = href
+
+
+class FakeItem:
+    def __init__(self, item_id, timestamp, *, properties=None, assets=None, collection="col"):
+        self.id = item_id
+        self.datetime = timestamp
+        self.collection_id = collection
+        self.properties = dict(properties or {})
+        self.assets = assets if assets is not None else {"B04": FakeAsset("https://x/B04.tif")}
+        self.bbox = [11.0, 46.5, 11.2, 46.7]
+
+
+class FakeSearch:
+    def __init__(self, items):
+        self._items = items
+
+    def items(self):
+        return iter(self._items)
+
+
+class FakeClient:
+    """Records how it was opened and searched so tests can assert on it."""
+
+    opened = []
+    searched = []
+    items_to_return = []
+
+    def __init__(self, url, modifier):
+        self.url = url
+        self.modifier = modifier
+
+    @classmethod
+    def open(cls, url, modifier=None):
+        client = cls(url, modifier)
+        cls.opened.append(client)
+        return client
+
+    def search(self, **params):
+        FakeClient.searched.append(params)
+        return FakeSearch(list(FakeClient.items_to_return))
+
+
+def _sign_inplace(item):  # pragma: no cover - identity stand-in for the real signer
+    return item
+
+
+@pytest.fixture
+def fake_stac(monkeypatch):
+    """Install fake pystac_client / planetary_computer modules."""
+    FakeClient.opened = []
+    FakeClient.searched = []
+    FakeClient.items_to_return = []
+
+    pystac_client = types.ModuleType("pystac_client")
+    pystac_client.Client = FakeClient
+    planetary_computer = types.ModuleType("planetary_computer")
+    planetary_computer.sign_inplace = _sign_inplace
+
+    monkeypatch.setitem(sys.modules, "pystac_client", pystac_client)
+    monkeypatch.setitem(sys.modules, "planetary_computer", planetary_computer)
+    return FakeClient
+
+
+def item(item_id, timestamp, **kwargs):
+    return FakeItem(item_id, timestamp, **kwargs)
+
+
+# --------------------------------------------------------------------------
+# Query construction
+# --------------------------------------------------------------------------
+def test_search_passes_collection_bbox_datetime_and_cloud_cover(fake_stac):
+    eeo.stac_search(
+        "sentinel-2-l2a",
+        bbox=(11.0, 46.5, 11.2, 46.7),
+        datetime="2023-06-01/2023-08-31",
+        cloud_cover=20,
+        limit=5,
+    )
+
+    params = fake_stac.searched[0]
+    assert params["collections"] == ["sentinel-2-l2a"]
+    assert params["bbox"] == [11.0, 46.5, 11.2, 46.7]
+    assert params["datetime"] == "2023-06-01/2023-08-31"
+    assert params["query"] == {"eo:cloud_cover": {"lte": 20.0}}
+    # `limit` caps the total item count, not the page size.
+    assert params["max_items"] == 5
+    assert "limit" not in params
+
+
+def test_search_accepts_several_collections(fake_stac):
+    eeo.stac_search(["sentinel-2-l2a", "landsat-c2-l2"])
+
+    assert fake_stac.searched[0]["collections"] == ["sentinel-2-l2a", "landsat-c2-l2"]
+
+
+def test_search_omits_unset_filters(fake_stac):
+    eeo.stac_search("sentinel-2-l2a")
+
+    assert fake_stac.searched[0] == {"collections": ["sentinel-2-l2a"]}
+
+
+def test_search_accepts_datetime_objects_and_pairs(fake_stac):
+    start, end = dt.datetime(2023, 6, 1, tzinfo=UTC), dt.datetime(2023, 8, 31, tzinfo=UTC)
+
+    eeo.stac_search("sentinel-2-l2a", datetime=(start, end))
+
+    assert fake_stac.searched[0]["datetime"] == (start, end)
+
+
+def test_search_defaults_to_planetary_computer(fake_stac):
+    eeo.stac_search("sentinel-2-l2a")
+
+    assert fake_stac.opened[0].url == PLANETARY_COMPUTER_STAC_URL
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("bad", ["", [], ["sentinel-2-l2a", ""], 3])
+def test_invalid_collection_raises_validation_error(fake_stac, bad):
+    with pytest.raises(eeo.ValidationError, match="collection"):
+        eeo.stac_search(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        (11.0, 46.5, 11.2),  # too few values
+        (11.0, 46.5, 11.2, 46.7, 1.0),  # too many
+        (11.2, 46.5, 11.0, 46.7),  # minx >= maxx
+        (11.0, 46.7, 11.2, 46.5),  # miny >= maxy
+        "11,46,12,47",  # a string is not a bbox
+    ],
+)
+def test_invalid_bbox_raises_validation_error(fake_stac, bad):
+    with pytest.raises(eeo.ValidationError, match="bbox"):
+        eeo.stac_search("sentinel-2-l2a", bbox=bad)
+
+
+@pytest.mark.parametrize("bad", [-1, 101])
+def test_invalid_cloud_cover_raises_validation_error(fake_stac, bad):
+    with pytest.raises(eeo.ValidationError, match="cloud_cover"):
+        eeo.stac_search("sentinel-2-l2a", cloud_cover=bad)
+
+
+@pytest.mark.parametrize("good", [0, 100])
+def test_cloud_cover_bounds_are_inclusive(fake_stac, good):
+    eeo.stac_search("sentinel-2-l2a", cloud_cover=good)
+
+    assert fake_stac.searched[0]["query"] == {"eo:cloud_cover": {"lte": float(good)}}
+
+
+@pytest.mark.parametrize("bad", [0, -3, 2.5, True])
+def test_invalid_limit_raises_validation_error(fake_stac, bad):
+    with pytest.raises(eeo.ValidationError, match="limit"):
+        eeo.stac_search("sentinel-2-l2a", limit=bad)
+
+
+def test_validation_happens_before_any_network_call(fake_stac):
+    with pytest.raises(eeo.ValidationError):
+        eeo.stac_search("sentinel-2-l2a", cloud_cover=200)
+
+    assert fake_stac.opened == []
+
+
+# --------------------------------------------------------------------------
+# Ordering and timestamps (Milestone 3 constraint)
+# --------------------------------------------------------------------------
+def test_results_are_ordered_oldest_first(fake_stac):
+    fake_stac.items_to_return = [
+        item("b", dt.datetime(2023, 7, 1, tzinfo=UTC)),
+        item("c", dt.datetime(2023, 8, 1, tzinfo=UTC)),
+        item("a", dt.datetime(2023, 6, 1, tzinfo=UTC)),
+    ]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert [r.id for r in results] == ["a", "b", "c"]
+    assert results.timestamps == [
+        dt.datetime(2023, 6, 1, tzinfo=UTC),
+        dt.datetime(2023, 7, 1, tzinfo=UTC),
+        dt.datetime(2023, 8, 1, tzinfo=UTC),
+    ]
+
+
+def test_naive_and_aware_timestamps_sort_together(fake_stac):
+    fake_stac.items_to_return = [
+        item("aware", dt.datetime(2023, 7, 1, tzinfo=UTC)),
+        item("naive", dt.datetime(2023, 6, 1)),
+    ]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert [r.id for r in results] == ["naive", "aware"]
+
+
+def test_undated_items_sort_last_and_report_none(fake_stac):
+    fake_stac.items_to_return = [
+        item("undated", None),
+        item("dated", dt.datetime(2023, 6, 1, tzinfo=UTC)),
+    ]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert [r.id for r in results] == ["dated", "undated"]
+    assert results[-1].timestamp is None
+
+
+def test_range_items_fall_back_to_start_datetime(fake_stac):
+    fake_stac.items_to_return = [
+        item("range", None, properties={"start_datetime": "2023-06-01T10:00:00Z"})
+    ]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert results[0].timestamp == dt.datetime(2023, 6, 1, 10, 0, tzinfo=UTC)
+
+
+def test_string_timestamps_are_parsed(fake_stac):
+    fake_stac.items_to_return = [item("s", "2023-06-05T10:06:21Z")]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert results[0].timestamp == dt.datetime(2023, 6, 5, 10, 6, 21, tzinfo=UTC)
+
+
+def test_unparseable_timestamp_becomes_none_instead_of_failing(fake_stac):
+    fake_stac.items_to_return = [item("bad", "not-a-date")]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert results[0].timestamp is None
+
+
+# --------------------------------------------------------------------------
+# Result and item surface
+# --------------------------------------------------------------------------
+def test_empty_result_is_not_an_error(fake_stac):
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert isinstance(results, STACSearchResult)
+    assert len(results) == 0
+    assert list(results) == []
+    assert "0 items" in repr(results)
+
+
+def test_result_is_a_sequence(fake_stac):
+    fake_stac.items_to_return = [
+        item(name, dt.datetime(2023, 6, day, tzinfo=UTC))
+        for day, name in enumerate(["a", "b", "c"], start=1)
+    ]
+
+    results = eeo.stac_search("sentinel-2-l2a")
+
+    assert len(results) == 3
+    assert isinstance(results[0], STACItem)
+    assert [r.id for r in results] == ["a", "b", "c"]
+    assert results.collections == ["sentinel-2-l2a"]
+    assert results.catalog == PLANETARY_COMPUTER_STAC_URL
+    assert "3 items" in repr(results)
+    assert "2023-06-01 to 2023-06-03" in repr(results)
+
+
+def test_result_retains_the_search_area_of_interest(fake_stac):
+    results = eeo.stac_search("sentinel-2-l2a", bbox=(11.0, 46.5, 11.2, 46.7))
+
+    # Retained so a later asset read can crop to the same AOI.
+    assert results.bbox == (11.0, 46.5, 11.2, 46.7)
+    assert results[:1].bbox == (11.0, 46.5, 11.2, 46.7)
+    assert eeo.stac_search("sentinel-2-l2a").bbox is None
+
+
+def test_slicing_returns_a_search_result(fake_stac):
+    fake_stac.items_to_return = [
+        item(name, dt.datetime(2023, 6, day, tzinfo=UTC))
+        for day, name in enumerate(["a", "b", "c"], start=1)
+    ]
+
+    subset = eeo.stac_search("sentinel-2-l2a")[:2]
+
+    assert isinstance(subset, STACSearchResult)
+    assert [r.id for r in subset] == ["a", "b"]
+    assert subset.collections == ["sentinel-2-l2a"]
+
+
+def test_item_exposes_metadata_and_the_raw_item(fake_stac):
+    raw = item(
+        "S2A_TEST",
+        dt.datetime(2023, 6, 5, 10, 6, 21, tzinfo=UTC),
+        properties={"eo:cloud_cover": 4.2, "platform": "sentinel-2a"},
+        assets={"B04": FakeAsset("https://x/B04.tif"), "B08": FakeAsset("https://x/B08.tif")},
+        collection="sentinel-2-l2a",
+    )
+    fake_stac.items_to_return = [raw]
+
+    found = eeo.stac_search("sentinel-2-l2a")[0]
+
+    assert found.id == "S2A_TEST"
+    assert found.collection == "sentinel-2-l2a"
+    assert found.cloud_cover == pytest.approx(4.2)
+    assert found.properties["platform"] == "sentinel-2a"
+    assert found.asset_names == ["B04", "B08"]
+    assert found.assets["B08"].href == "https://x/B08.tif"
+    assert found.bbox == (11.0, 46.5, 11.2, 46.7)
+    assert found.item is raw
+    assert "S2A_TEST" in repr(found)
+
+
+def test_item_without_cloud_cover_reports_none(fake_stac):
+    fake_stac.items_to_return = [item("a", dt.datetime(2023, 6, 1, tzinfo=UTC))]
+
+    assert eeo.stac_search("sentinel-2-l2a")[0].cloud_cover is None
+
+
+# --------------------------------------------------------------------------
+# Asset-URL signing
+# --------------------------------------------------------------------------
+def test_planetary_computer_assets_are_signed_by_default(fake_stac):
+    eeo.stac_search("sentinel-2-l2a")
+
+    assert fake_stac.opened[0].modifier is _sign_inplace
+
+
+def test_signing_can_be_disabled(fake_stac):
+    eeo.stac_search("sentinel-2-l2a", sign=False)
+
+    assert fake_stac.opened[0].modifier is None
+
+
+def test_other_catalogs_are_not_signed(fake_stac):
+    eeo.stac_search("sentinel-2-l2a", catalog="https://earth-search.aws.element84.com/v1")
+
+    assert fake_stac.opened[0].modifier is None
+
+
+def test_signing_can_be_forced_for_any_catalog(fake_stac):
+    eeo.stac_search("sentinel-2-l2a", catalog="https://example.com/stac", sign=True)
+
+    assert fake_stac.opened[0].modifier is _sign_inplace
+
+
+# --------------------------------------------------------------------------
+# Missing extra
+# --------------------------------------------------------------------------
+def test_search_without_the_stac_extra_raises_missing_dependency_error(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name):
+        if name == "pystac_client":
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        return real_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(eeo.MissingDependencyError, match=r"pip install 'easy-eo\[stac\]'"):
+        eeo.stac_search("sentinel-2-l2a")

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -92,6 +101,93 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
+    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -450,6 +546,10 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+stac = [
+    { name = "planetary-computer" },
+    { name = "pystac-client" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -457,13 +557,15 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "numpy", specifier = ">=1.26,<3" },
+    { name = "planetary-computer", marker = "extra == 'stac'", specifier = ">=1.0,<2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
+    { name = "pystac-client", marker = "extra == 'stac'", specifier = ">=0.8,<1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "rasterio", specifier = ">=1.4,<2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["stac", "dev"]
 
 [[package]]
 name = "exceptiongroup"
@@ -574,12 +676,49 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1489,6 +1628,25 @@ wheels = [
 ]
 
 [[package]]
+name = "planetary-computer"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pystac" },
+    { name = "pystac-client" },
+    { name = "python-dotenv" },
+    { name = "pytz" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/d3/ccfb0e823e9beb72b7e6b749f0985c4db1530d4e4a145b1b5d12f5de417e/planetary-computer-1.0.0.tar.gz", hash = "sha256:5958a8e1d8ba1aafc7ac45878df2d7d03405806ae31ed2e675333faebca960cc", size = 17076, upload-time = "2023-07-05T13:06:58.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/7a/3965a2b58d172e106c1064af19707d29f86a0142c28ff40185490a0a8cfe/planetary_computer-1.0.0-py3-none-any.whl", hash = "sha256:7af5839f9346c1d23d53fff4e80e955db18a2d81992877816e22dcbc2f90c40d", size = 14163, upload-time = "2023-07-05T13:06:57.06Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1520,6 +1678,137 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -1699,6 +1988,335 @@ wheels = [
 ]
 
 [[package]]
+name = "pystac"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+    { name = "pystac-ext-classification" },
+    { name = "pystac-ext-datacube" },
+    { name = "pystac-ext-eo" },
+    { name = "pystac-ext-file" },
+    { name = "pystac-ext-grid" },
+    { name = "pystac-ext-item-assets" },
+    { name = "pystac-ext-label" },
+    { name = "pystac-ext-mgrs" },
+    { name = "pystac-ext-mlm" },
+    { name = "pystac-ext-pointcloud" },
+    { name = "pystac-ext-projection" },
+    { name = "pystac-ext-raster" },
+    { name = "pystac-ext-render" },
+    { name = "pystac-ext-sar" },
+    { name = "pystac-ext-sat" },
+    { name = "pystac-ext-scientific" },
+    { name = "pystac-ext-storage" },
+    { name = "pystac-ext-table" },
+    { name = "pystac-ext-timestamps" },
+    { name = "pystac-ext-version" },
+    { name = "pystac-ext-view" },
+    { name = "pystac-ext-xarray-assets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/f8/d792facb89e85d1e7d7d94e819477296486e5d227c5b755fef827bc441c2/pystac-1.15.1.tar.gz", hash = "sha256:0975f78ac648b89f180378089fdd358006c0dc5d974db57c6f8fa81c4162f5d5", size = 5549, upload-time = "2026-06-30T21:48:54.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/7d/b3a4dd7f5c7873c4e884c26bd6fd7b7791036b31ef82bb5eca7f12c3acaa/pystac-1.15.1-py3-none-any.whl", hash = "sha256:3a1be7a1d819a3dadfa6612be0035fec62ceb38d64acdc9cef66649d03eb84da", size = 5079, upload-time = "2026-06-30T21:48:53.3Z" },
+]
+
+[package.optional-dependencies]
+validation = [
+    { name = "jsonschema" },
+]
+
+[[package]]
+name = "pystac-client"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac", extra = ["validation"] },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8d/b98aeffd325fc208e1624cf586d0c4dfb927bc7a2bce20d3b58ee80d2483/pystac_client-0.9.0.tar.gz", hash = "sha256:3908951583bcc6a3aaaf2828024a8e03764e6ca9d9f9f1d8149df587e14dd744", size = 52339, upload-time = "2025-07-18T15:44:41.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/d2/5f6367b14c9f250d1a6725d18bd1e9584f5ab1587e292f3a847e59189598/pystac_client-0.9.0-py3-none-any.whl", hash = "sha256:eed146b5980f93646aaa3a59080f11f1dcab6000b0bfbc28b1d0c6fd0a61eda1", size = 41826, upload-time = "2025-07-18T15:44:40.197Z" },
+]
+
+[[package]]
+name = "pystac-core"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/74/8f95e14d899748d4c340783f9c45089e2a011075a480d332561d605af054/pystac_core-1.15.1.tar.gz", hash = "sha256:c24e50176035cc49b99a40a13da12115cab0b05c97ebac64c5e3ca8330d47b41", size = 95327, upload-time = "2026-06-30T21:49:04.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/4c/108088b03de051de59153ad52ff2ac586ff3b2b20a8f6546f19f91ba103c/pystac_core-1.15.1-py3-none-any.whl", hash = "sha256:69c504dd42da77e741f7f54f18a1deeb8122b8817a5aa2827767459a2f9cfae0", size = 119040, upload-time = "2026-06-30T21:49:02.763Z" },
+]
+
+[[package]]
+name = "pystac-ext-classification"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/ef/4ae97a54de23f84f8ca9637a73efc42dfc343881a9ce159ff40f7dc5c5ce/pystac_ext_classification-2.0.0.tar.gz", hash = "sha256:b744d42eb74fa5038cf00896f3cf4fbb85b79cf208454b7401bd8219e491eb94", size = 21154, upload-time = "2026-06-25T15:49:41.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/d3/f19b3e52938785e3540e5515ba0453291700729d7fa6863c6c07c3faf6bc/pystac_ext_classification-2.0.0-py3-none-any.whl", hash = "sha256:fe8c94fd83b2402cb314f608e835d45d70397614928d6cbb29b12d4728586abd", size = 7036, upload-time = "2026-06-25T15:49:40.585Z" },
+]
+
+[[package]]
+name = "pystac-ext-datacube"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/bc/77eb864cc837ce95c36b67b94f9b102ab6ecc6889a6c131a382f6c5afd08/pystac_ext_datacube-2.2.0.tar.gz", hash = "sha256:a64643cb826c3f2f169c7497b5e5ba218f0a1ababbbd3bad04c57f99df3a67c7", size = 22016, upload-time = "2026-06-25T15:49:43.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/12/f988dea7251ba3bb089fa9012ebb459b1229b35da23eedf53a9a0e05faed/pystac_ext_datacube-2.2.0-py3-none-any.whl", hash = "sha256:823538db9751b6e7312a06ec9b6a74f98561830664f45ed43908bea73f624f16", size = 6824, upload-time = "2026-06-25T15:49:42.815Z" },
+]
+
+[[package]]
+name = "pystac-ext-eo"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f3/b15b8919d6849b4c94ddef1f3dcf12a6c69d3674d9f67e62ced31483f43e/pystac_ext_eo-1.1.0.tar.gz", hash = "sha256:c599b1f4a470eceefb745b26f4dabea05661e843d26c8c59f0d7343b6ac9ab35", size = 21113, upload-time = "2026-06-25T15:49:47.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/39/6bc20044e0513bb290a871aba05608b945f261d294c2cdc78207e98a1938/pystac_ext_eo-1.1.0-py3-none-any.whl", hash = "sha256:ca367465d37bc65d9a4c0cd54c4a04a45deb9904d55ae2c1f37d11734cc38ca0", size = 7366, upload-time = "2026-06-25T15:49:46.629Z" },
+]
+
+[[package]]
+name = "pystac-ext-file"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/37/e8a111a9ba9547bd36a3a2cab3b6797115b57ed518d21b51d7447463ea5c/pystac_ext_file-2.1.0.tar.gz", hash = "sha256:93964df13550d0b016770774a6608728928f3a2c8d92ae03dc2f11bd76dbc6f0", size = 12979, upload-time = "2026-06-25T15:49:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/e1/2d5b893323fdc7ca64e58464f6eea91158d0dcfd76a1463c4d9390fcf34b/pystac_ext_file-2.1.0-py3-none-any.whl", hash = "sha256:90b91c82155f763143de2daf1aec37dd0e7f98da7f39f6636a4ede590be9f322", size = 5485, upload-time = "2026-06-25T15:49:52.11Z" },
+]
+
+[[package]]
+name = "pystac-ext-grid"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/0f/a59e46a04e36668e9ae52da4493786f0a0af3513020551e784947ab9efe1/pystac_ext_grid-1.1.0.tar.gz", hash = "sha256:0b8855ff3ddb278bf6f2caf01bb857da50cf23bc322d0722f93b206b7f3673f6", size = 9086, upload-time = "2026-06-25T15:49:48.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/a4/43d317a422528090320166a908f9d110384d67ac2f30353a4a331e990151/pystac_ext_grid-1.1.0-py3-none-any.whl", hash = "sha256:6c8c804a07b4c1fc9dc4058a16d4ec18d7715883a183555c826d312830018db1", size = 3319, upload-time = "2026-06-25T15:49:46.927Z" },
+]
+
+[[package]]
+name = "pystac-ext-item-assets"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/93/fd0d0251ac227b654dabffc15bafad69600c91edf0472d1bba48096cd1c5/pystac_ext_item_assets-1.0.0.tar.gz", hash = "sha256:63b063ae3b0c9508ad84aa06c85513fb2ca09f505ee2aed1a8a1f0c3a906d070", size = 3908, upload-time = "2026-06-25T15:49:56.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/63/eca6602e084b1bd764fe0c7e6e5efa351bb6ad5432aaab2a3d56cb1fdbc9/pystac_ext_item_assets-1.0.0-py3-none-any.whl", hash = "sha256:4dd61fcaeb861f1bd0c77299d9e3332865bfded44e061206fc0bb9fd8ce8d156", size = 3418, upload-time = "2026-06-25T15:49:54.905Z" },
+]
+
+[[package]]
+name = "pystac-ext-label"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/e4/b3c010715ec522735f5c5393f685cadf55a687b47c9084fe4ae82bd9c41c/pystac_ext_label-1.0.1.tar.gz", hash = "sha256:34e52bbc79d46a5a0f76833ce0f656de65b425a41ca362e705be68430196abc7", size = 8339, upload-time = "2026-06-25T15:49:51.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/f5/583b8f20f8c041fb3decb36ab4b5be703f64cc84883ef152373f9a075a99/pystac_ext_label-1.0.1-py3-none-any.whl", hash = "sha256:9b089b290ce953916cd087a86d108262cf74ca39d0f00e27af6eeaf1ab2be167", size = 7871, upload-time = "2026-06-25T15:49:50.341Z" },
+]
+
+[[package]]
+name = "pystac-ext-mgrs"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/5f54dccb399f0246e12d5b2a9c1ca5269f1adcf993a3812ecf897663e004/pystac_ext_mgrs-1.0.0.tar.gz", hash = "sha256:31d79b288f2523640138aff1b12acd2b67d7a40b1822909a04700fb048861d11", size = 6610, upload-time = "2026-06-25T15:49:54.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c2/aa4c889ffbd5d95b9cbcb78163399feb51eae3968f387f87f26efef2bf59/pystac_ext_mgrs-1.0.0-py3-none-any.whl", hash = "sha256:4efe67b4dac4fb7c3057985a056e59275371c535d84c82d0a55f110f9144f9f0", size = 3849, upload-time = "2026-06-25T15:49:53.206Z" },
+]
+
+[[package]]
+name = "pystac-ext-mlm"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/5c/7b540355fc4be970f076047a222216f2af513870ebfca53c48242de5e078/pystac_ext_mlm-1.4.0.tar.gz", hash = "sha256:fdaf464e729071348b3921e908dbe3c2e1cce5d65153ee19995e2e7315e9edf9", size = 35919, upload-time = "2026-06-25T15:49:53.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/65/a4f7b03201993bd647a3260d9b1663b1d0d28145d35bc69562334ef49a28/pystac_ext_mlm-1.4.0-py3-none-any.whl", hash = "sha256:69dac825477b7dd458ad5392aa72188377b267f267b6b28a60e883daed0ef252", size = 13599, upload-time = "2026-06-25T15:49:52.664Z" },
+]
+
+[[package]]
+name = "pystac-ext-pointcloud"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/51/cf14464aad24d1547dd0e5c06bcfba9627a0b0510d8ec147e17a7c90c2de/pystac_ext_pointcloud-1.0.0.tar.gz", hash = "sha256:92a4bc88fe6eb15ad27c75358b1dbf5bf40ded26df4cd6b8bfc16a4c9a838764", size = 12581, upload-time = "2026-06-25T15:49:59.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/e9/783c234f711661603c21c5c83c6cbb41efcb2cd0ca791cf27316498088b2/pystac_ext_pointcloud-1.0.0-py3-none-any.whl", hash = "sha256:3bc688b3da93dc0dbf91b357026eb7648ec3e49a3008003859648b80dfb55732", size = 6166, upload-time = "2026-06-25T15:49:58.81Z" },
+]
+
+[[package]]
+name = "pystac-ext-projection"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/55/2d2230a5bb55d9e954338e71c5fd469ff63097532f2b45fa219f607c075a/pystac_ext_projection-2.0.0.tar.gz", hash = "sha256:72517587636c3d0f325cf11dfa75e0431570c6a13305bf53d0f95b2548deec1f", size = 72074, upload-time = "2026-06-25T15:50:02.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/27/cede1d2f621f4c399ee2434072bf5a8bba0e3b0e3369547664f343e0ed84/pystac_ext_projection-2.0.0-py3-none-any.whl", hash = "sha256:892e9852a1a81cf1be1b79e3ad52e9b11f780143d3a75d67cde3e4fd31ec83e4", size = 7114, upload-time = "2026-06-25T15:50:00.785Z" },
+]
+
+[[package]]
+name = "pystac-ext-raster"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/04/2459cd1a4b954fc3320594ef86e6f4379f15d0cf4a63259852fb4b4a9b5b/pystac_ext_raster-1.1.0.tar.gz", hash = "sha256:19dd7c993defe450fa90b3fd690f30a6191b701fc704f1626748bdb57d9da1ed", size = 30679, upload-time = "2026-06-25T15:50:05.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/1e/9bced0383702b1ceb240a4aa4c32f0f4f76f6666325a7d35c3e499ef1104/pystac_ext_raster-1.1.0-py3-none-any.whl", hash = "sha256:07c312ae956d70ccdb1da7af67fc92793c2546ca8e26ca384013ebf5c674b410", size = 6567, upload-time = "2026-06-25T15:50:04.448Z" },
+]
+
+[[package]]
+name = "pystac-ext-render"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/ba/e8711c8b46719f4d8e74fd73c5ae66fa5cd0b79e0dc7770d00bc1d14adcf/pystac_ext_render-2.0.0.tar.gz", hash = "sha256:ed53926d0af556c98d5f6bbfd86b8d02d635df24b70607f37f386cea7713b4f7", size = 9611, upload-time = "2026-06-25T15:50:00.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/63/3162c536d3f3cacf627b7a74915dc90abb10cf3baa5ed9b28b3b92b5914c/pystac_ext_render-2.0.0-py3-none-any.whl", hash = "sha256:69c3a8307d9528b8ae5baadde76dae9e546c19c1f4210a57daf235f8e9d9e427", size = 5020, upload-time = "2026-06-25T15:49:59.974Z" },
+]
+
+[[package]]
+name = "pystac-ext-sar"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/30/e229a96be9e03157c92eb7f3bfafbd84702372bd1a7ed23e734094c48ead/pystac_ext_sar-1.0.0.tar.gz", hash = "sha256:0d49130fc55152f039f22ac843df35e1c5b2a1a667a4ee91d4a9c5b3ecd379ca", size = 11122, upload-time = "2026-06-25T15:50:01.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/75/8d62c8d697740c01c01d707446b53b332a466d6caf174187588000daa9a8/pystac_ext_sar-1.0.0-py3-none-any.whl", hash = "sha256:4b73d97e4c1cdba1c1d6cc1d69181fed31eefb0ec164500b636d6a8d8bca271c", size = 6262, upload-time = "2026-06-25T15:50:00.762Z" },
+]
+
+[[package]]
+name = "pystac-ext-sat"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/d7/0492bae1d417dc4990748183a950fd1e6acbc202a2b11bbb73cc75a37f34/pystac_ext_sat-1.0.0.tar.gz", hash = "sha256:2163b31d3044f9c2965abd9cb4144482813068ff9f99107a240eed06cf78bace", size = 9875, upload-time = "2026-06-25T15:50:12.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/ca/20d80d50b5108f649383568d3c103e9cc0cf12e53f283562f9dfc1774dd3/pystac_ext_sat-1.0.0-py3-none-any.whl", hash = "sha256:ee951eee24b47c576863bbf5890957b7094a6a2bb0ef8fc967a4d327dff571fd", size = 4576, upload-time = "2026-06-25T15:50:11.303Z" },
+]
+
+[[package]]
+name = "pystac-ext-scientific"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/f6/1bf1ec97be09266a258f53620020573d8321956e390361daa81d0905b9ae/pystac_ext_scientific-1.0.0.tar.gz", hash = "sha256:b55128b7b2281c28dcfc3c00c008fe4391c84b47a7572c4770766f1e96eec5b5", size = 12764, upload-time = "2026-06-25T15:50:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f7/cde7d45905f4f15449f142c7d6f81de488b3920bf3fb063b2382d1ffefba/pystac_ext_scientific-1.0.0-py3-none-any.whl", hash = "sha256:1f78efcd34a4b4344c70d80ddcde70785815e738455e3c1d35b5e843ca671207", size = 5174, upload-time = "2026-06-25T15:50:05.179Z" },
+]
+
+[[package]]
+name = "pystac-ext-storage"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/dc/57f0dfa715f6bdc0de1830359969ffb019424838c875f899c011fdbf2af0/pystac_ext_storage-2.0.0.tar.gz", hash = "sha256:58b28988e49a188cc8ee09e8bc88440aec9985f0d3ccd295b6209215896e4250", size = 13063, upload-time = "2026-06-25T15:50:08.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/af/5aaa33cf912da18e178c7bc15633c3c9f1cc9a22efcad7f78964136e4e14/pystac_ext_storage-2.0.0-py3-none-any.whl", hash = "sha256:8f1d809a8f5efebe051450fcfce3ae13ef4c7ad9133b43b2a1f4df69e74645c2", size = 7353, upload-time = "2026-06-25T15:50:07.687Z" },
+]
+
+[[package]]
+name = "pystac-ext-table"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/06/d4ad9edaf4bae2922cf86a6ac216375d530fa70e4f13bff28b52c595a2d1/pystac_ext_table-1.2.0.tar.gz", hash = "sha256:c7035db662272a84f1149e7d694c8409f85093cc056cdc655c06e9b9f5cefe37", size = 8003, upload-time = "2026-06-25T15:50:09.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/52/6209f65f1b4f966525486b7eb39f82f1cd0f8aae592e52c679b520e969ea/pystac_ext_table-1.2.0-py3-none-any.whl", hash = "sha256:461e8475eaee81190c36db818150e0b24d14d46b021f063a928ff6a0ee77a971", size = 4430, upload-time = "2026-06-25T15:50:08.808Z" },
+]
+
+[[package]]
+name = "pystac-ext-timestamps"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/74/97061e036f74c850b63450ab425f7c1aa2681582ce53b98ed4f7235acc7b/pystac_ext_timestamps-1.1.0.tar.gz", hash = "sha256:d78250e3ddc61b825348444ad05c8cff8c2aa1cd3d18155b880783ee880520d3", size = 8544, upload-time = "2026-06-25T15:50:18.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/22/d0e9f1e46da156c34e070ba04ebca1bba67b4b60724118cfb98c0b83b368/pystac_ext_timestamps-1.1.0-py3-none-any.whl", hash = "sha256:17990ad4827bfd0798010d247fa2f3d770f78d80180579cbe63d8267fb3e8d39", size = 4252, upload-time = "2026-06-25T15:50:17.677Z" },
+]
+
+[[package]]
+name = "pystac-ext-version"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/48/0d67ffdc3c930cd64805e15603372f2a759d2ad453f31d979fefda637999/pystac_ext_version-1.2.0.tar.gz", hash = "sha256:aac23024e76cd64c9bec46a8b49f884f2e8c89cc3d0fe317f5f58dfaa56d1aa0", size = 12543, upload-time = "2026-06-25T15:50:19.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/bb/c0a732f1827233e91200b4c14538e8cc4dafa9e843c46c048462212e2b72/pystac_ext_version-1.2.0-py3-none-any.whl", hash = "sha256:95ba628abe934098356654f2bd57423475d1cb59e2f49c44dd7e2ef5392efefd", size = 5366, upload-time = "2026-06-25T15:50:18.547Z" },
+]
+
+[[package]]
+name = "pystac-ext-view"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/1d/663184b0c94583ed2c3d2fbe1f1b3ab8da27ee7ff5695da2d0d42652e610/pystac_ext_view-1.0.0.tar.gz", hash = "sha256:cb677dcd49f9a62824087d150f01eea97fc24c577971edb60374c9e48e517311", size = 9698, upload-time = "2026-06-25T15:50:11.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/1f/aab5f54ee091b47b6edf22dea97863c36996ca7886b32e8772374fcbb5e9/pystac_ext_view-1.0.0-py3-none-any.whl", hash = "sha256:3000615569d1826093a6b231778e7ddb1afb106dd516e8029a0083bfcd166d7d", size = 4479, upload-time = "2026-06-25T15:50:10.359Z" },
+]
+
+[[package]]
+name = "pystac-ext-xarray-assets"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pystac-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/a0/1bcb9ba80eb0e0a6cc4605520d831d7118863559f13f797f271430bad125/pystac_ext_xarray_assets-1.0.0.tar.gz", hash = "sha256:da4f4877c018d531b6b5c45f20bc64842f14587ae86bac8d2acf110804c773d1", size = 6703, upload-time = "2026-06-25T15:50:18.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/cc/4f310e5acb0c59c8b3db417fc903a055dc01ac7e7f7e82c941304f30b4d9/pystac_ext_xarray_assets-1.0.0-py3-none-any.whl", hash = "sha256:a31e90e7e9bc5ae191e7449df28c39857c818e8c1cf2c09a2eceaa7c6e13241c", size = 3614, upload-time = "2026-06-25T15:50:17.871Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1753,6 +2371,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1953,6 +2580,298 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
@@ -2119,12 +3038,33 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds STAC-based satellite data access with optional dependency support, searchable catalog results, lazy remote asset loading, AOI-aware cropping, and offline-safe test coverage. The implementation supports both bounding-box and geometry-based spatial queries, preserves dataset information and band metadata, and provides a quickstart for searching and loading satellite data directly into Easy-EO workflows.

## Related issues / tasks

- Completes **STAC Data Access**

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behavior is stated in the docstring and covered by a test
- [x] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

- Added the optional `easy-eo[stac]` extra with `pystac-client` and
  `planetary-computer`, including a clear `MissingDependencyError` when the
  optional dependencies are unavailable.
- Added `eeo.stac_search()` for querying STAC catalogs with filters for
  collections, bbox, datetime, cloud cover, and GeoJSON-compatible
  `intersects` geometries.
- Search results are ordered by timestamp and expose convenient metadata such
  as collections, timestamps, assets, bounding boxes, and catalog information.
- Added `STACItem.load()` for loading remote raster assets using HTTP range
  requests rather than downloading entire scenes.
- STAC loads crop to the requested AOI by default, with support for explicit
  `bbox`, `crop=False`, and geometry-based `mask=True` workflows.
- Added automatic reprojection and grid alignment when loading multiple assets,
  including support for different CRSs, resolutions, offsets, and partially
  overlapping assets.
- Band names, timestamps, and STAC item/collection/asset provenance are carried
  into the resulting `EEORasterDataset`.
- Added recorded-response and mocked tests so the default test suite performs
  zero live network access. Network tests remain explicitly opt-in.
- Added a satellite-data quickstart and detailed documentation covering search
  filters, asset naming across catalogs, AOI handling, multi-asset loading,
  catalog differences, and remote-data caveats.
- Documented important STAC/catalog behaviours discovered during live
  verification, including inclusive datetime handling, approximate cloud-cover
  filtering, reprocessed duplicates, neighbouring tile matches, and
  requester-pays assets.