### PR TITLE
Adding DOI badges and Citation Pages to the Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ are called out under a **Breaking** heading.
 
 ## [Unreleased]
 
+### Added
+
+- A DOI badge in the README, and the Zenodo DOI in `CITATION.cff`. Both use
+  the concept DOI rather than the version DOI Zenodo offers by default, so
+  they track the newest release instead of pinning to v0.3.1.
+
 ## [0.3.1] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ are called out under a **Breaking** heading.
 - A DOI badge in the README, and the Zenodo DOI in `CITATION.cff`. Both use
   the concept DOI rather than the version DOI Zenodo offers by default, so
   they track the newest release instead of pinning to v0.3.1.
+- A "Citing Easy-EO" documentation page covering the software DOI, the
+  separate sample-data DOI, and the Copernicus attribution that citing the
+  deposit does not replace.
 
 ## [0.3.1] - 2026-08-16
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,9 @@ authors:
     orcid: "https://orcid.org/0009-0007-0358-0337"
     affiliation: "University of Salzburg, Austria"
 license: MIT
+# Zenodo concept DOI: always resolves to the newest archived release, so it
+# never needs updating. Each release also gets its own version DOI.
+doi: "10.5281/zenodo.21967655"
 repository-code: "https://github.com/Tommy-Burns/easy-eo"
 url: "https://easy-eo.readthedocs.io"
 keywords:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | **Install** | [![PyPI][pypi-badge]][pypi] [![conda-forge][conda-badge]][conda] [![Python versions][pyversions-badge]][pypi] [![Platforms][platforms-badge]][ci] |
 | **Build & quality** | [![CI][ci-badge]][ci] [![Latest deps][latest-deps-badge]][latest-deps] [![Coverage][codecov-badge]][codecov] [![Ruff][ruff-badge]][ruff] [![Checked with mypy][mypy-badge]][mypy] |
 | **Security** | [![CodeQL][codeql-badge]][codeql] [![OpenSSF Scorecard][scorecard-badge]][scorecard] |
-| **Project** | [![Documentation][docs-badge]][docs] [![License: MIT][license-badge]][license] |
+| **Project** | [![Documentation][docs-badge]][docs] [![License: MIT][license-badge]][license] [![DOI][doi-badge]][doi] |
 
 [pypi]: https://pypi.org/project/easy-eo/
 [pypi-badge]: https://img.shields.io/pypi/v/easy-eo.svg
@@ -35,6 +35,8 @@
 [docs-badge]: https://readthedocs.org/projects/easy-eo/badge/?version=latest
 [license]: https://github.com/Tommy-Burns/easy-eo/blob/main/LICENSE
 [license-badge]: https://img.shields.io/github/license/Tommy-Burns/easy-eo
+[doi]: https://doi.org/10.5281/zenodo.21967655
+[doi-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.21967655.svg
 
 
 Easy-EO is a lightweight, extensible Python library for raster-based Earth

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -1,0 +1,72 @@
+Citing Easy-EO
+==============
+
+If Easy-EO contributed to work you are publishing, please cite it. Citations
+are how open-source research software earns the recognition that keeps it
+maintained.
+
+Citing the software
+-------------------
+
+Easy-EO is archived on Zenodo, and every release gets its own archived
+snapshot. The DOI below is the **concept DOI**: it always resolves to the most
+recent release, so it stays correct as new versions appear.
+
+.. code-block:: bibtex
+
+    @software{easy_eo,
+      author    = {Botchwey, Thomas Burns},
+      title     = {Easy-EO: chainable raster analysis for Earth Observation
+                   in Python},
+      publisher = {Zenodo},
+      doi       = {10.5281/zenodo.21967655},
+      url       = {https://github.com/Tommy-Burns/easy-eo}
+    }
+
+To cite the exact version you used instead, open the `Zenodo record
+<https://doi.org/10.5281/zenodo.21967655>`_, select that release, and use its
+own version DOI. Naming the version is worth doing in a methods section, where
+reproducibility depends on which release produced the numbers.
+
+``CITATION.cff`` in the repository carries the same metadata in machine-readable
+form. GitHub reads it to render the **Cite this repository** button, and tools
+such as ``cffconvert`` convert it to BibTeX, APA, and other formats.
+
+Citing the sample data
+----------------------
+
+The bundled sample files reached through :func:`eeo.datasets.load_sample_dataset`
+are archived separately, with their own DOI. Cite it if a figure or result in
+your work was produced from them:
+
+.. code-block:: bibtex
+
+    @dataset{easy_eo_sample_data,
+      author    = {Botchwey, Thomas Burns},
+      title     = {Easy-EO sample data: Sentinel-2 and Copernicus DEM
+                   subsets for testing and teaching},
+      publisher = {Zenodo},
+      year      = {2026},
+      version   = {1},
+      doi       = {10.5281/zenodo.21917533}
+    }
+
+This is a version DOI rather than a concept DOI, deliberately: a reproducible
+result depends on the exact files, and a later deposit could change them.
+
+Attribution for the underlying data
+-----------------------------------
+
+Citing the deposit does not replace the attribution the source data requires.
+The sample files are derived from open Copernicus data, which must be credited
+whenever the data or figures made from it are redistributed. Each file carries
+the exact wording:
+
+.. code-block:: python
+
+    from eeo.datasets import load_sample_dataset
+
+    sd = load_sample_dataset()
+    print(sd.sentinel2_cog_stacked.attribution)
+
+See :doc:`user_guide/sample_data` for the full terms.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,6 +94,7 @@ runnable notebooks — each one openable in Colab with nothing to install.
    user_guide/statistical_locations
    user_guide/xarray_interop
    backends
+   citation
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
<!--
Thanks for contributing to Easy-EO! Keep PRs focused on a single task where possible.
-->

## Summary
This PR adds the DOI bade to the readme and also adds a citation page to the documentation
<!-- What does this PR change, and why?  (e.g. "feat: add NDMI index"). -->

## Related issues / tasks
Citation
<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [x] Docs / tooling / CI only

## Checklist (Definition of Done)

- [ ] `pytest` passes and coverage stays at or above the threshold
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy` passes
- [ ] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [ ] Nodata and dtype behavior is stated in the docstring and covered by a test
- [ ] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer
N/A
<!-- Anything the maintainer should pay special attention to, verify manually, or be aware of (e.g. dependency bound changes, memory behavior). -->
