### PR TITLE
fix(viz): stop rasterio 1.5 rescaling bands under our display limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ are called out under a **Breaking** heading.
   `AttributeError: Rectangle.set() got an unexpected keyword argument
   'sharey'`. The example is corrected, and `plot_histogram` does not gain the
   parameter — see the Breaking note above, which removes the last one.
+- `plot_raster` and `plot_raster_with_histogram` now pass `adjust=False` to
+  `rasterio.plot.show`. rasterio 1.5 extended `adjust=` to 2D arrays, min-max
+  rescaling the band to `[0, 1]` before drawing, which silently voided the
+  display limits set from the percentile stretch: on Python 3.12+ (where the
+  lockfile resolves rasterio 1.5) the image was drawn against limits its pixels
+  no longer used, and the colorbar reported a range that was not there. Scaling
+  is now left entirely to Matplotlib. A caller passing `adjust=True` through
+  `**show_kwargs` still gets rasterio's behaviour.
 - Plotting now excludes a declared nodata value, as the nodata contract
   ("Mask before compute" in `CODE_STYLE.md`) has always required: a `-9999`
   fill must not shift a percentile stretch. Every plotting function read

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -787,9 +787,14 @@ def plot_raster(
 
     for ax, d, band in panels:
         array, transform = _read_band_for_display(d, band, size)
-        draw_kwargs = show_kwargs
+        draw_kwargs = dict(show_kwargs)
         if stretch:
-            draw_kwargs = _with_stretch_limits(show_kwargs, array, pmin, pmax)
+            draw_kwargs = _with_stretch_limits(draw_kwargs, array, pmin, pmax)
+        # rasterio 1.5 extended show()'s adjust= to 2D arrays, min-max rescaling
+        # the band to [0, 1] before drawing. That silently voids our display
+        # limits, which are in the band's own units. Opt out explicitly (a no-op
+        # on 1.4, which only adjusted RGB), leaving all scaling to Matplotlib.
+        draw_kwargs.setdefault("adjust", False)
         rioplot.show(array, transform=transform, ax=ax, cmap=cmap, **draw_kwargs)
         ax.set_title(_band_label(d, band))
         if colorbar:
@@ -999,6 +1004,9 @@ def plot_raster_with_histogram(
         # Limits scale the image panel only; the histogram bins raw values, so
         # its x-axis stays in the band's own units whatever the stretch does.
         draw_kwargs = _with_stretch_limits({}, array, pmin, pmax) if stretch else {}
+        # See plot_raster: rasterio 1.5's show() rescales 2D arrays unless told
+        # not to, which would override the display limits set just above.
+        draw_kwargs["adjust"] = False
 
         rioplot.show(array, transform=transform, ax=axes[row, 0], cmap=cmap, **draw_kwargs)
         axes[row, 1].hist(_valid_values(array), bins=bins)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -262,6 +262,48 @@ def test_stretch_sets_display_limits_without_rescaling(ndvi_like_raster, plot_fu
     assert clim == pytest.approx(tuple(np.nanpercentile(expected, (2, 98))))
 
 
+def _capture_rioplot_show(monkeypatch):
+    """Spy on ``rasterio.plot.show``, recording the kwargs it is called with."""
+    calls = []
+    real_show = plot_module.rioplot.show
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs)
+        return real_show(*args, **kwargs)
+
+    monkeypatch.setattr(plot_module.rioplot, "show", spy)
+    return calls
+
+
+@pytest.mark.parametrize(
+    "plot_func",
+    [plot_raster, plot_raster_with_histogram],
+    ids=["plot_raster", "plot_raster_with_histogram"],
+)
+def test_rasterio_show_is_told_not_to_rescale(ndvi_like_raster, plot_func, monkeypatch):
+    """rasterio must not min-max the band out from under our display limits.
+
+    rasterio 1.5 extended ``show(adjust=...)`` to 2D arrays, so the band was
+    rescaled to [0, 1] while ``vmin``/``vmax`` stayed in the band's own units:
+    the image was drawn against limits its pixels no longer used and the
+    colorbar described a range that was not there. 1.4 only adjusted RGB, so
+    this assertion is what catches a regression on either version.
+    """
+    calls = _capture_rioplot_show(monkeypatch)
+
+    plot_func(ndvi_like_raster, stretch=True)
+
+    assert calls[0]["adjust"] is False
+
+
+def test_caller_can_still_ask_rasterio_to_rescale(ndvi_like_raster, monkeypatch):
+    calls = _capture_rioplot_show(monkeypatch)
+
+    plot_raster(ndvi_like_raster, stretch=False, adjust=True)
+
+    assert calls[0]["adjust"] is True
+
+
 @pytest.mark.parametrize(
     "plot_func",
     [plot_band_array, plot_raster],


### PR DESCRIPTION
<!--
Thanks for contributing to Easy-EO! Keep PRs focused on a single task where possible.
-->

## Summary

<!-- What does this PR change, and why?  (e.g. "feat: add NDMI index"). -->

## Related issues / tasks

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [ ] `pytest` passes and coverage stays at or above the threshold
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [ ] Nodata and dtype behavior is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [ ] Docs API reference updated where relevant
- [ ] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

<!-- Anything the maintainer should pay special attention to, verify manually, or be aware of (e.g. dependency bound changes, memory behavior). -->
