### PR TITLE
Release/prepare for 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- `sentinel2_blue_cog`, `sentinel2_green_cog`, `sentinel2_red_cog` and
+  `sentinel2_nir_cog` on `load_sample_dataset()`. The four per-band
+  Cloud-Optimized GeoTIFFs were already published on the `sample-data-v1`
+  release but were missing from the registry, so the single-band rasters were
+  the only ones without a COG counterpart a user could ask for. Their pinned
+  checksums and sizes were taken from the live release assets. A test now
+  asserts every plain raster in the registry has a COG sibling, so a future
+  upload cannot go unreachable the same way.
 - A weekly link check covering the documentation, the Markdown files, and the
   tutorial notebooks. `sphinx-build -b linkcheck` handles the docs; `lychee`
   handles `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ are called out under a **Breaking** heading.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-16
+
 ### Added
 
 - A `dpi` argument on every plotting function that writes a file —
@@ -91,9 +93,6 @@ are called out under a **Breaking** heading.
   audit is deliberately not gating unrelated pull requests: a new advisory
   against an unchanged dependency is time-based news, not a regression in the
   branch that happens to be open.
-
-### Added
-
 - Tagging a release now creates a GitHub Release, with the tag's `CHANGELOG.md`
   section as its notes and the sdist and wheel attached. A tag previously
   published to PyPI and left no Release behind, which matters beyond
@@ -114,7 +113,6 @@ are called out under a **Breaking** heading.
   extra is absent — importing Easy-EO as a user would, and refusing to run
   against a source checkout. The sdist is covered because conda-forge builds
   from it.
-
 - The documentation now builds in CI on every pull request, with Sphinx
   warnings treated as errors. Previously it built only on Read the Docs, after
   a merge, so a broken cross-reference or an autodoc target that no longer
@@ -434,7 +432,8 @@ Initial public beta release.
 - Visualization: `plot_raster`, `plot_composite`,
   `plot_raster_with_histogram`, `plot_band_array`.
 
-[Unreleased]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Tommy-Burns/easy-eo/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Tommy-Burns/easy-eo/compare/v0.1.0b1...v0.2.0
 [0.1.0b1]: https://github.com/Tommy-Burns/easy-eo/releases/tag/v0.1.0b1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- A `dpi` argument on every plotting function that writes a file —
+  `plot_band_array`, `plot_raster`, `plot_histogram`,
+  `plot_raster_with_histogram` and `plot_composite`. All five hardcoded
+  `dpi=300` in their `savefig` call, so `save_path` could only ever write at
+  print resolution: a 15x5 figure came out near 4500x1500 pixels and well over
+  10 MB, and trimming one for a README or a paper meant re-encoding it
+  afterwards. The default is unchanged at 300, so existing output is
+  byte-identical. Note that raising it much past 200 enlarges the canvas
+  without adding image detail, since bands are read at the on-screen display
+  budget rather than at `dpi`; the visualization guide has a new "Saving
+  Figures" section on choosing a value.
 - `sentinel2_blue_cog`, `sentinel2_green_cog`, `sentinel2_red_cog` and
   `sentinel2_nir_cog` on `load_sample_dataset()`. The four per-band
   Cloud-Optimized GeoTIFFs were already published on the `sample-data-v1`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "Easy-EO"
 copyright = "2025, Thomas Burns Botchwey"
 author = "Thomas Burns Botchwey"
-release = "0.3.0"
+release = "0.3.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/user_guide/sample_data.rst
+++ b/docs/source/user_guide/sample_data.rst
@@ -84,6 +84,9 @@ attribution (``sd.<name>.info()`` / ``sd.<name>.attribution``).
    * - ``sentinel2_blue`` / ``sentinel2_green`` / ``sentinel2_red`` / ``sentinel2_nir``
      - raster
      - The four Sentinel-2 bands as separate single-band files.
+   * - ``sentinel2_blue_cog`` / ``sentinel2_green_cog`` / ``sentinel2_red_cog`` / ``sentinel2_nir_cog``
+     - raster
+     - Cloud-Optimized GeoTIFF variants of the four single-band files.
    * - ``copernicus_dem``
      - raster
      - Copernicus GLO-30 DEM warped onto the same grid (float32 metres).

--- a/docs/source/user_guide/visualization.rst
+++ b/docs/source/user_guide/visualization.rst
@@ -145,10 +145,32 @@ Notes:
     - ``plot_composite`` takes no colorbar: an RGB composite maps three bands to
       colour channels, so there is no single scalar scale to label.
 
+Saving Figures
+--------------
+
+Every plotting function writes the figure to disk when given ``save_path``, at
+the resolution ``dpi`` asks for:
+
+.. code-block:: python
+
+   scene.plot_raster(cmap="RdYlGn", save_path="ndvi.png")             # 300 dpi
+   scene.plot_raster(cmap="RdYlGn", save_path="ndvi.png", dpi=120)    # preferably for the web
+
+The default, 300, is a print resolution and multiplies with ``figsize``: a 15x5
+figure lands near 4500x1500 pixels and well over 10 MB. That is the wrong size
+for a figure committed to a repository, embedded in a README, or shown on a web
+page — pass ``dpi=100`` to ``dpi=150`` for those.
+
+Raising ``dpi`` much above 200 buys less than it appears to for the image
+panels. Bands are read decimated to the figure's on-screen display budget
+(``figsize`` times the Matplotlib ``figure.dpi``, oversampled twice over), so
+past that point a larger canvas holds the same pixels. Histogram panels, being
+drawn rather than read, do keep sharpening.
+
 Plot Band Arrays (Array Coordinates)
 ------------------------------------
 
-.. function:: plot_band_array(ds, bands=None, *, cmap="gray", figsize=None, nrows=None, ncols=None, stretch=True, pmin=2, pmax=98, colorbar=False, colorbar_label=None, title=None, save_path=None, **imshow_kwargs)
+.. function:: plot_band_array(ds, bands=None, *, cmap="gray", figsize=None, nrows=None, ncols=None, stretch=True, pmin=2, pmax=98, colorbar=False, colorbar_label=None, title=None, save_path=None, dpi=300, **imshow_kwargs)
 
    Plot raster bands as NumPy arrays using row/column coordinates.
 
@@ -168,13 +190,15 @@ Plot Band Arrays (Array Coordinates)
    :param colorbar_label: Colorbar label; ``None`` uses the band's name.
    :param title: Optional figure title.
    :param save_path: File path if the figure should be saved to disk.
+   :param dpi: Resolution of the saved file, in dots per inch (default ``300``).
+       Lower it for a figure committed to a repository or shown on the web.
    :param imshow_kwargs: Additional keyword arguments passed to
        ``matplotlib.pyplot.imshow``.
 
 Plot Raster (Spatial Coordinates)
 ---------------------------------
 
-.. function:: plot_raster(ds, bands=None, *, cmap="gray", figsize=None, nrows=None, ncols=None, stretch=True, pmin=2, pmax=98, colorbar=False, colorbar_label=None, title=None, save_path=None, **show_kwargs)
+.. function:: plot_raster(ds, bands=None, *, cmap="gray", figsize=None, nrows=None, ncols=None, stretch=True, pmin=2, pmax=98, colorbar=False, colorbar_label=None, title=None, save_path=None, dpi=300, **show_kwargs)
 
    Plot raster bands in spatial (CRS-aware) coordinates.
 
@@ -195,13 +219,15 @@ Plot Raster (Spatial Coordinates)
    :param colorbar_label: Colorbar label; ``None`` uses the band's name.
    :param title: Optional figure title.
    :param save_path: File path if the figure should be saved to disk.
+   :param dpi: Resolution of the saved file, in dots per inch (default ``300``).
+       Lower it for a figure committed to a repository or shown on the web.
    :param show_kwargs: Additional keyword arguments passed to
        ``rasterio.plot.show``.
 
 Plot Histogram
 --------------
 
-.. function:: plot_histogram(ds, bands=None, *, bins=256, figsize=None, nrows=None, ncols=None, log=False, title=None, save_path=None, **hist_kwargs)
+.. function:: plot_histogram(ds, bands=None, *, bins=256, figsize=None, nrows=None, ncols=None, log=False, title=None, save_path=None, dpi=300, **hist_kwargs)
 
    Plot histograms of raster band values.
 
@@ -218,13 +244,15 @@ Plot Histogram
    :param log: Use a logarithmic scale on the y-axis.
    :param title: Optional figure title.
    :param save_path: File path if the figure should be saved to disk.
+   :param dpi: Resolution of the saved file, in dots per inch (default ``300``).
+       Lower it for a figure committed to a repository or shown on the web.
    :param hist_kwargs: Additional keyword arguments passed to
        ``matplotlib.pyplot.hist``.
 
 Plot Raster with Histogram
 --------------------------
 
-.. function:: plot_raster_with_histogram(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (10, 5), bins=256, pmin=2, pmax=98, stretch=False, colorbar=False, colorbar_label=None, title=None, save_path=None)
+.. function:: plot_raster_with_histogram(ds, bands=None, *, cmap="gray", figsize: tuple[int, int] = (10, 5), bins=256, pmin=2, pmax=98, stretch=False, colorbar=False, colorbar_label=None, title=None, save_path=None, dpi=300)
 
    Plot raster bands alongside their corresponding histograms.
 
@@ -244,11 +272,13 @@ Plot Raster with Histogram
    :param colorbar_label: Colorbar label; ``None`` uses the band's name.
    :param title: Optional figure title.
    :param save_path: File path if the figure should be saved to disk.
+   :param dpi: Resolution of the saved file, in dots per inch (default ``300``).
+       Lower it for a figure committed to a repository or shown on the web.
 
 Plot Composite (RGB / False-Color)
 ----------------------------------
 
-.. function:: plot_composite(ds, bands, *, stretch=True, figsize=(8, 8), pmin=2, pmax=98, title=None, save_path=None)
+.. function:: plot_composite(ds, bands, *, stretch=True, figsize=(8, 8), pmin=2, pmax=98, title=None, save_path=None, dpi=300)
 
    Plot a three-band raster composite (e.g., RGB or false-color).
 
@@ -263,6 +293,8 @@ Plot Composite (RGB / False-Color)
    :param pmax: Upper percentile used when ``stretch=True``.
    :param title: Optional figure title.
    :param save_path: File path if the figure should be saved to disk.
+   :param dpi: Resolution of the saved file, in dots per inch (default ``300``).
+       Lower it for a figure committed to a repository or shown on the web.
 
    .. note::
 

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -38,4 +38,4 @@ __all__ = [
     "MissingDependencyError",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/eeo/core/core.pyi
+++ b/eeo/core/core.pyi
@@ -227,6 +227,7 @@ class EEORasterDataset:
         colorbar_label: str | None = ...,
         title: str | None = ...,
         save_path: StrPath | None = ...,
+        dpi: int = ...,
         **imshow_kwargs,
     ) -> None: ...
     def plot_composite(
@@ -239,6 +240,7 @@ class EEORasterDataset:
         pmax: float = ...,
         title: str | None = ...,
         save_path: StrPath | None = ...,
+        dpi: int = ...,
     ) -> None: ...
     def plot_histogram(
         self,
@@ -251,6 +253,7 @@ class EEORasterDataset:
         log: bool = ...,
         title: str | None = ...,
         save_path: StrPath | None = ...,
+        dpi: int = ...,
         **hist_kwargs,
     ) -> None: ...
     def plot_raster(
@@ -268,6 +271,7 @@ class EEORasterDataset:
         colorbar_label: str | None = ...,
         title: str | None = ...,
         save_path: StrPath | None = ...,
+        dpi: int = ...,
         **show_kwargs,
     ) -> None: ...
     def plot_raster_with_histogram(
@@ -283,6 +287,7 @@ class EEORasterDataset:
         colorbar: bool = ...,
         colorbar_label: str | None = ...,
         save_path: StrPath | None = ...,
+        dpi: int = ...,
         title: str | None = ...,
     ) -> None: ...
     def power(self, exponent: int | float) -> EEORasterDataset: ...

--- a/eeo/datasets/_registry.py
+++ b/eeo/datasets/_registry.py
@@ -77,9 +77,8 @@ class SampleFile:
 #: The curated samples, keyed by the attribute name they are exposed under on
 #: :class:`eeo.datasets.SampleDataset`. Band files use the library's colour band
 #: names. This is the single source of truth for both the download machinery and
-#: the namespace attributes. Per-band Cloud-Optimized GeoTIFFs are intentionally
-#: absent: only the stacked COG has a checksum pinned today, and fabricating one
-#: would defeat the download verification.
+#: the namespace attributes. Every raster published on the release has both a
+#: plain and a Cloud-Optimized variant here, the latter suffixed ``_cog``.
 SAMPLE_FILES: dict[str, SampleFile] = {
     "sentinel2_stacked": SampleFile(
         Asset(
@@ -111,6 +110,16 @@ SAMPLE_FILES: dict[str, SampleFile] = {
         "Sentinel-2 L2A band B02 (blue), 1024x1024 @ 10 m, EPSG:32633.",
         _S2_ATTRIBUTION,
     ),
+    "sentinel2_blue_cog": SampleFile(
+        Asset(
+            "B02_COG.tif",
+            "555f6fb67522148c05d7bb9a4f49d157cde2d9da00d1304ed953bfd383c9ead1",
+            2293197,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the blue band (B02).",
+        _S2_ATTRIBUTION,
+    ),
     "sentinel2_green": SampleFile(
         Asset(
             "B03.tif",
@@ -119,6 +128,16 @@ SAMPLE_FILES: dict[str, SampleFile] = {
         ),
         "raster",
         "Sentinel-2 L2A band B03 (green), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
+    ),
+    "sentinel2_green_cog": SampleFile(
+        Asset(
+            "B03_COG.tif",
+            "0f0e6cd16141725fe4dfd749a911f3846429b0cd7c222d543d90848ac1f95833",
+            2404804,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the green band (B03).",
         _S2_ATTRIBUTION,
     ),
     "sentinel2_red": SampleFile(
@@ -131,6 +150,16 @@ SAMPLE_FILES: dict[str, SampleFile] = {
         "Sentinel-2 L2A band B04 (red), 1024x1024 @ 10 m, EPSG:32633.",
         _S2_ATTRIBUTION,
     ),
+    "sentinel2_red_cog": SampleFile(
+        Asset(
+            "B04_COG.tif",
+            "5781624003c04ae978196df98dd54e742fe38d1bd5b56237ffc4162209eafc28",
+            2436025,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the red band (B04).",
+        _S2_ATTRIBUTION,
+    ),
     "sentinel2_nir": SampleFile(
         Asset(
             "B08.tif",
@@ -139,6 +168,16 @@ SAMPLE_FILES: dict[str, SampleFile] = {
         ),
         "raster",
         "Sentinel-2 L2A band B08 (nir), 1024x1024 @ 10 m, EPSG:32633.",
+        _S2_ATTRIBUTION,
+    ),
+    "sentinel2_nir_cog": SampleFile(
+        Asset(
+            "B08_COG.tif",
+            "1488f68cad9f37a90ffef9eb62716e2cab77bd7c22954a08e2f2a5d06ce4014d",
+            2504710,
+        ),
+        "raster",
+        "Cloud-Optimized GeoTIFF variant of the nir band (B08).",
         _S2_ATTRIBUTION,
     ),
     "copernicus_dem": SampleFile(

--- a/eeo/datasets/_samples.py
+++ b/eeo/datasets/_samples.py
@@ -144,6 +144,8 @@ class SampleDataset:
         Cloud-Optimized GeoTIFF variant of ``sentinel2_stacked``.
     sentinel2_blue, sentinel2_green, sentinel2_red, sentinel2_nir : SamplePath
         The four Sentinel-2 bands as separate single-band GeoTIFFs.
+    sentinel2_blue_cog, sentinel2_green_cog, sentinel2_red_cog, sentinel2_nir_cog : SamplePath
+        Cloud-Optimized GeoTIFF variants of the four single-band files.
     copernicus_dem : SamplePath
         Copernicus GLO-30 DEM warped onto the Sentinel-2 grid (float32 metres).
     copernicus_dem_cog : SamplePath
@@ -156,9 +158,13 @@ class SampleDataset:
     sentinel2_stacked: SamplePath
     sentinel2_cog_stacked: SamplePath
     sentinel2_blue: SamplePath
+    sentinel2_blue_cog: SamplePath
     sentinel2_green: SamplePath
+    sentinel2_green_cog: SamplePath
     sentinel2_red: SamplePath
+    sentinel2_red_cog: SamplePath
     sentinel2_nir: SamplePath
+    sentinel2_nir_cog: SamplePath
     copernicus_dem: SamplePath
     copernicus_dem_cog: SamplePath
     boundary: SamplePath

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -564,6 +564,7 @@ def plot_band_array(
     colorbar_label: str | None = None,
     title: str | None = None,
     save_path: StrPath | None = None,
+    dpi: int = 300,
     **imshow_kwargs,
 ) -> None:
     """Plot raster bands as arrays in row/column (pixel) space.
@@ -614,7 +615,15 @@ def plot_band_array(
     title : str or None, default None
         Optional figure title.
     save_path : str or path-like or None, default None
-        If given, save the figure to this path at 300 dpi.
+        If given, save the figure to this path, at ``dpi``.
+    dpi : int, default 300
+        Resolution of the saved file, in dots per inch; ignored when
+        ``save_path`` is None. The default suits print, but multiplies with
+        ``figsize``: a 15x5 figure lands near 4500x1500 pixels and well over
+        10 MB, so lower it (100-150) for a figure committed to a
+        repository or embedded in a web page. Raising it past roughly 200
+        enlarges the canvas without adding detail, because bands are read at
+        the on-screen display budget (see Notes), not at ``dpi``.
     **imshow_kwargs
         Extra keyword arguments forwarded to ``matplotlib.pyplot.imshow``. An
         explicit ``vmin``/``vmax`` takes precedence over the stretch.
@@ -671,7 +680,7 @@ def plot_band_array(
     plt.tight_layout()
 
     if save_path is not None:
-        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
     plt.show()
     plt.close()
 
@@ -693,6 +702,7 @@ def plot_raster(
     colorbar_label: str | None = None,
     title: str | None = None,
     save_path: StrPath | None = None,
+    dpi: int = 300,
     **show_kwargs,
 ) -> None:
     """Plot raster bands in spatial (CRS-aware) coordinates.
@@ -743,7 +753,15 @@ def plot_raster(
     title : str or None, default None
         Optional figure title.
     save_path : str or path-like or None, default None
-        If given, save the figure to this path at 300 dpi.
+        If given, save the figure to this path, at ``dpi``.
+    dpi : int, default 300
+        Resolution of the saved file, in dots per inch; ignored when
+        ``save_path`` is None. The default suits print, but multiplies with
+        ``figsize``: a 15x5 figure lands near 4500x1500 pixels and well over
+        10 MB, so lower it (100-150) for a figure committed to a
+        repository or embedded in a web page. Raising it past roughly 200
+        enlarges the canvas without adding detail, because bands are read at
+        the on-screen display budget (see Notes), not at ``dpi``.
     **show_kwargs
         Extra keyword arguments forwarded to ``rasterio.plot.show``. An
         explicit ``vmin``/``vmax`` takes precedence over the stretch.
@@ -807,7 +825,7 @@ def plot_raster(
 
     plt.tight_layout()
     if save_path is not None:
-        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
     plt.show()
     plt.close()
 
@@ -825,6 +843,7 @@ def plot_histogram(
     log: bool = False,
     title: str | None = None,
     save_path: StrPath | None = None,
+    dpi: int = 300,
     **hist_kwargs,
 ) -> None:
     """Plot per-band value histograms.
@@ -859,7 +878,13 @@ def plot_histogram(
     title : str or None, default None
         Optional figure title.
     save_path : str or path-like or None, default None
-        If given, save the figure to this path at 300 dpi.
+        If given, save the figure to this path, at ``dpi``.
+    dpi : int, default 300
+        Resolution of the saved file, in dots per inch; ignored when
+        ``save_path`` is None. The default suits print, but multiplies with
+        ``figsize``: a 15x5 figure lands near 4500x1500 pixels and well over
+        10 MB, so lower it (100-150) for a figure committed to a
+        repository or embedded in a web page.
     **hist_kwargs
         Extra keyword arguments forwarded to ``matplotlib.pyplot.hist``.
 
@@ -904,7 +929,7 @@ def plot_histogram(
 
     plt.tight_layout()
     if save_path is not None:
-        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
     plt.show()
     plt.close()
 
@@ -924,6 +949,7 @@ def plot_raster_with_histogram(
     colorbar: bool = False,
     colorbar_label: str | None = None,
     save_path: StrPath | None = None,
+    dpi: int = 300,
     title: str | None = None,
 ) -> None:
     """Plot each band alongside its value histogram.
@@ -960,7 +986,15 @@ def plot_raster_with_histogram(
         Label for the colorbars; None uses each band's name, leaving an
         unnamed band's colorbar unlabelled.
     save_path : str or path-like or None, default None
-        If given, save the figure to this path at 300 dpi.
+        If given, save the figure to this path, at ``dpi``.
+    dpi : int, default 300
+        Resolution of the saved file, in dots per inch; ignored when
+        ``save_path`` is None. The default suits print, but multiplies with
+        ``figsize``: a 15x5 figure lands near 4500x1500 pixels and well over
+        10 MB, so lower it (100-150) for a figure committed to a
+        repository or embedded in a web page. Past roughly 200 the histogram
+        panel keeps sharpening but the image panel does not, because bands are
+        read at the on-screen display budget (see Notes), not at ``dpi``.
     title : str or None, default None
         Optional figure title.
 
@@ -1026,7 +1060,7 @@ def plot_raster_with_histogram(
 
     plt.tight_layout()
     if save_path is not None:
-        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
     plt.show()
     plt.close()
 
@@ -1043,6 +1077,7 @@ def plot_composite(
     pmax: float = 98,
     title: str | None = None,
     save_path: StrPath | None = None,
+    dpi: int = 300,
 ) -> None:
     """Plot a three-band RGB (or false-colour) composite.
 
@@ -1070,7 +1105,15 @@ def plot_composite(
     title : str or None, default None
         Optional figure title.
     save_path : str or path-like or None, default None
-        If given, save the figure to this path at 300 dpi.
+        If given, save the figure to this path, at ``dpi``.
+    dpi : int, default 300
+        Resolution of the saved file, in dots per inch; ignored when
+        ``save_path`` is None. The default suits print, but multiplies with
+        ``figsize``: a 15x5 figure lands near 4500x1500 pixels and well over
+        10 MB, so lower it (100-150) for a figure committed to a
+        repository or embedded in a web page. Raising it past roughly 200
+        enlarges the canvas without adding detail, because bands are read at
+        the on-screen display budget (see Notes), not at ``dpi``.
 
     Returns
     -------
@@ -1138,7 +1181,7 @@ def plot_composite(
 
     plt.tight_layout()
     if save_path is not None:
-        plt.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
 
     plt.show()
     plt.close()

--- a/examples/00_getting_started/01_installation_and_setup.ipynb
+++ b/examples/00_getting_started/01_installation_and_setup.ipynb
@@ -204,7 +204,7 @@
     {
      "data": {
       "text/plain": [
-       "SampleDataset(sentinel2_stacked, sentinel2_cog_stacked, sentinel2_blue, sentinel2_green, sentinel2_red, sentinel2_nir, copernicus_dem, copernicus_dem_cog, boundary)"
+       "SampleDataset(sentinel2_stacked, sentinel2_cog_stacked, sentinel2_blue, sentinel2_blue_cog, sentinel2_green, sentinel2_green_cog, sentinel2_red, sentinel2_red_cog, sentinel2_nir, sentinel2_nir_cog, copernicus_dem, copernicus_dem_cog, boundary)"
       ]
      },
      "execution_count": 4,
@@ -239,9 +239,13 @@
       "sentinel2_stacked        raster  Sentinel-2 L2A 4-band stack (blue/green/red/nir), 1024x1024 @ 10 m, EPSG:32633.\n",
       "sentinel2_cog_stacked    raster  Cloud-Optimized GeoTIFF variant of the 4-band Sentinel-2 stack (HTTP range-read demos).\n",
       "sentinel2_blue           raster  Sentinel-2 L2A band B02 (blue), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_blue_cog       raster  Cloud-Optimized GeoTIFF variant of the blue band (B02).\n",
       "sentinel2_green          raster  Sentinel-2 L2A band B03 (green), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_green_cog      raster  Cloud-Optimized GeoTIFF variant of the green band (B03).\n",
       "sentinel2_red            raster  Sentinel-2 L2A band B04 (red), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_red_cog        raster  Cloud-Optimized GeoTIFF variant of the red band (B04).\n",
       "sentinel2_nir            raster  Sentinel-2 L2A band B08 (nir), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_nir_cog        raster  Cloud-Optimized GeoTIFF variant of the nir band (B08).\n",
       "copernicus_dem           raster  Copernicus GLO-30 DEM warped onto the Sentinel-2 grid, float32 metres.\n",
       "copernicus_dem_cog       raster  Cloud-Optimized GeoTIFF variant of the Copernicus GLO-30 DEM.\n",
       "boundary                 vector  Region-of-interest polygon (GeoPackage, EPSG:4326) inside the Sentinel-2 footprint.\n"

--- a/examples/02_data_access/01_sample_data.ipynb
+++ b/examples/02_data_access/01_sample_data.ipynb
@@ -76,7 +76,7 @@
     {
      "data": {
       "text/plain": [
-       "SampleDataset(sentinel2_stacked, sentinel2_cog_stacked, sentinel2_blue, sentinel2_green, sentinel2_red, sentinel2_nir, copernicus_dem, copernicus_dem_cog, boundary)"
+       "SampleDataset(sentinel2_stacked, sentinel2_cog_stacked, sentinel2_blue, sentinel2_blue_cog, sentinel2_green, sentinel2_green_cog, sentinel2_red, sentinel2_red_cog, sentinel2_nir, sentinel2_nir_cog, copernicus_dem, copernicus_dem_cog, boundary)"
       ]
      },
      "execution_count": 2,
@@ -111,9 +111,13 @@
       "sentinel2_stacked        raster  Sentinel-2 L2A 4-band stack (blue/green/red/nir), 1024x1024 @ 10 m, EPSG:32633.\n",
       "sentinel2_cog_stacked    raster  Cloud-Optimized GeoTIFF variant of the 4-band Sentinel-2 stack (HTTP range-read demos).\n",
       "sentinel2_blue           raster  Sentinel-2 L2A band B02 (blue), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_blue_cog       raster  Cloud-Optimized GeoTIFF variant of the blue band (B02).\n",
       "sentinel2_green          raster  Sentinel-2 L2A band B03 (green), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_green_cog      raster  Cloud-Optimized GeoTIFF variant of the green band (B03).\n",
       "sentinel2_red            raster  Sentinel-2 L2A band B04 (red), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_red_cog        raster  Cloud-Optimized GeoTIFF variant of the red band (B04).\n",
       "sentinel2_nir            raster  Sentinel-2 L2A band B08 (nir), 1024x1024 @ 10 m, EPSG:32633.\n",
+      "sentinel2_nir_cog        raster  Cloud-Optimized GeoTIFF variant of the nir band (B08).\n",
       "copernicus_dem           raster  Copernicus GLO-30 DEM warped onto the Sentinel-2 grid, float32 metres.\n",
       "copernicus_dem_cog       raster  Cloud-Optimized GeoTIFF variant of the Copernicus GLO-30 DEM.\n",
       "boundary                 vector  Region-of-interest polygon (GeoPackage, EPSG:4326) inside the Sentinel-2 footprint.\n"
@@ -174,7 +178,7 @@
     "| --- | --- |\n",
     "| `sentinel2_stacked` | blue, green, red, nir as one 4-band GeoTIFF |\n",
     "| `sentinel2_cog_stacked` | the same, as a Cloud-Optimized GeoTIFF |\n",
-    "| `sentinel2_blue` / `_green` / `_red` / `_nir` | the four bands as separate files |\n",
+    "| `sentinel2_blue` / `_green` / `_red` / `_nir` | the four bands as separate files |\n| `sentinel2_blue_cog` / `_green_cog` / `_red_cog` / `_nir_cog` | the same four, as COGs |\n",
     "| `copernicus_dem` | Copernicus GLO-30 DEM, float32 metres |\n",
     "| `copernicus_dem_cog` | the same, as a COG |\n",
     "| `boundary` | a region-of-interest polygon (GeoPackage, EPSG:4326) |\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "easy-eo"
-version = "0.3.0"
+version = "0.3.1"
 description = "A lightweight Earth Observation utilities library for chainable raster operations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -298,6 +298,46 @@ def test_namespace_iterates_all_handles():
     assert all(isinstance(h, SamplePath) for h in sd)
 
 
+def test_every_raster_has_a_cog_counterpart():
+    # The release publishes a COG beside every plain raster; the registry must
+    # expose all of them, or a hosted asset is unreachable from user code.
+    pairs = {
+        "sentinel2_stacked": "sentinel2_cog_stacked",
+        "sentinel2_blue": "sentinel2_blue_cog",
+        "sentinel2_green": "sentinel2_green_cog",
+        "sentinel2_red": "sentinel2_red_cog",
+        "sentinel2_nir": "sentinel2_nir_cog",
+        "copernicus_dem": "copernicus_dem_cog",
+    }
+    plain_rasters = {
+        name
+        for name, sample in _registry.SAMPLE_FILES.items()
+        if sample.kind == "raster" and not name.endswith("_cog") and "_cog_" not in name
+    }
+    assert plain_rasters == set(pairs)
+    for plain, cog in pairs.items():
+        assert cog in _registry.SAMPLE_FILES, cog
+        assert _registry.SAMPLE_FILES[cog].kind == "raster"
+        # A COG entry must point at its own asset, not reuse the plain one.
+        assert (
+            _registry.SAMPLE_FILES[cog].asset.remote != _registry.SAMPLE_FILES[plain].asset.remote
+        )
+        assert _registry.SAMPLE_FILES[cog].attribution == _registry.SAMPLE_FILES[plain].attribution
+
+
+def test_single_band_cogs_point_at_the_published_assets():
+    expected = {
+        "sentinel2_blue_cog": "B02_COG.tif",
+        "sentinel2_green_cog": "B03_COG.tif",
+        "sentinel2_red_cog": "B04_COG.tif",
+        "sentinel2_nir_cog": "B08_COG.tif",
+    }
+    for name, remote in expected.items():
+        sample = _registry.SAMPLE_FILES[name]
+        assert sample.asset.remote == remote
+        assert "Sentinel-2" in sample.attribution
+
+
 def test_sample_files_are_single_pinned_assets():
     for name, sample in _registry.SAMPLE_FILES.items():
         assert isinstance(sample, SampleFile), name
@@ -326,3 +366,6 @@ def test_real_download_roundtrip(tmp_path, monkeypatch):
     ds = eeo.load_raster(sd.sentinel2_stacked)
     assert ds.get_count() == 4
     assert ds.band_names == ["blue", "green", "red", "nir"]
+    cog = eeo.load_raster(sd.sentinel2_blue_cog)  # checks a per-band COG checksum
+    assert cog.get_count() == 1
+    assert cog.band_names == ["blue"]

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1117,6 +1117,67 @@ def test_plot_composite_stretched(rgb_float32_raster):
     plot_composite(rgb_float32_raster, bands=(1, 2, 3), stretch=True)
 
 
+# ---------------------------------------------------------------------
+# save_path / dpi
+# ---------------------------------------------------------------------
+# Every plotting function that writes a file takes the same ``dpi``, so the
+# cases below run against all five rather than the three the API grew it for.
+
+
+def _savers(ds):
+    """Return one zero-argument call per plotting function that can save."""
+    return {
+        "plot_band_array": lambda **kw: plot_band_array(ds, **kw),
+        "plot_raster": lambda **kw: plot_raster(ds, **kw),
+        "plot_histogram": lambda **kw: plot_histogram(ds, **kw),
+        "plot_raster_with_histogram": lambda **kw: plot_raster_with_histogram(ds, **kw),
+        "plot_composite": lambda **kw: plot_composite(ds, bands=(1, 2, 3), **kw),
+    }
+
+
+@pytest.fixture
+def savefig_spy(monkeypatch):
+    """Record the keyword arguments every ``plt.savefig`` call receives."""
+    calls: list[dict] = []
+    monkeypatch.setattr(plt, "savefig", lambda *a, **kw: calls.append(kw))
+    return calls
+
+
+@pytest.mark.parametrize("name", list(_savers(None)))
+def test_dpi_defaults_to_300(rgb_float32_raster, savefig_spy, tmp_path, name):
+    _savers(rgb_float32_raster)[name](save_path=tmp_path / "out.png")
+    assert [c["dpi"] for c in savefig_spy] == [300]
+
+
+@pytest.mark.parametrize("name", list(_savers(None)))
+def test_dpi_is_forwarded_to_savefig(rgb_float32_raster, savefig_spy, tmp_path, name):
+    _savers(rgb_float32_raster)[name](save_path=tmp_path / "out.png", dpi=72)
+    assert [c["dpi"] for c in savefig_spy] == [72]
+
+
+@pytest.mark.parametrize("name", list(_savers(None)))
+def test_dpi_without_save_path_writes_nothing(rgb_float32_raster, savefig_spy, name):
+    # dpi is inert on its own: passing it must not turn on saving.
+    _savers(rgb_float32_raster)[name](dpi=72)
+    assert savefig_spy == []
+
+
+@pytest.mark.parametrize("name", list(_savers(None)))
+def test_dpi_scales_the_written_image(rgb_float32_raster, tmp_path, name):
+    """The point of the argument: a lower dpi really writes a smaller file."""
+    call = _savers(rgb_float32_raster)[name]
+    big, small = tmp_path / "big.png", tmp_path / "small.png"
+    call(save_path=big, figsize=(6, 4), dpi=200)
+    call(save_path=small, figsize=(6, 4), dpi=50)
+
+    big_h, big_w = plt.imread(big).shape[:2]
+    small_h, small_w = plt.imread(small).shape[:2]
+    assert big_w > small_w and big_h > small_h
+    assert small.stat().st_size < big.stat().st_size
+    # 4x the dpi is 4x the linear size, give or take tight-bbox rounding.
+    assert abs(big_w / small_w - 4.0) < 0.2
+
+
 def test_plot_composite_stretch_integer_not_truncated(multiband_uint16, monkeypatch):
     """Regression: stretching an integer raster must not render black.
 

--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "easy-eo"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "geopandas" },


### PR DESCRIPTION
## Summary

- **feat: register the four single-band COG samples** — `B02/B03/B04/B08_COG.tif`  were published on the `sample-data-v1` release but missing from `SAMPLE_FILES`.
  Now exposed as `sentinel2_{blue,green,red,nir}_cog`.
- **feat: expose `dpi` on the plotting functions that save** — all five hardcoded `savefig(..., dpi=300)`, so `save_path` could only write at print resolution. `dpi: int = 300` is now a parameter; the default is unchanged, so existing output is byte-identical.

## Related issues / tasks

Release of version 0.3.1

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold (972 passed, 2 skipped)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable example, per `CODE_STYLE.md`
- [ ] Nodata and dtype behaviour is stated in the docstring and covered by a test
- [x] Bound ops changed? Regenerated `eeo/core/core.pyi`
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer
All local tests were run and verified