### PR TITLE
fix(README): corrected the cmap of the DEM plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ with `python scripts/build_gallery.py`.
 | <img src=".github/assets/gallery/composite_true_colour.jpg" alt="True colour composite of a Sentinel-2 scene"> | <img src=".github/assets/gallery/composite_false_colour.jpg" alt="False colour composite, vegetation in red"> |
 | `scene.plot_composite(["red", "green", "blue"])` | `scene.plot_composite(["nir", "red", "green"])` |
 | <img src=".github/assets/gallery/index_ndvi.jpg" alt="NDVI map on a red-yellow-green colour scale"> | <img src=".github/assets/gallery/dem_terrain.jpg" alt="Copernicus DEM elevation map"> |
-| `scene.ndvi(red="red", nir="nir", name="NDVI").plot_raster(cmap="RdYlGn")` | `dem.plot_raster(cmap="YlOrBr")` - the same call on a DEM |
+| `scene.ndvi(red="red", nir="nir", name="NDVI").plot_raster(cmap="RdYlGn")` | `dem.plot_raster(cmap="Spectral_r")` - the same call on a DEM |
 | <img src=".github/assets/gallery/histogram_bands.png" alt="Value distribution of each of the four bands"> | <img src=".github/assets/gallery/clip_ndvi_histogram.png" alt="NDVI clipped to a hexagonal boundary beside its histogram"> |
 | `scene.plot_histogram()` - every band at once | `clipped.plot_raster_with_histogram(cmap="RdYlGn")` |
 


### PR DESCRIPTION
<!--
Thanks for contributing to Easy-EO! Keep PRs focused on a single task where possible.
-->

## Summary

<!-- What does this PR change, and why?  (e.g. "feat: add NDMI index"). -->
The cmap for the DEM plot on the README was different from what the `scripts/build_script.py` uses. This PR makes sure thry are the same. It replaces the one in the README with the one in the `scripts/build_script.py`.

## Related issues / tasks
README
<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [x] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [ ] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [ ] Nodata and dtype behavior is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [ ] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

<!-- Anything the maintainer should pay special attention to, verify manually, or be aware of (e.g. dependency bound changes, memory behavior). -->
