### PR TITLE
feat: scene loaders for Sentinel-2 and Landsat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ are called out under a **Breaking** heading.
 
 ### Added
 
+- `eeo.load_sentinel2()` and `eeo.load_landsat()`, for reading a product you
+  have already downloaded rather than one in a catalog. Both return the same
+  `EEORasterDataset` a STAC load does — same grid, same band names, same
+  values — so a workflow does not care which route the data took; they share
+  one reader with `STACItem.load` for exactly that reason. `load_landsat` is
+  one function for Landsat 4, 5, 7, 8 and 9, not one per satellite: the
+  mission is read from the product's own metadata and only decides which band
+  table the names resolve against, so `["red", "nir08"]` is the same request
+  on a sensor where red is band 4 and one where it is band 3. Bands are always
+  named explicitly — a full Sentinel-2 product is several gigabytes, so a
+  default of "everything" would turn a two-band NDVI into a load that does not
+  fit in memory. Only surface reflectance is read: Sentinel-2 Level-2A and
+  Landsat `L2SP`/`L2SR`, with Level-1C and the Level-1 products refused by
+  name and told which product to download instead. The level comes from the
+  metadata rather than the filename, so a renamed product cannot mislead the
+  reader.
+- Either loader reads a product as it was downloaded — a `.SAFE` directory or
+  a Copernicus `.zip`, a Landsat directory or a USGS `.tar` — without
+  unpacking it first. A compressed archive is refused with the command to
+  extract it: it holds no index, so reading one band would decompress every
+  byte before it, once per band, and accepting that silently would make a load
+  mysteriously slow rather than honestly refuse. Pointing at a folder that
+  holds more than one product is also refused, by name, rather than loading
+  whichever sorts first.
+- A "Loading Downloaded Scenes" guide beside the STAC one, covering where the
+  products come from, what a path can be, why bands are named rather than
+  numbered, resolution selection, and the supported-level boundary. It carries
+  a "What the values mean" section documenting something that was true before
+  and undocumented: **a load returns the product's stored integers, not
+  reflectance** — the values a GIS shows, since the assets declare a scale of
+  1.0 and an offset of 0.0 to GDAL and nothing in the chain decodes them. That
+  matters because a multiplicative scale cancels in a normalised difference
+  while an additive offset does not, so an index over digital numbers is
+  biased toward zero: measured on Sentinel-2 farmland, the same NDVI came out
+  at 0.438 over DN against 0.668 over reflectance. The STAC guide's quickstart
+  now says which convention its NDVI is in and links across.
+
 - A DOI badge in the README, and the Zenodo DOI in `CITATION.cff`. Both use
   the concept DOI rather than the version DOI Zenodo offers by default, so
   they track the newest release instead of pinning to v0.3.1.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -85,6 +85,7 @@ runnable notebooks — each one openable in Colab with nothing to install.
    user_guide/core_dataset
    user_guide/sample_data
    user_guide/loading_satellite_data
+   user_guide/loading_downloaded_scenes
    user_guide/band_names
    user_guide/ops
    user_guide/spectral_indices

--- a/docs/source/modules/io.rst
+++ b/docs/source/modules/io.rst
@@ -1,10 +1,12 @@
 IO Module
 =========
 
-Data access and exchange beyond the local filesystem: STAC search and xarray
-interop. Each needs its optional extra (``pip install "easy-eo[stac]"`` /
+Data access and exchange beyond the local filesystem: STAC search, loaders
+for products downloaded to disk, and xarray interop. STAC and xarray each need
+their optional extra (``pip install "easy-eo[stac]"`` /
 ``pip install "easy-eo[xarray]"``); without it, the call raises
-:class:`~eeo.MissingDependencyError` with the install command.
+:class:`~eeo.MissingDependencyError` with the install command. The product
+loaders need no extra.
 
 :func:`eeo.stac_search` finds scenes and :meth:`eeo.io.STACItem.load` reads
 them. Searches go to Microsoft Planetary Computer
@@ -39,6 +41,30 @@ STAC search
     :members:
 
 .. autodata:: eeo.io.PLANETARY_COMPUTER_STAC_URL
+
+Downloaded products
+-------------------
+
+:func:`eeo.load_sentinel2` reads a Copernicus ``.SAFE`` product and
+:func:`eeo.load_landsat` a USGS Collection 2 Level-2 one — one function for
+Landsat 4, 5, 7, 8, and 9, since the mission only selects which band table the
+names resolve against. Either accepts the product unpacked or still in the
+``.zip`` or ``.tar`` it was downloaded as, and both return the same dataset a
+catalog load does:
+
+.. code-block:: python
+
+    import eeo
+
+    scene = eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red", "nir"])
+    ndvi = scene.ndvi(red="red", nir="nir")
+
+Values are the product's stored integers, not reflectance —
+see :doc:`../user_guide/loading_downloaded_scenes`.
+
+.. autofunction:: eeo.load_sentinel2
+
+.. autofunction:: eeo.load_landsat
 
 xarray interop
 --------------

--- a/docs/source/user_guide/loading_downloaded_scenes.rst
+++ b/docs/source/user_guide/loading_downloaded_scenes.rst
@@ -79,10 +79,10 @@ Either loader accepts the product as it arrived, unpacked or not:
 
    # the product itself
    eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red"])
-   # the folder it was unpacked into
-   eeo.load_sentinel2(path="downloads/", bands=["red"])
    # still zipped, as downloaded
-   eeo.load_sentinel2(path="S2B_MSIL2A_….zip", bands=["red"])
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE.zip", bands=["red"])
+   # the folder it was unpacked into, or downloaded into still zipped
+   eeo.load_sentinel2(path="downloads/", bands=["red"])
    # the manifest itself
    eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE/MTD_MSIL2A.xml", bands=["red"])
 
@@ -100,9 +100,14 @@ A **compressed** archive is refused rather than read slowly:
    byte before it, once per band. Extract it first — `tar -xf LC09_….tar.gz` —
    and pass the 'LC09_….tar' directory.
 
-Pointing at a folder is only unambiguous while it holds **one** product. A
-folder with several is refused by name rather than loading whichever sorts
-first, which would silently analyse the wrong date.
+A folder counts as holding the product whether it was unpacked there or is
+still the ``.zip`` or ``.tar`` you downloaded into it — so pointing at the
+folder works either way, and an unpacked product beside its own archive wins,
+being the cheaper of the two to read.
+
+Pointing at a folder is only unambiguous while it holds **one** product,
+though. A folder with several is refused by name rather than loading whichever
+sorts first, which would silently analyse the wrong date.
 
 -----
 

--- a/docs/source/user_guide/loading_downloaded_scenes.rst
+++ b/docs/source/user_guide/loading_downloaded_scenes.rst
@@ -1,0 +1,401 @@
+Loading Downloaded Scenes
+=========================
+
+:doc:`loading_satellite_data` reads scenes from a catalog over the network.
+This page covers the other case: a product you have already downloaded, sitting
+on disk as a folder or as the archive it arrived in.
+
+:func:`~eeo.load_sentinel2` reads a Copernicus ``.SAFE`` product.
+:func:`~eeo.load_landsat` reads a USGS Collection 2 Level-2 product — one
+function for Landsat 4, 5, 7, 8, and 9. Both return the same
+:class:`~eeo.core.EEORasterDataset` as a catalog load, on the same grid, with
+the same band names, so a workflow does not care which route the data took.
+
+Neither needs an optional extra.
+
+.. seealso::
+
+   :doc:`loading_satellite_data` for reading the same scenes from a catalog,
+   :doc:`band_names` for addressing bands by name, and :doc:`spectral_indices`
+   for the indices computed here.
+
+-----
+
+Quickstart
+----------
+
+.. code-block:: python
+
+   import eeo
+
+   scene = eeo.load_sentinel2(
+       path="S2B_MSIL2A_20240830T100559_N0511_R022_T32TPS_20240830T134009.SAFE",
+       bands=["red", "nir"],
+       bbox=(11.0, 46.5, 11.2, 46.7),
+   )
+   ndvi = scene.ndvi(red="red", nir="nir")
+
+Landsat is the same call:
+
+.. code-block:: python
+
+   scene = eeo.load_landsat(
+       path="LC09_L2SP_193028_20260822_20260823_02_T1",
+       bands=["red", "nir08"],
+       bbox=(11.0, 46.5, 11.2, 46.7),
+   )
+   ndvi = scene.ndvi(red="red", nir="nir08")
+
+.. important::
+
+   Both return the product's **stored integers**, not reflectance — the same
+   values QGIS shows when you open the file. See
+   `What the values mean`_ before computing an index from them.
+
+-----
+
+Where the products come from
+----------------------------
+
+Sentinel-2
+   The `Copernicus Data Space Ecosystem <https://dataspace.copernicus.eu/>`_.
+   Download the **Level-2A** product; it arrives as a ``.zip`` containing one
+   ``.SAFE`` directory.
+
+Landsat
+   `USGS EarthExplorer <https://earthexplorer.usgs.gov/>`_. Order the
+   **Collection 2 Level-2** product; it arrives as a ``.tar``.
+
+Both are free and both require an account.
+
+-----
+
+What a path can be
+------------------
+
+Either loader accepts the product as it arrived, unpacked or not:
+
+.. code-block:: python
+
+   # the product itself
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red"])
+   # the folder it was unpacked into
+   eeo.load_sentinel2(path="downloads/", bands=["red"])
+   # still zipped, as downloaded
+   eeo.load_sentinel2(path="S2B_MSIL2A_….zip", bands=["red"])
+   # the manifest itself
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE/MTD_MSIL2A.xml", bands=["red"])
+
+   # still tarred, as downloaded
+   eeo.load_landsat(path="LC09_L2SP_….tar", bands=["red"])
+
+Reading straight from the archive means you don't have to unpack the
+archive yourself, which is worth it for a scene you will read once.
+A **compressed** archive is refused rather than read slowly:
+
+.. code-block:: text
+
+   ValidationError: 'LC09_….tar.gz' is a compressed archive, which cannot be
+   read in place: it holds no index, so reading one band would decompress every
+   byte before it, once per band. Extract it first — `tar -xf LC09_….tar.gz` —
+   and pass the 'LC09_….tar' directory.
+
+Pointing at a folder is only unambiguous while it holds **one** product. A
+folder with several is refused by name rather than loading whichever sorts
+first, which would silently analyse the wrong date.
+
+-----
+
+Bands are named, not numbered
+-------------------------------
+
+``["red", "nir08"]`` means the same thing on every sensor. Band *numbers* do
+not: red is band 4 on Landsat 8 and 9, and band 3 on Landsat 7. Naming a band
+is what lets one script run over both.
+
+.. code-block:: python
+
+   # Landsat 9: red is SR_B4, nir08 is SR_B5
+   eeo.load_landsat(path="LC09_L2SP_….tar", bands=["red", "nir08"])
+   # Landsat 7: red is SR_B3, nir08 is SR_B4
+   eeo.load_landsat(path="LE07_L2SP_….tar", bands=["red", "nir08"])
+
+Anything in the first column can be passed to ``bands=``, and so can any native
+id on the same row. A dash means the sensor has no such band, and asking for it
+fails with a message listing what the product does hold.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 18 30 30
+
+   * - Pass this
+     - Sentinel-2
+     - Landsat 4, 5, 7
+     - Landsat 8, 9
+   * - ``coastal``
+     - ``B01``
+     - —
+     - ``SR_B1``
+   * - ``blue``
+     - ``B02``
+     - ``SR_B1``
+     - ``SR_B2``
+   * - ``green``
+     - ``B03``
+     - ``SR_B2``
+     - ``SR_B3``
+   * - ``red``
+     - ``B04``
+     - ``SR_B3``
+     - ``SR_B4``
+   * - ``rededge1``
+     - ``B05``
+     - —
+     - —
+   * - ``rededge2``
+     - ``B06``
+     - —
+     - —
+   * - ``rededge3``
+     - ``B07``
+     - —
+     - —
+   * - ``nir``
+     - ``B08``
+     - —
+     - —
+   * - ``nir08``
+     - ``B8A``
+     - ``SR_B4``
+     - ``SR_B5``
+   * - ``nir09``
+     - ``B09``
+     - —
+     - —
+   * - ``swir16``
+     - ``B11``
+     - ``SR_B5``
+     - ``SR_B6``
+   * - ``swir22``
+     - ``B12``
+     - ``SR_B7``
+     - ``SR_B7``
+   * - ``lwir11``
+     - —
+     - —
+     - ``ST_B10``
+   * - ``lwir``
+     - —
+     - ``ST_B6``
+     - —
+
+The quality and ancillary layers are requested the same way:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 18 30 30
+
+   * - Pass this
+     - Sentinel-2
+     - Landsat 4, 5, 7
+     - Landsat 8, 9
+   * - ``scl``
+     - ``SCL``
+     - —
+     - —
+   * - ``aot``
+     - ``AOT``
+     - —
+     - —
+   * - ``wvp``
+     - ``WVP``
+     - —
+     - —
+   * - ``tci``
+     - ``TCI``
+     - —
+     - —
+   * - ``qa_pixel``
+     - —
+     - ``QA_PIXEL``
+     - ``QA_PIXEL``
+   * - ``qa_radsat``
+     - —
+     - ``QA_RADSAT``
+     - ``QA_RADSAT``
+   * - ``qa_aerosol``
+     - —
+     - —
+     - ``SR_QA_AEROSOL``
+   * - ``atmos_opacity``
+     - —
+     - ``SR_ATMOS_OPACITY``
+     - —
+   * - ``cloud_qa``
+     - —
+     - ``SR_CLOUD_QA``
+     - —
+
+Note ``nir`` and ``nir08``: Sentinel-2 carries both, a wide band and a narrow
+one, while Landsat's near-infrared is the narrow kind. So ``"nir08"`` is the
+name that works on every mission, and ``"nir"`` is Sentinel-2 only.
+
+The native ids work with or without their prefix, so ``"SR_B4"`` and ``"B4"``
+both reach the same band — useful when following a formula written in those
+terms. See :doc:`band_names` for the full vocabulary.
+
+**There is no default band list.** A full Sentinel-2 Level-2A product holds
+several gigabytes of imagery: one 10 m band alone is 10,980 × 10,980 pixels at
+two bytes each, about 241 MB, and a Landsat scene is roughly 7,700 × 7,900,
+about 120 MB per band. A default of "everything" would turn a two-band NDVI
+into a load that contains many unneeded items in memory , so the set to read is always an
+explicit choice — and ``bbox`` is what keeps it bounded.
+
+-----
+
+Resolution
+----------
+
+Sentinel-2 writes its bands at 10, 20, and 60 m. ``load_sentinel2`` defaults to
+the finest resolution among the bands you actually asked for, so a load never
+upsamples everything to a resolution only one band was sensed at:
+
+.. code-block:: python
+
+   # both 10 m, so 10 m
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red", "nir"])
+   # both 20 m, so 20 m
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["swir16", "swir22"])
+   # mixed, so the finest of them: 10 m
+   eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red", "swir16"])
+   # or say which you want
+   eeo.load_sentinel2(
+       path="S2B_MSIL2A_….SAFE", bands=["red", "swir16"], resolution=20
+   )
+   # nearest is used for "scl" whatever this says, since it holds classes
+   eeo.load_sentinel2(
+       path="S2B_MSIL2A_….SAFE",
+       bands=["red", "scl"],
+       resolution=10,
+       resampling="bilinear",
+   )
+
+A band the product does not hold at the chosen resolution is read at the finest
+it does hold and warped onto the grid.
+
+``load_landsat`` has **no** ``resolution`` or ``resampling`` argument, because
+nothing is ever resampled: every Collection 2 Level-2 band, thermal and quality
+included, is delivered on one 30 m grid.
+
+-----
+
+Which levels are read
+---------------------
+
+Surface reflectance only:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Mission
+     - Read
+     - Refused
+   * - Sentinel-2
+     - Level-2A
+     - Level-1C
+   * - Landsat
+     - ``L2SP``, ``L2SR``
+     - ``L1TP``, ``L1GT``, ``L1GS``
+
+The level is read from the metadata, not from
+the filename, so renaming a product cannot talk the loader into the wrong one.
+
+-----
+
+.. _what-the-values-mean:
+
+What the values mean
+--------------------
+
+**A load returns the product's stored integers.** Not reflectance — the digital
+numbers the file holds, which are the same values QGIS shows. This is true of
+:func:`~eeo.load_sentinel2`, :func:`~eeo.load_landsat`, and
+:meth:`~eeo.io.STACItem.load` alike: the assets declare a scale of ``1.0`` and
+an offset of ``0.0`` to GDAL.
+
+Converting is one line, and each mission encodes differently:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Product
+     - Conversion
+   * - Sentinel-2 L2A, baseline 04.00 and later
+     - ``reflectance = DN * 1e-4 - 0.1``
+   * - Sentinel-2 L2A, before baseline 04.00
+     - ``reflectance = DN * 1e-4``
+   * - Landsat C2 L2 surface reflectance
+     - ``reflectance = DN * 2.75e-5 - 0.2``
+   * - Landsat C2 L2 surface temperature
+     - ``kelvin = DN * 0.00341802 + 149.0``
+
+The coefficients for the product in hand travel on the result, so you do not
+have to hardcode them:
+
+.. code-block:: python
+
+   scene = eeo.load_sentinel2(path="S2B_MSIL2A_….SAFE", bands=["red", "nir"])
+   reflectance = scene * 1e-4 - 0.1        # baseline 04.00 and later
+
+   scene.attrs["processing_baseline"]      # '05.XX'
+   scene.attrs["band_offsets"]             # {'B04': -1000.0, ...}
+
+.. warning::
+
+   **An index computed over digital numbers is biased.** A *multiplicative*
+   scale cancels in a normalised difference — the same factor appears in the
+   numerator and the denominator — so it is easy to assume the offset cancels
+   too. It does not: an additive offset survives, and pulls the result toward
+   zero.
+
+   Measured on Sentinel-2 farmland in the Po valley, the same NDVI came out at
+   **0.438** over raw digital numbers and **0.668** over reflectance — a median
+   error of +0.231, and up to 0.593 on individual pixels. That is the
+   difference between "sparse vegetation" and "dense canopy".
+
+   Convert before computing an index if the absolute value matters.
+
+Sentinel-2's offset applies to products processed with baseline 04.00 (January
+2022) or later; earlier products have none. A time series spanning that date
+mixes two encodings 1,000 DN apart, and ``attrs["processing_baseline"]`` is
+what tells them apart.
+
+-----
+
+What the result carries
+-----------------------
+
+Beyond the pixels, a load records where they came from:
+
+.. code-block:: python
+
+   scene = eeo.load_landsat(path="LC09_L2SP_….tar", bands=["red", "nir08"])
+
+   scene.band_names            # ['red', 'nir08']
+   scene.timestamp             # acquisition time, UTC
+   scene.attrs["product"]      # 'LC09_L2SP_193028_20260822_20260823_02_T1'
+   scene.attrs["mission"]      # 'Landsat 9'
+   scene.attrs["level"]        # 'L2SP'
+
+Sentinel-2 additionally records ``tile`` and ``processing_baseline``; Landsat
+records ``wrs_path``, ``wrs_row``, and the scaling coefficients above.
+
+.. note::
+
+   **Landsat 7 after 31 May 2003 is missing about 22% of each scene.** The scan
+   line corrector failed, leaving wedge-shaped gaps that widen toward the scene
+   edges. Those pixels carry the fill value, not a measurement, so they are
+   nodata and must be excluded from statistics rather than read as zero
+   reflectance. See :doc:`nodata_and_dtype`.

--- a/docs/source/user_guide/loading_satellite_data.rst
+++ b/docs/source/user_guide/loading_satellite_data.rst
@@ -30,9 +30,10 @@ This needs the optional ``stac`` extra:
 
 .. seealso::
 
-   :doc:`spectral_indices` for the indices computed here, :doc:`band_names` for
-   addressing bands by name, and :doc:`sample_data` for working offline from a
-   bundled sample instead.
+   :doc:`loading_downloaded_scenes` for reading a product you have already
+   downloaded, :doc:`spectral_indices` for the indices computed here,
+   :doc:`band_names` for addressing bands by name, and :doc:`sample_data` for
+   working offline from a bundled sample instead.
 
 -----
 
@@ -60,6 +61,15 @@ That is the whole workflow. The scene it reads is a Sentinel-2 tile of roughly
 11,000 × 11,000 pixels per band — around 240 MB — but only the window covering
 your bounding box is fetched, so the load moves a few megabytes and finishes in
 seconds.
+
+.. important::
+
+   That NDVI is computed over the assets' **stored integers**, not reflectance.
+   A multiplicative scale cancels in a normalised difference but an additive
+   offset does not, so the result is biased toward zero — on real farmland,
+   0.438 where reflectance gives 0.668. See
+   :ref:`What the values mean <what-the-values-mean>` for the conversion and
+   when it matters.
 
 -----
 

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -18,7 +18,7 @@ from .core import (
     load_raster,
 )
 from .core.adapters import *
-from .io import from_xarray, stac_search
+from .io import from_xarray, load_sentinel2, stac_search
 from .ops import *
 from .preprocessing import *
 from .viz import *
@@ -28,6 +28,7 @@ __all__ = [
     "load_raster",
     "load_array",
     "stac_search",
+    "load_sentinel2",
     "from_xarray",
     "show_versions",
     "EEOError",

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -18,7 +18,7 @@ from .core import (
     load_raster,
 )
 from .core.adapters import *
-from .io import from_xarray, load_sentinel2, stac_search
+from .io import from_xarray, load_landsat, load_sentinel2, stac_search
 from .ops import *
 from .preprocessing import *
 from .viz import *
@@ -28,6 +28,7 @@ __all__ = [
     "load_raster",
     "load_array",
     "stac_search",
+    "load_landsat",
     "load_sentinel2",
     "from_xarray",
     "show_versions",

--- a/eeo/io/__init__.py
+++ b/eeo/io/__init__.py
@@ -7,11 +7,12 @@ pulls in no optional dependency; an extra is only required when one of its
 features actually runs.
 """
 
-from .products import load_sentinel2
+from .products import load_landsat, load_sentinel2
 from .stac import PLANETARY_COMPUTER_STAC_URL, STACItem, STACSearchResult, stac_search
 from .xarray import from_xarray
 
 __all__ = [
+    "load_landsat",
     "load_sentinel2",
     "stac_search",
     "STACItem",

--- a/eeo/io/__init__.py
+++ b/eeo/io/__init__.py
@@ -1,15 +1,18 @@
 """Data access and exchange beyond the local filesystem.
 
-Holds STAC catalog access (:mod:`eeo.io.stac`, the ``stac`` extra) and xarray
-interop (:mod:`eeo.io.xarray`, the ``xarray`` extra). Importing this package
+Holds STAC catalog access (:mod:`eeo.io.stac`, the ``stac`` extra), loaders for
+products downloaded to disk (:mod:`eeo.io.products`), and xarray interop
+(:mod:`eeo.io.xarray`, the ``xarray`` extra). Importing this package
 pulls in no optional dependency; an extra is only required when one of its
 features actually runs.
 """
 
+from .products import load_sentinel2
 from .stac import PLANETARY_COMPUTER_STAC_URL, STACItem, STACSearchResult, stac_search
 from .xarray import from_xarray
 
 __all__ = [
+    "load_sentinel2",
     "stac_search",
     "STACItem",
     "STACSearchResult",

--- a/eeo/io/_archive.py
+++ b/eeo/io/_archive.py
@@ -1,0 +1,267 @@
+"""Where a product's files live, so the readers do not have to care.
+
+A downloaded scene arrives as a directory, a Copernicus ``.zip``, or a USGS
+``.tar``, and identifying it means the same four questions in every case: does
+this file exist, which files match this pattern, what does this metadata file
+say, and what do I hand rasterio to read this image? :class:`ProductSource`
+answers those four and nothing else, so :mod:`eeo.io._sentinel2` and
+:mod:`eeo.io._landsat` can be written once against a product rather than once
+per container it might be shipped in.
+
+Paths inside a source are relative :class:`~pathlib.PurePosixPath` values, and
+purely nominal — an archive member has no filesystem path to be relative to.
+Only :meth:`ProductSource.href` produces something openable, which keeps the
+one place that has to know about ``/vsizip/`` down to a single line.
+
+The read half of the loader never needed this: rasterio opens a URL as happily
+as a path. It is discovery that is filesystem-bound, so it is discovery this
+covers. A remote product is the same shape of problem as an archive — the
+product is not a plain directory — and would arrive as one more implementation
+here rather than as changes to the readers.
+
+Notes
+-----
+**A compressed tar is refused rather than read.** The three containers here all
+allow a single member to be addressed on its own: a directory by definition, a
+zip through its central directory, an uncompressed tar through its member
+headers. Wrapping a tar in gzip removes that. The compressed stream has no
+index, so reaching any member means decompressing everything before it, and a
+windowed read of one band decompresses the entire archive ahead of it — every
+time, for every band. The cost is not a constant factor, so accepting it
+silently would make the loader mysteriously slow rather than honestly refuse.
+
+Zip is not free either, only bounded: a deflated member is decompressed from
+its own start, not from the start of the archive. That is one image at worst,
+and it is the format Copernicus actually ships, so it is supported with the
+cost noted rather than refused.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import tarfile
+import zipfile
+from abc import ABC, abstractmethod
+from pathlib import Path, PurePosixPath
+
+from eeo.core.exceptions import ValidationError
+from eeo.core.types import StrPath
+
+#: Final suffixes marking a compressed archive, which is refused. ``.tgz`` and
+#: friends are the one-piece spellings of the same thing.
+_COMPRESSED_SUFFIXES = (
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".z",
+    ".zst",
+    ".tgz",
+    ".tbz",
+    ".tbz2",
+    ".txz",
+)
+
+#: Archive suffixes, mapped to the GDAL virtual filesystem that reads them.
+_ARCHIVE_VSI = {".zip": "vsizip", ".tar": "vsitar"}
+
+
+@functools.lru_cache(maxsize=64)
+def _anchored(pattern: str) -> re.Pattern[str]:
+    """Compile a glob pattern the way :meth:`pathlib.Path.glob` reads it.
+
+    Anchored at the root and with ``*`` stopping at a separator, so an archive
+    answers a pattern exactly as the equivalent directory would. Matching
+    archive members with :meth:`PurePosixPath.match` instead would match from
+    the right, and quietly find things a directory source would not.
+    """
+    parts = []
+    for char in pattern:
+        if char == "*":
+            parts.append("[^/]*")
+        elif char == "?":
+            parts.append("[^/]")
+        else:
+            parts.append(re.escape(char))
+    return re.compile("".join(parts))
+
+
+class ProductSource(ABC):
+    """The files of one product, wherever they physically live.
+
+    Attributes
+    ----------
+    name : str
+        A name for the product, used where a message or a provenance record
+        needs to identify it.
+    location : Path
+        What the caller actually passed, for error messages.
+    named_entry : PurePosixPath or None
+        The file the caller named, when they named one rather than a container.
+        A reader honours it instead of searching, so pointing at a specific
+        metadata file selects that file and not a sibling it prefers.
+    """
+
+    name: str
+    location: Path
+    named_entry: PurePosixPath | None
+
+    @abstractmethod
+    def exists(self, relative: PurePosixPath | str) -> bool:
+        """Whether the source holds a file at this relative path."""
+
+    @abstractmethod
+    def glob(self, pattern: str) -> list[PurePosixPath]:
+        """Relative paths of the files matching a glob pattern, sorted."""
+
+    @abstractmethod
+    def read_bytes(self, relative: PurePosixPath | str) -> bytes:
+        """Read one file whole. For metadata, never for imagery."""
+
+    @abstractmethod
+    def href(self, relative: PurePosixPath | str) -> str:
+        """Return what rasterio should open to read this file."""
+
+
+class DirectorySource(ProductSource):
+    """A product unpacked into a directory."""
+
+    def __init__(self, root: Path, named_entry: PurePosixPath | None = None) -> None:
+        self.root = root
+        self.name = root.name
+        self.named_entry = named_entry
+        self.location = root if named_entry is None else root / named_entry
+
+    def exists(self, relative: PurePosixPath | str) -> bool:
+        return (self.root / str(relative)).is_file()
+
+    def glob(self, pattern: str) -> list[PurePosixPath]:
+        return sorted(
+            PurePosixPath(match.relative_to(self.root).as_posix())
+            for match in self.root.glob(pattern)
+            if match.is_file()
+        )
+
+    def read_bytes(self, relative: PurePosixPath | str) -> bytes:
+        try:
+            return (self.root / str(relative)).read_bytes()
+        except OSError as err:
+            raise ValidationError(f"could not read {relative} under {self.root}: {err}") from err
+
+    def href(self, relative: PurePosixPath | str) -> str:
+        return str(self.root / str(relative))
+
+
+class ArchiveSource(ProductSource):
+    """A product still inside the zip or tar it was downloaded as.
+
+    The member list is read once and kept; the archive itself is reopened for
+    each metadata read, of which there are one or two. Imagery is never read
+    through here — :meth:`href` hands GDAL a virtual filesystem path and GDAL
+    addresses the member directly.
+    """
+
+    def __init__(self, archive: Path, suffix: str, entries: tuple[str, ...]) -> None:
+        self.archive = archive
+        self.suffix = suffix
+        self.name = archive.name
+        self.location = archive
+        self.named_entry = None
+        self._entries = entries
+        self._set = frozenset(entries)
+
+    def exists(self, relative: PurePosixPath | str) -> bool:
+        return str(relative) in self._set
+
+    def glob(self, pattern: str) -> list[PurePosixPath]:
+        matches = _anchored(pattern)
+        return sorted(PurePosixPath(e) for e in self._entries if matches.fullmatch(e))
+
+    def read_bytes(self, relative: PurePosixPath | str) -> bytes:
+        try:
+            if self.suffix == ".zip":
+                with zipfile.ZipFile(self.archive) as archive:
+                    return archive.read(str(relative))
+            with tarfile.open(self.archive) as tar:
+                member = tar.extractfile(str(relative))
+                if member is None:
+                    raise ValidationError(f"{relative} is not a file in {self.archive.name}")
+                return member.read()
+        except (OSError, KeyError, zipfile.BadZipFile, tarfile.TarError) as err:
+            raise ValidationError(
+                f"could not read {relative} from {self.archive.name}: {err}"
+            ) from err
+
+    def href(self, relative: PurePosixPath | str) -> str:
+        # GDAL addresses an archive member as /vsizip/<archive path>/<member>.
+        # An absolute archive path leaves a doubled slash after the prefix,
+        # which is the documented spelling rather than an accident.
+        return f"/{_ARCHIVE_VSI[self.suffix]}/{self.archive.as_posix()}/{relative}"
+
+
+def _archive_entries(archive: Path, suffix: str) -> tuple[str, ...]:
+    """List an archive's file members, without extracting anything."""
+    try:
+        if suffix == ".zip":
+            with zipfile.ZipFile(archive) as zipped:
+                return tuple(info.filename for info in zipped.infolist() if not info.is_dir())
+        with tarfile.open(archive) as tarred:
+            return tuple(member.name for member in tarred.getmembers() if member.isfile())
+    except (OSError, zipfile.BadZipFile, tarfile.TarError) as err:
+        raise ValidationError(f"{archive.name} is not a readable archive: {err}") from err
+
+
+def open_product(path: StrPath, mission: str) -> ProductSource:
+    """Open whatever the caller pointed at as a source of product files.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A product directory, a directory holding one, a ``.zip`` or ``.tar``
+        holding one, or a single file inside a product directory.
+    mission : str
+        How to name the mission when the path turns out to hold nothing, e.g.
+        ``"Sentinel-2"``.
+
+    Returns
+    -------
+    ProductSource
+        A directory-backed source, or an archive-backed one.
+
+    Raises
+    ------
+    ValidationError
+        If the path does not exist, if the archive cannot be read, or if it is
+        a compressed archive.
+
+    Notes
+    -----
+    A compressed archive is refused with instructions rather than read. See the
+    module docstring for why the cost is not a constant factor.
+
+    Examples
+    --------
+    >>> open_product("S2B_MSIL2A_20240830T100559.SAFE", "Sentinel-2")  # doctest: +SKIP
+    <eeo.io._archive.DirectorySource object at ...>
+    """
+    candidate = Path(path)
+    if not candidate.exists():
+        raise ValidationError(f"no such {mission} product: {str(path)!r}")
+    if candidate.is_dir():
+        return DirectorySource(candidate)
+
+    suffix = candidate.suffix.lower()
+    if suffix in _COMPRESSED_SUFFIXES:
+        stem = candidate.name[: -len(candidate.suffix)]
+        raise ValidationError(
+            f"{candidate.name!r} is a compressed archive, which cannot be read in "
+            f"place: it holds no index, so reading one band would decompress every "
+            f"byte before it, once per band. Extract it first — "
+            f"`tar -xf {candidate.name}` — and pass the {stem!r} directory."
+        )
+    if suffix in _ARCHIVE_VSI:
+        return ArchiveSource(candidate, suffix, _archive_entries(candidate, suffix))
+
+    # A plain file: the caller named one file of a product, so read the
+    # directory around it and remember which file they meant.
+    return DirectorySource(candidate.parent, named_entry=PurePosixPath(candidate.name))

--- a/eeo/io/_archive.py
+++ b/eeo/io/_archive.py
@@ -109,23 +109,77 @@ class ProductSource(ABC):
 
     @abstractmethod
     def exists(self, relative: PurePosixPath | str) -> bool:
-        """Whether the source holds a file at this relative path."""
+        """Report whether the source holds a file at a relative path.
+
+        Parameters
+        ----------
+        relative : PurePosixPath or str
+            Path within the source.
+
+        Returns
+        -------
+        bool
+            True if a file sits there. Directories do not count.
+        """
 
     @abstractmethod
     def glob(self, pattern: str) -> list[PurePosixPath]:
-        """Relative paths of the files matching a glob pattern, sorted."""
+        """Find the files matching a glob pattern.
+
+        Parameters
+        ----------
+        pattern : str
+            Glob pattern, read as :meth:`pathlib.Path.glob` reads it: anchored
+            at the source root, with ``*`` stopping at a separator.
+
+        Returns
+        -------
+        list of PurePosixPath
+            Matching files, relative to the source, sorted.
+        """
 
     @abstractmethod
     def read_bytes(self, relative: PurePosixPath | str) -> bytes:
-        """Read one file whole. For metadata, never for imagery."""
+        """Read one file whole. For metadata, never for imagery.
+
+        Parameters
+        ----------
+        relative : PurePosixPath or str
+            Path within the source.
+
+        Returns
+        -------
+        bytes
+            The file's contents.
+        """
 
     @abstractmethod
     def href(self, relative: PurePosixPath | str) -> str:
-        """Return what rasterio should open to read this file."""
+        """Return what rasterio should open to read this file.
+
+        Parameters
+        ----------
+        relative : PurePosixPath or str
+            Path within the source.
+
+        Returns
+        -------
+        str
+            A path or virtual filesystem URL rasterio can open.
+        """
 
 
 class DirectorySource(ProductSource):
-    """A product unpacked into a directory."""
+    """A product unpacked into a directory.
+
+    Parameters
+    ----------
+    root : Path
+        The directory paths are resolved against.
+    named_entry : PurePosixPath or None, default None
+        The file the caller named, when they named one rather than the
+        directory. A reader honours it instead of searching.
+    """
 
     def __init__(self, root: Path, named_entry: PurePosixPath | None = None) -> None:
         self.root = root
@@ -160,6 +214,16 @@ class ArchiveSource(ProductSource):
     each metadata read, of which there are one or two. Imagery is never read
     through here — :meth:`href` hands GDAL a virtual filesystem path and GDAL
     addresses the member directly.
+
+    Parameters
+    ----------
+    archive : Path
+        The ``.zip`` or ``.tar`` file.
+    suffix : str
+        Which of the two it is, lowercased, as the key into the virtual
+        filesystem table.
+    entries : tuple of str
+        The archive's file members, listed once at construction.
     """
 
     def __init__(self, archive: Path, suffix: str, entries: tuple[str, ...]) -> None:
@@ -232,9 +296,25 @@ def nested_archive(source: ProductSource, mission: str) -> ProductSource | None:
     at the folder is what people do. One archive there is unambiguous; several
     are refused the same way several products are.
 
-    Returns None when the source is not a directory, when the caller named a
-    specific file, or when the directory holds no archive at all — in each case
-    there is nothing to resolve to and the caller's own search stands.
+    Parameters
+    ----------
+    source : ProductSource
+        Where the caller pointed. Only a directory source can hold an archive.
+    mission : str
+        How to name the mission in any error, e.g. ``"Sentinel-2"``.
+
+    Returns
+    -------
+    ProductSource or None
+        A source for the archive, or None when there is nothing to resolve to:
+        the source is not a directory, the caller named a specific file, or the
+        directory holds no archive at all. In each of those the caller's own
+        search stands.
+
+    Raises
+    ------
+    ValidationError
+        If the directory holds more than one archive.
     """
     if not isinstance(source, DirectorySource) or source.named_entry is not None:
         return None

--- a/eeo/io/_archive.py
+++ b/eeo/io/_archive.py
@@ -44,6 +44,7 @@ import tarfile
 import zipfile
 from abc import ABC, abstractmethod
 from pathlib import Path, PurePosixPath
+from typing import NamedTuple
 
 from eeo.core.exceptions import ValidationError
 from eeo.core.types import StrPath
@@ -209,6 +210,50 @@ def _archive_entries(archive: Path, suffix: str) -> tuple[str, ...]:
             return tuple(member.name for member in tarred.getmembers() if member.isfile())
     except (OSError, zipfile.BadZipFile, tarfile.TarError) as err:
         raise ValidationError(f"{archive.name} is not a readable archive: {err}") from err
+
+
+class Located(NamedTuple):
+    """A product's metadata file, and the source it was actually found in.
+
+    The source is returned alongside the path because finding a product can
+    change where the rest of it will be read from: pointing at a folder that
+    holds an archive resolves to that archive, and every later read has to go
+    there rather than to the folder.
+    """
+
+    source: ProductSource
+    path: PurePosixPath
+
+
+def nested_archive(source: ProductSource, mission: str) -> ProductSource | None:
+    """Open the one archive sitting inside a directory, if there is exactly one.
+
+    A download that has not been unpacked still lives in a folder, and pointing
+    at the folder is what people do. One archive there is unambiguous; several
+    are refused the same way several products are.
+
+    Returns None when the source is not a directory, when the caller named a
+    specific file, or when the directory holds no archive at all — in each case
+    there is nothing to resolve to and the caller's own search stands.
+    """
+    if not isinstance(source, DirectorySource) or source.named_entry is not None:
+        return None
+
+    archives = sorted(
+        entry
+        for entry in source.root.iterdir()
+        if entry.is_file() and entry.suffix.lower() in _ARCHIVE_VSI
+    )
+    if not archives:
+        return None
+    if len(archives) > 1:
+        raise ValidationError(
+            f"{str(source.root)!r} holds {len(archives)} archives, so which one to "
+            f"load cannot be told from the path alone: "
+            f"{', '.join(archive.name for archive in archives)}. "
+            f"Name the one you mean."
+        )
+    return open_product(archives[0], mission)
 
 
 def open_product(path: StrPath, mission: str) -> ProductSource:

--- a/eeo/io/_bands.py
+++ b/eeo/io/_bands.py
@@ -1,0 +1,417 @@
+"""Per-sensor band tables, and resolving a band name to a file on disk.
+
+Every mission numbers its bands its own way, and the numbering is not
+transferable: **Landsat 7's red is band 3 where Landsat 8 and 9's red is
+band 4**, so ``SR_B4`` is red on one sensor and near-infrared on the other.
+Asking for a band by number is therefore a question that cannot be answered
+without knowing the mission, and a script that moves between missions silently
+computes an index over the wrong wavelengths. Common names — ``"red"``,
+``"nir"``, ``"swir16"`` — are the primary spelling here for that reason; the
+native ids are accepted as aliases within a sensor's own table.
+
+The common names follow the STAC Electro-Optical extension, which is what the
+catalogues use and therefore what :mod:`eeo.io.stac` already returns, so a band
+called ``"red"`` means the same thing whether a scene was loaded from a
+catalogue or from a folder.
+
+Notes
+-----
+Every entry below was derived from real scenes rather than from documentation:
+the Landsat mapping by reading which ``SR_B*`` file each common-name asset of a
+real Landsat 5, 7, 8 and 9 product resolves to, and the Sentinel-2 mapping from
+the ``eo:bands`` of the live ``sentinel-2-l2a`` collections
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from eeo.core.exceptions import ValidationError
+
+# Sentinel-2 spells single-digit bands with a leading zero ("B04"), so a caller
+# who types "B4" is asking for the same band.
+_SHORT_S2_BAND = re.compile(r"^B(\d)$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class BandInfo:
+    """One band of one sensor.
+
+    Attributes
+    ----------
+    common_name : str
+        Cross-sensor name, e.g. ``"red"``. The primary spelling.
+    band_id : str
+        The mission's own identifier and the token its files carry, e.g.
+        ``"B04"`` for Sentinel-2 or ``"SR_B4"`` for Landsat.
+    wavelength : float or None
+        Centre wavelength in micrometres, or None for a band that measures no
+        single wavelength, such as a quality mask.
+    resolution : int
+        Pixel size in metres as the band is *delivered*, which is not always
+        the instrument's own resolution — Landsat's thermal band is sensed at
+        100 m and delivered resampled to 30 m.
+    kind : str
+        ``"reflectance"``, ``"temperature"``, ``"quality"``, or ``"ancillary"``.
+        Quality bands hold class numbers or packed bits, so they must never be
+        resampled by anything but nearest neighbour.
+    """
+
+    common_name: str
+    band_id: str
+    wavelength: float | None
+    resolution: int
+    kind: str
+
+
+def _table(entries: tuple[BandInfo, ...]) -> dict[str, BandInfo]:
+    """Key a band table by common name."""
+    return {band.common_name: band for band in entries}
+
+
+#: Sentinel-2 Level-2A. No ``B10``: the cirrus band is not written to L2A.
+SENTINEL2 = _table(
+    (
+        BandInfo("coastal", "B01", 0.443, 60, "reflectance"),
+        BandInfo("blue", "B02", 0.490, 10, "reflectance"),
+        BandInfo("green", "B03", 0.560, 10, "reflectance"),
+        BandInfo("red", "B04", 0.665, 10, "reflectance"),
+        BandInfo("rededge1", "B05", 0.704, 20, "reflectance"),
+        BandInfo("rededge2", "B06", 0.740, 20, "reflectance"),
+        BandInfo("rededge3", "B07", 0.783, 20, "reflectance"),
+        BandInfo("nir", "B08", 0.842, 10, "reflectance"),
+        BandInfo("nir08", "B8A", 0.865, 20, "reflectance"),
+        BandInfo("nir09", "B09", 0.945, 60, "reflectance"),
+        BandInfo("swir16", "B11", 1.610, 20, "reflectance"),
+        BandInfo("swir22", "B12", 2.190, 20, "reflectance"),
+        BandInfo("scl", "SCL", None, 20, "quality"),
+        BandInfo("aot", "AOT", None, 10, "ancillary"),
+        BandInfo("wvp", "WVP", None, 10, "ancillary"),
+        BandInfo("tci", "TCI", None, 10, "ancillary"),
+    )
+)
+
+#: Landsat 8 and 9 (OLI/TIRS and OLI-2/TIRS-2), which share a band numbering.
+LANDSAT_OLI = _table(
+    (
+        BandInfo("coastal", "SR_B1", 0.44, 30, "reflectance"),
+        BandInfo("blue", "SR_B2", 0.48, 30, "reflectance"),
+        BandInfo("green", "SR_B3", 0.56, 30, "reflectance"),
+        BandInfo("red", "SR_B4", 0.65, 30, "reflectance"),
+        BandInfo("nir08", "SR_B5", 0.87, 30, "reflectance"),
+        BandInfo("swir16", "SR_B6", 1.61, 30, "reflectance"),
+        BandInfo("swir22", "SR_B7", 2.20, 30, "reflectance"),
+        BandInfo("lwir11", "ST_B10", 10.90, 30, "temperature"),
+        BandInfo("qa_pixel", "QA_PIXEL", None, 30, "quality"),
+        BandInfo("qa_radsat", "QA_RADSAT", None, 30, "quality"),
+        BandInfo("qa_aerosol", "SR_QA_AEROSOL", None, 30, "quality"),
+    )
+)
+
+#: Landsat 4, 5 and 7 (TM and ETM+). Numbering differs from OLI: red is band 3
+#: here and band 4 there, and there is no coastal band at all.
+LANDSAT_TM = _table(
+    (
+        BandInfo("blue", "SR_B1", 0.48, 30, "reflectance"),
+        BandInfo("green", "SR_B2", 0.56, 30, "reflectance"),
+        BandInfo("red", "SR_B3", 0.66, 30, "reflectance"),
+        BandInfo("nir08", "SR_B4", 0.84, 30, "reflectance"),
+        BandInfo("swir16", "SR_B5", 1.65, 30, "reflectance"),
+        BandInfo("swir22", "SR_B7", 2.20, 30, "reflectance"),
+        BandInfo("lwir", "ST_B6", 11.45, 30, "temperature"),
+        BandInfo("qa_pixel", "QA_PIXEL", None, 30, "quality"),
+        BandInfo("qa_radsat", "QA_RADSAT", None, 30, "quality"),
+        BandInfo("atmos_opacity", "SR_ATMOS_OPACITY", None, 30, "ancillary"),
+        BandInfo("cloud_qa", "SR_CLOUD_QA", None, 30, "quality"),
+    )
+)
+
+#: Landsat mission number to its band table.
+_LANDSAT_TABLES = {4: LANDSAT_TM, 5: LANDSAT_TM, 7: LANDSAT_TM, 8: LANDSAT_OLI, 9: LANDSAT_OLI}
+
+
+def landsat_bands(mission: int) -> dict[str, BandInfo]:
+    """Return the band table for one Landsat mission.
+
+    Parameters
+    ----------
+    mission : int
+        Landsat mission number, e.g. ``9``.
+
+    Returns
+    -------
+    dict of str to BandInfo
+        The mission's bands, keyed by common name.
+
+    Raises
+    ------
+    ValidationError
+        If the mission has no Collection 2 Level-2 band table.
+
+    Examples
+    --------
+    >>> landsat_bands(9)["red"].band_id
+    'SR_B4'
+    >>> landsat_bands(7)["red"].band_id
+    'SR_B3'
+    """
+    try:
+        return _LANDSAT_TABLES[mission]
+    except KeyError:
+        raise ValidationError(
+            f"no band table for Landsat {mission}; supported missions are "
+            f"{', '.join(str(m) for m in sorted(_LANDSAT_TABLES))}"
+        ) from None
+
+
+def _aliases(bands: Mapping[str, BandInfo]) -> dict[str, BandInfo]:
+    """Build every accepted spelling for a table, lowercased."""
+    lookup: dict[str, BandInfo] = {}
+    for band in bands.values():
+        lookup[band.common_name.lower()] = band
+        lookup[band.band_id.lower()] = band
+        # "SR_B4" is also reachable as "B4"; "B04" is also reachable as "B4".
+        _, _, bare = band.band_id.partition("_")
+        if bare:
+            lookup.setdefault(bare.lower(), band)
+        short = _SHORT_S2_BAND.match(band.band_id)
+        if short is None and band.band_id.lower().startswith("b0"):
+            lookup.setdefault(f"b{band.band_id[2:]}".lower(), band)
+    return lookup
+
+
+def resolve_band(spec: str, bands: Mapping[str, BandInfo]) -> BandInfo:
+    """Resolve one band name or native id against a sensor's table.
+
+    Matching is case-insensitive and ignores surrounding whitespace, but is
+    otherwise exact: no fuzzy matching and no guessing between sensors.
+
+    Parameters
+    ----------
+    spec : str
+        A common name (``"red"``), a native id (``"B04"``, ``"SR_B4"``), or a
+        native id without its product prefix (``"B4"``).
+    bands : Mapping of str to BandInfo
+        The sensor's table, from :data:`SENTINEL2` or :func:`landsat_bands`.
+
+    Returns
+    -------
+    BandInfo
+        The matching band.
+
+    Raises
+    ------
+    ValidationError
+        If ``spec`` is not a string, or names no band in this table. The
+        message lists the names the sensor does have.
+
+    Examples
+    --------
+    >>> resolve_band("red", SENTINEL2).band_id
+    'B04'
+    >>> resolve_band(" NIR ", SENTINEL2).common_name
+    'nir'
+    >>> resolve_band("SR_B3", landsat_bands(7)).common_name
+    'red'
+    """
+    if not isinstance(spec, str):
+        raise ValidationError(
+            f"a band must be named by a string, such as 'red' or 'B04'; got {spec!r}"
+        )
+    band = _aliases(bands).get(spec.strip().lower())
+    if band is None:
+        raise ValidationError(
+            f"no band {spec!r} on this sensor; available bands are "
+            f"{', '.join(sorted(bands))} (or their ids: "
+            f"{', '.join(b.band_id for b in bands.values())})"
+        )
+    return band
+
+
+def resolve_bands(specs: Sequence[str], bands: Mapping[str, BandInfo]) -> list[BandInfo]:
+    """Resolve several band names, preserving order and rejecting duplicates.
+
+    Parameters
+    ----------
+    specs : sequence of str
+        Band names or ids, in the order they should become bands.
+    bands : Mapping of str to BandInfo
+        The sensor's table.
+
+    Returns
+    -------
+    list of BandInfo
+        The matching bands, in the order given.
+
+    Raises
+    ------
+    ValidationError
+        If ``specs`` is empty, names an unknown band, or names one band twice
+        — including twice under different spellings, since ``"red"`` and
+        ``"B04"`` would otherwise produce two identical bands.
+
+    Examples
+    --------
+    >>> [b.band_id for b in resolve_bands(["red", "nir"], SENTINEL2)]
+    ['B04', 'B08']
+    """
+    if isinstance(specs, str):
+        raise ValidationError(
+            f"expected a sequence of band names, such as ['red', 'nir']; got {specs!r}"
+        )
+    resolved = [resolve_band(spec, bands) for spec in specs]
+    if not resolved:
+        raise ValidationError("name at least one band to load; got an empty sequence")
+
+    seen: dict[str, str] = {}
+    for spec, band in zip(specs, resolved, strict=True):
+        if band.common_name in seen:
+            raise ValidationError(
+                f"band {band.common_name!r} named twice, as {seen[band.common_name]!r} "
+                f"and {spec!r}; each band can only be loaded once"
+            )
+        seen[band.common_name] = spec
+    return resolved
+
+
+def finest_resolution(bands: Sequence[BandInfo]) -> int:
+    """Return the finest native pixel size among some bands, in metres.
+
+    This is the default output grid for a load: it never discards detail a
+    requested band actually has, and never invents detail by upsampling every
+    band to a resolution only one of them was sensed at.
+
+    Parameters
+    ----------
+    bands : sequence of BandInfo
+        The bands being loaded.
+
+    Returns
+    -------
+    int
+        The smallest :attr:`BandInfo.resolution` among them.
+
+    Raises
+    ------
+    ValidationError
+        If no bands are given.
+
+    Examples
+    --------
+    >>> finest_resolution(resolve_bands(["red", "swir16"], SENTINEL2))
+    10
+    """
+    if not bands:
+        raise ValidationError("name at least one band; got an empty sequence")
+    return min(band.resolution for band in bands)
+
+
+def sentinel2_available_resolutions(image_files: Sequence[str], band: BandInfo) -> list[int]:
+    """List the resolutions a Sentinel-2 product actually holds a band at.
+
+    Availability is read from the product rather than assumed, because it is
+    irregular and baseline-dependent: ``B01`` is sensed at 60 m yet written at
+    both 20 m and 60 m from baseline 04.00 onward, ``B08`` is written only at
+    10 m, and ``B09`` only at 60 m.
+
+    Parameters
+    ----------
+    image_files : sequence of str
+        The manifest's image paths, extensionless, as
+        :attr:`~eeo.io._sentinel2.Sentinel2Product.image_files` gives them.
+    band : BandInfo
+        The band to look for.
+
+    Returns
+    -------
+    list of int
+        Resolutions in metres, ascending. Empty when the product holds no file
+        for the band at all.
+
+    Examples
+    --------
+    >>> files = ["GRANULE/g/IMG_DATA/R20m/T32TPS_20240929T100719_B01_20m"]
+    >>> sentinel2_available_resolutions(files, SENTINEL2["coastal"])
+    [20]
+    """
+    pattern = re.compile(rf"/R(\d+)m/.*_{re.escape(band.band_id)}_(\d+)m$", re.IGNORECASE)
+    found = {int(m.group(1)) for m in (pattern.search(f) for f in image_files) if m}
+    return sorted(found)
+
+
+def sentinel2_band_file(image_files: Sequence[str], band: BandInfo, resolution: int) -> str:
+    """Find a Sentinel-2 band's image path at one resolution.
+
+    Parameters
+    ----------
+    image_files : sequence of str
+        The manifest's image paths, extensionless.
+    band : BandInfo
+        The band to find.
+    resolution : int
+        Pixel size in metres, one of 10, 20, or 60.
+
+    Returns
+    -------
+    str
+        The path, relative to the ``.SAFE`` directory and without a file
+        extension — the manifest does not record one.
+
+    Raises
+    ------
+    ValidationError
+        If the product holds no file for the band at that resolution. The
+        message names the resolutions it does hold, so a caller asking for a
+        10 m ``swir16`` is told it exists at 20 m and 60 m rather than merely
+        that something is missing.
+    """
+    pattern = re.compile(
+        rf"/R{resolution}m/.*_{re.escape(band.band_id)}_{resolution}m$", re.IGNORECASE
+    )
+    for path in image_files:
+        if pattern.search(path):
+            return path
+
+    available = sentinel2_available_resolutions(image_files, band)
+    if not available:
+        raise ValidationError(
+            f"this product holds no {band.common_name!r} ({band.band_id}) band at all"
+        )
+    raise ValidationError(
+        f"{band.common_name!r} ({band.band_id}) is not available at {resolution} m in "
+        f"this product; it is written at {', '.join(f'{r} m' for r in available)}"
+    )
+
+
+def landsat_band_file(band_files: Mapping[str, str], band: BandInfo) -> str:
+    """Find a Landsat band's image filename.
+
+    Parameters
+    ----------
+    band_files : Mapping of str to str
+        Filenames keyed by band token, as
+        :attr:`~eeo.io._landsat.LandsatProduct.band_files` gives them.
+    band : BandInfo
+        The band to find.
+
+    Returns
+    -------
+    str
+        The filename, relative to the product directory.
+
+    Raises
+    ------
+    ValidationError
+        If the product lists no file for the band. A Level-2 reflectance-only
+        product legitimately has no thermal band, so this is a normal outcome
+        rather than a corrupt product.
+    """
+    filename = band_files.get(band.band_id)
+    if filename is None:
+        raise ValidationError(
+            f"this product holds no {band.common_name!r} ({band.band_id}) band; "
+            f"it holds {', '.join(sorted(band_files))}"
+        )
+    return filename

--- a/eeo/io/_landsat.py
+++ b/eeo/io/_landsat.py
@@ -1,0 +1,401 @@
+"""Identifying and reading the metadata of a Landsat Collection 2 product.
+
+A downloaded Landsat product is a directory of single-band GeoTIFFs beside one
+metadata file, written three times over in different syntaxes: ``*_MTL.xml``,
+``*_MTL.json``, and ``*_MTL.txt``. All three carry the same content under the
+same group names, so they are parsed into one shape — a mapping of group name
+to that group's key-value pairs — and read from there.
+
+Reading is **group-scoped, never by key name alone**. A Level-2 metadata file
+documents the Level-1 product it was derived from as well as itself, so the same
+key appears twice with different values: ``PROCESSING_LEVEL`` is ``L2SP`` under
+``PRODUCT_CONTENTS`` and ``L1TP`` under ``LEVEL1_PROCESSING_RECORD``, and
+``REFLECTANCE_MULT_BAND_4`` is the surface-reflectance coefficient
+(``2.75e-05``) under ``LEVEL2_SURFACE_REFLECTANCE_PARAMETERS`` but the
+top-of-atmosphere one (``2.0000E-05``) under ``LEVEL1_RADIOMETRIC_RESCALING``.
+Searching for a bare key name would pick whichever came first, which is a
+property of the file's ordering rather than of its meaning.
+
+Landsat has no "L1C" or "L2A" — that vocabulary belongs to Sentinel-2 and does
+not transfer. Landsat levels are ``L1TP``/``L1GT``/``L1GS`` and ``L2SP``/
+``L2SR``, and only the Level-2 pair is supported here.
+
+Every field read here was checked against real USGS output rather than
+documentation, using ``LC09_L2SP_193028_20260822_02_T1`` and
+``LE07_L2SP_193028_20231024_02_T2`` in all three syntaxes. Three details worth
+keeping in mind: ``SCENE_CENTER_TIME`` is written with seven fractional digits
+(``10:04:22.1183580Z``), which is more precision than
+:meth:`datetime.datetime.fromisoformat` accepts; ``WRS_ROW`` is zero-padded in
+the ODL text (``028``) but not in the JSON (``28``); and Landsat 7 has no
+band 6 in surface reflectance and no band 9 at all, so a per-band table read
+from one sensor must never be assumed to fit another.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from eeo.core.exceptions import ValidationError
+from eeo.core.types import StrPath
+
+#: Metadata syntaxes, in the order they are preferred when several are present.
+_METADATA_SUFFIXES = ("_MTL.xml", "_MTL.json", "_MTL.txt")
+
+#: The document's outermost group, which wraps every other group.
+_ROOT_GROUP = "LANDSAT_METADATA_FILE"
+
+#: Groups the fields below are read from.
+_CONTENTS = "PRODUCT_CONTENTS"
+_ATTRIBUTES = "IMAGE_ATTRIBUTES"
+_REFLECTANCE = "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS"
+_TEMPERATURE = "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS"
+
+#: Product-id prefix to mission number and instrument. Landsat 8 and 9 share a
+#: product layout and band numbering; Landsat 4, 5, and 7 share a different one.
+_SENSORS = {
+    "LT04": (4, "TM"),
+    "LT05": (5, "TM"),
+    "LE07": (7, "ETM+"),
+    "LC08": (8, "OLI/TIRS"),
+    "LC09": (9, "OLI-2/TIRS-2"),
+}
+
+#: Level-2 processing levels: a science product (reflectance and temperature)
+#: and a reflectance-only product for scenes where temperature cannot be made.
+_SUPPORTED_LEVELS = ("L2SP", "L2SR")
+
+#: Level-1 processing levels, recognised only so they can be refused by name.
+_LEVEL1_LEVELS = ("L1TP", "L1GT", "L1GS")
+
+_MULT = re.compile(r"^REFLECTANCE_MULT_BAND_(\w+)$")
+_TEMP_MULT = re.compile(r"^TEMPERATURE_MULT_BAND_(\w+)$")
+
+
+@dataclass(frozen=True)
+class LandsatProduct:
+    """What a Landsat Collection 2 metadata file says about its product.
+
+    Attributes
+    ----------
+    path : Path
+        The directory holding the product.
+    metadata : Path
+        The metadata file that was read.
+    product_id : str
+        Full ``LANDSAT_PRODUCT_ID``, e.g.
+        ``"LC09_L2SP_193028_20260822_20260823_02_T1"``.
+    level : str
+        Processing level, ``"L2SP"`` or ``"L2SR"``.
+    mission : int
+        Landsat mission number, e.g. ``9``.
+    instrument : str
+        Instrument name, e.g. ``"OLI-2/TIRS-2"``.
+    spacecraft : str
+        The file's own ``SPACECRAFT_ID``, e.g. ``"LANDSAT_9"``.
+    wrs_path, wrs_row : str
+        WRS-2 path and row, zero-padded to three digits so they read the same
+        whichever syntax the metadata was written in.
+    acquired : datetime.datetime
+        Scene centre acquisition time, timezone-aware in UTC.
+    collection_number, collection_category : str
+        Collection number (``"02"``) and tier (``"T1"``, ``"T2"``, ``"RT"``).
+    reflectance_scaling : dict of str to tuple of float
+        ``(multiplier, additive)`` per surface-reflectance band, keyed by the
+        band's file token (``"SR_B4"``). Converts a digital number to
+        reflectance.
+    temperature_scaling : dict of str to tuple of float
+        ``(multiplier, additive)`` per surface-temperature band, keyed by file
+        token (``"ST_B10"``). Converts a digital number to kelvin.
+    band_files : dict of str to str
+        Image filenames the metadata lists, keyed by file token
+        (``"SR_B4"``, ``"ST_B10"``, ``"QA_PIXEL"``).
+    groups : dict of str to dict
+        The whole parsed document, group by group, for anything not lifted out
+        above.
+    """
+
+    path: Path
+    metadata: Path
+    product_id: str
+    level: str
+    mission: int
+    instrument: str
+    spacecraft: str
+    wrs_path: str
+    wrs_row: str
+    acquired: dt.datetime
+    collection_number: str
+    collection_category: str
+    reflectance_scaling: dict[str, tuple[float, float]]
+    temperature_scaling: dict[str, tuple[float, float]]
+    band_files: dict[str, str]
+    groups: dict[str, dict[str, str]]
+
+
+def find_metadata(path: StrPath) -> Path:
+    """Locate a Landsat product's metadata file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A product directory, or a metadata file directly.
+
+    Returns
+    -------
+    Path
+        The metadata file, preferring ``_MTL.xml`` over ``_MTL.json`` over
+        ``_MTL.txt`` when more than one is present.
+
+    Raises
+    ------
+    ValidationError
+        If the path does not exist or holds no metadata file.
+
+    Examples
+    --------
+    >>> find_metadata("LC09_L2SP_193028_20260822_02_T1")  # doctest: +SKIP
+    PosixPath('LC09_L2SP_193028_20260822_02_T1/..._MTL.xml')
+    """
+    candidate = Path(path)
+    if not candidate.exists():
+        raise ValidationError(f"no such Landsat product: {str(path)!r}")
+    if candidate.is_file():
+        return candidate
+
+    for suffix in _METADATA_SUFFIXES:
+        matches = sorted(candidate.glob(f"*{suffix}"))
+        if matches:
+            return matches[0]
+
+    raise ValidationError(
+        f"{str(path)!r} holds no Landsat metadata file; expected one ending in "
+        f"{', '.join(_METADATA_SUFFIXES)}"
+    )
+
+
+def _parse_odl(text: str) -> dict[str, dict[str, str]]:
+    """Parse the ODL text syntax into groups of key-value pairs."""
+    groups: dict[str, dict[str, str]] = {}
+    stack: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line == "END":
+            continue
+        key, _, value = line.partition("=")
+        key, value = key.strip(), value.strip()
+        if key == "GROUP":
+            stack.append(value)
+            groups.setdefault(value, {})
+        elif key == "END_GROUP":
+            if stack:
+                stack.pop()
+        elif stack:
+            groups[stack[-1]][key] = value.strip('"')
+    groups.pop(_ROOT_GROUP, None)
+    return groups
+
+
+def _parse_json(text: str) -> dict[str, dict[str, str]]:
+    """Parse the JSON syntax into groups of key-value pairs."""
+    document = json.loads(text)
+    root = document.get(_ROOT_GROUP, document)
+    return {
+        group: {key: str(value) for key, value in members.items()}
+        for group, members in root.items()
+        if isinstance(members, Mapping)
+    }
+
+
+def _parse_xml(text: str) -> dict[str, dict[str, str]]:
+    """Parse the XML syntax into groups of key-value pairs."""
+    root = ET.fromstring(text)
+    return {
+        group.tag: {member.tag: (member.text or "").strip() for member in group if len(member) == 0}
+        for group in root
+    }
+
+
+def read_metadata_groups(metadata: Path) -> dict[str, dict[str, str]]:
+    """Parse a Landsat metadata file of any syntax into groups.
+
+    Parameters
+    ----------
+    metadata : Path
+        An ``_MTL.xml``, ``_MTL.json``, or ``_MTL.txt`` file. The syntax is
+        chosen by suffix, since all three carry identical content.
+
+    Returns
+    -------
+    dict
+        Group name to that group's key-value pairs, values as strings. The
+        outermost ``LANDSAT_METADATA_FILE`` wrapper is unwrapped.
+
+    Raises
+    ------
+    ValidationError
+        If the file cannot be parsed in its syntax.
+    """
+    text = metadata.read_text(errors="replace")
+    parsers = {".xml": _parse_xml, ".json": _parse_json}
+    parser = parsers.get(metadata.suffix.lower(), _parse_odl)
+    try:
+        return parser(text)
+    except (ET.ParseError, json.JSONDecodeError, ValueError) as err:
+        raise ValidationError(f"{metadata.name} is not readable: {err}") from err
+
+
+def _require(groups: Mapping[str, Mapping[str, str]], group: str, key: str) -> str:
+    """Read one key from one group, failing with both names when it is absent."""
+    value = groups.get(group, {}).get(key)
+    if value is None or not value.strip():
+        raise ValidationError(
+            f"the Landsat metadata states no {key} in {group}, so the product cannot be identified"
+        )
+    return value.strip()
+
+
+def _scaling(group: Mapping[str, str], pattern: re.Pattern[str], prefix: str) -> dict:
+    """Pair each MULT coefficient in a group with its matching ADD coefficient."""
+    found: dict[str, tuple[float, float]] = {}
+    for key, value in group.items():
+        match = pattern.match(key)
+        if match is None:
+            continue
+        band = match.group(1)
+        add = group.get(key.replace("_MULT_", "_ADD_"))
+        if add is None:
+            continue
+        try:
+            coefficients = (float(value), float(add))
+        except ValueError as err:
+            raise ValidationError(
+                f"scaling coefficients for band {band} are not numbers; got {value!r} and {add!r}"
+            ) from err
+        # Reflectance keys name the band by number alone; temperature keys
+        # already carry the ST_ token.
+        found[band if band.startswith(prefix) else f"{prefix}{band}"] = coefficients
+    return found
+
+
+def _acquired(groups: Mapping[str, Mapping[str, str]]) -> dt.datetime:
+    """Combine the acquisition date and scene centre time into one instant."""
+    date = _require(groups, _ATTRIBUTES, "DATE_ACQUIRED")
+    time = _require(groups, _ATTRIBUTES, "SCENE_CENTER_TIME").rstrip("Zz")
+    # USGS writes seven fractional digits; fromisoformat accepts three or six,
+    # so the value is truncated to microseconds rather than rejected.
+    if "." in time:
+        whole, _, fraction = time.partition(".")
+        time = f"{whole}.{fraction[:6].ljust(6, '0')}"
+    try:
+        parsed = dt.datetime.fromisoformat(f"{date}T{time}")
+    except ValueError as err:
+        raise ValidationError(
+            f"could not read the acquisition time; got DATE_ACQUIRED={date!r} "
+            f"and SCENE_CENTER_TIME={time!r}"
+        ) from err
+    return parsed.replace(tzinfo=dt.timezone.utc)
+
+
+def read_product(path: StrPath, *, level: str | None = None) -> LandsatProduct:
+    """Identify a Landsat Collection 2 product and read its metadata.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A product directory, or a metadata file directly.
+    level : str or None, default None
+        Assert the processing level rather than detecting it. Exists for a
+        product whose metadata is damaged; when the metadata states a level and
+        this contradicts it, the metadata wins and this raises.
+
+    Returns
+    -------
+    LandsatProduct
+        The product's identity, geometry, scaling coefficients, and file list.
+
+    Raises
+    ------
+    ValidationError
+        If no metadata file is found, it cannot be parsed, the product is a
+        Level-1 product, its mission is not recognised, or ``level``
+        contradicts the metadata.
+
+    Notes
+    -----
+    Level-1 products are refused. They are scaled radiance rather than surface
+    reflectance, with different coefficients and a different band list.
+
+    Examples
+    --------
+    >>> product = read_product("LC09_L2SP_193028_20260822_02_T1")  # doctest: +SKIP
+    >>> product.mission, product.level, product.wrs_row  # doctest: +SKIP
+    (9, 'L2SP', '028')
+    """
+    metadata = find_metadata(path)
+    groups = read_metadata_groups(metadata)
+
+    detected = groups.get(_CONTENTS, {}).get("PROCESSING_LEVEL", "").strip().upper()
+    if level is not None:
+        wanted = level.strip().upper()
+        if detected and detected != wanted:
+            raise ValidationError(
+                f"level={level!r} contradicts the product, which reports {detected} "
+                f"in {metadata.name}. Remove the override to use the product's own level."
+            )
+        detected = wanted
+    if not detected:
+        raise ValidationError(
+            f"{metadata.name} states no PROCESSING_LEVEL in {_CONTENTS}, so the "
+            f"product cannot be identified"
+        )
+    if detected in _LEVEL1_LEVELS:
+        raise ValidationError(
+            f"Level-1 is not supported; {metadata.name} reports a {detected} product. "
+            f"Easy-EO reads Collection 2 Level-2 surface reflectance, so download the "
+            f"L2SP or L2SR product for this scene."
+        )
+    if detected not in _SUPPORTED_LEVELS:
+        raise ValidationError(
+            f"unrecognised Landsat processing level {detected!r} in {metadata.name}; "
+            f"expected one of {', '.join(_SUPPORTED_LEVELS)}"
+        )
+
+    product_id = _require(groups, _CONTENTS, "LANDSAT_PRODUCT_ID")
+    prefix = product_id[:4].upper()
+    if prefix not in _SENSORS:
+        raise ValidationError(
+            f"unrecognised Landsat mission {prefix!r} in product id {product_id!r}; "
+            f"supported missions are {', '.join(sorted(_SENSORS))}"
+        )
+    mission, instrument = _SENSORS[prefix]
+
+    band_files = {}
+    for key, value in groups.get(_CONTENTS, {}).items():
+        if key.startswith("FILE_NAME_") and value.upper().endswith(".TIF"):
+            token = Path(value).stem
+            band_files[token.removeprefix(f"{product_id}_")] = value
+
+    return LandsatProduct(
+        path=metadata.parent,
+        metadata=metadata,
+        product_id=product_id,
+        level=detected,
+        mission=mission,
+        instrument=instrument,
+        spacecraft=groups.get(_ATTRIBUTES, {}).get("SPACECRAFT_ID", "").strip(),
+        wrs_path=_require(groups, _ATTRIBUTES, "WRS_PATH").zfill(3),
+        wrs_row=_require(groups, _ATTRIBUTES, "WRS_ROW").zfill(3),
+        acquired=_acquired(groups),
+        collection_number=groups.get(_CONTENTS, {}).get("COLLECTION_NUMBER", "").strip(),
+        collection_category=groups.get(_CONTENTS, {}).get("COLLECTION_CATEGORY", "").strip(),
+        reflectance_scaling=_scaling(groups.get(_REFLECTANCE, {}), _MULT, "SR_B"),
+        temperature_scaling=_scaling(groups.get(_TEMPERATURE, {}), _TEMP_MULT, "ST_"),
+        band_files=band_files,
+        groups=groups,
+    )

--- a/eeo/io/_landsat.py
+++ b/eeo/io/_landsat.py
@@ -43,7 +43,7 @@ from xml.etree import ElementTree as ET
 
 from eeo.core.exceptions import ValidationError
 from eeo.core.types import StrPath
-from eeo.io._archive import ProductSource, open_product
+from eeo.io._archive import Located, ProductSource, nested_archive, open_product
 
 #: Metadata syntaxes, in the order they are preferred when several are present.
 _METADATA_SUFFIXES = ("_MTL.xml", "_MTL.json", "_MTL.txt")
@@ -146,7 +146,7 @@ class LandsatProduct:
     groups: dict[str, dict[str, str]]
 
 
-def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
+def find_metadata(source: StrPath | ProductSource) -> Located:
     """Locate a Landsat product's metadata file within a source.
 
     Parameters
@@ -157,10 +157,12 @@ def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
 
     Returns
     -------
-    PurePosixPath
-        The metadata file's path **relative to the source**, preferring
-        ``_MTL.xml`` over ``_MTL.json`` over ``_MTL.txt`` when more than one is
-        present. Its parent is the product root.
+    Located
+        The source the metadata was found in, and its path **relative to that
+        source**, preferring ``_MTL.xml`` over ``_MTL.json`` over ``_MTL.txt``
+        when more than one is present. The path's parent is the product root.
+        The source is not always the one passed in: pointing at a folder that
+        holds a ``.tar`` resolves to the tar.
 
     Raises
     ------
@@ -169,12 +171,12 @@ def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
 
     Examples
     --------
-    >>> find_metadata("LC09_L2SP_193028_20260822_02_T1")  # doctest: +SKIP
+    >>> find_metadata("LC09_L2SP_193028_20260822_02_T1").path  # doctest: +SKIP
     PurePosixPath('LC09_L2SP_193028_20260822_20260823_02_T1_MTL.xml')
     """
     opened = source if isinstance(source, ProductSource) else open_product(source, "Landsat")
     if opened.named_entry is not None:
-        return opened.named_entry
+        return Located(opened, opened.named_entry)
 
     # A USGS tar holds its files at the root; a directory the product was
     # unpacked into holds them one level down. Either way there must be exactly
@@ -191,11 +193,16 @@ def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
                     f"Name the one you mean."
                 )
             if matches:
-                return matches[0]
+                return Located(opened, matches[0])
+
+    # The folder may hold the product still tarred, which is how it arrives.
+    archive = nested_archive(opened, "Landsat")
+    if archive is not None:
+        return find_metadata(archive)
 
     raise ValidationError(
         f"{str(opened.location)!r} holds no Landsat metadata file; expected one ending in "
-        f"{', '.join(_METADATA_SUFFIXES)}"
+        f"{', '.join(_METADATA_SUFFIXES)}, or a .tar holding one"
     )
 
 
@@ -363,8 +370,9 @@ def read_product(path: StrPath | ProductSource, *, level: str | None = None) -> 
     >>> product.mission, product.level, product.wrs_row  # doctest: +SKIP
     (9, 'L2SP', '028')
     """
-    source = path if isinstance(path, ProductSource) else open_product(path, "Landsat")
-    metadata = find_metadata(source)
+    source, metadata = find_metadata(
+        path if isinstance(path, ProductSource) else open_product(path, "Landsat")
+    )
     groups = read_metadata_groups(source, metadata)
 
     detected = groups.get(_CONTENTS, {}).get("PROCESSING_LEVEL", "").strip().upper()

--- a/eeo/io/_landsat.py
+++ b/eeo/io/_landsat.py
@@ -38,11 +38,12 @@ import json
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import PurePosixPath
 from xml.etree import ElementTree as ET
 
 from eeo.core.exceptions import ValidationError
 from eeo.core.types import StrPath
+from eeo.io._archive import ProductSource, open_product
 
 #: Metadata syntaxes, in the order they are preferred when several are present.
 _METADATA_SUFFIXES = ("_MTL.xml", "_MTL.json", "_MTL.txt")
@@ -83,10 +84,15 @@ class LandsatProduct:
 
     Attributes
     ----------
-    path : Path
-        The directory holding the product.
-    metadata : Path
-        The metadata file that was read.
+    source : ProductSource
+        Where the product's files are read from — a directory, a tar, or a zip.
+    root : PurePosixPath
+        The product's root within that source. Every file the metadata names
+        sits directly under it.
+    name : str
+        The product's name, normally the directory's or the archive's.
+    metadata : PurePosixPath
+        The metadata file that was read, relative to :attr:`source`.
     product_id : str
         Full ``LANDSAT_PRODUCT_ID``, e.g.
         ``"LC09_L2SP_193028_20260822_20260823_02_T1"``.
@@ -120,8 +126,10 @@ class LandsatProduct:
         above.
     """
 
-    path: Path
-    metadata: Path
+    source: ProductSource
+    root: PurePosixPath
+    name: str
+    metadata: PurePosixPath
     product_id: str
     level: str
     mission: int
@@ -138,19 +146,21 @@ class LandsatProduct:
     groups: dict[str, dict[str, str]]
 
 
-def find_metadata(path: StrPath) -> Path:
-    """Locate a Landsat product's metadata file.
+def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
+    """Locate a Landsat product's metadata file within a source.
 
     Parameters
     ----------
-    path : str or pathlib.Path
-        A product directory, or a metadata file directly.
+    source : str or pathlib.Path or ProductSource
+        A product directory, a directory or archive holding one, a metadata
+        file directly, or an already-opened source.
 
     Returns
     -------
-    Path
-        The metadata file, preferring ``_MTL.xml`` over ``_MTL.json`` over
-        ``_MTL.txt`` when more than one is present.
+    PurePosixPath
+        The metadata file's path **relative to the source**, preferring
+        ``_MTL.xml`` over ``_MTL.json`` over ``_MTL.txt`` when more than one is
+        present. Its parent is the product root.
 
     Raises
     ------
@@ -160,21 +170,22 @@ def find_metadata(path: StrPath) -> Path:
     Examples
     --------
     >>> find_metadata("LC09_L2SP_193028_20260822_02_T1")  # doctest: +SKIP
-    PosixPath('LC09_L2SP_193028_20260822_02_T1/..._MTL.xml')
+    PurePosixPath('LC09_L2SP_193028_20260822_20260823_02_T1_MTL.xml')
     """
-    candidate = Path(path)
-    if not candidate.exists():
-        raise ValidationError(f"no such Landsat product: {str(path)!r}")
-    if candidate.is_file():
-        return candidate
+    opened = source if isinstance(source, ProductSource) else open_product(source, "Landsat")
+    if opened.named_entry is not None:
+        return opened.named_entry
 
-    for suffix in _METADATA_SUFFIXES:
-        matches = sorted(candidate.glob(f"*{suffix}"))
-        if matches:
-            return matches[0]
+    # A USGS tar holds its files at the root; a directory the product was
+    # unpacked into holds them one level down.
+    for depth in ("", "*/"):
+        for suffix in _METADATA_SUFFIXES:
+            matches = opened.glob(f"{depth}*{suffix}")
+            if matches:
+                return matches[0]
 
     raise ValidationError(
-        f"{str(path)!r} holds no Landsat metadata file; expected one ending in "
+        f"{str(opened.location)!r} holds no Landsat metadata file; expected one ending in "
         f"{', '.join(_METADATA_SUFFIXES)}"
     )
 
@@ -221,14 +232,19 @@ def _parse_xml(text: str) -> dict[str, dict[str, str]]:
     }
 
 
-def read_metadata_groups(metadata: Path) -> dict[str, dict[str, str]]:
+def read_metadata_groups(
+    source: ProductSource, metadata: PurePosixPath
+) -> dict[str, dict[str, str]]:
     """Parse a Landsat metadata file of any syntax into groups.
 
     Parameters
     ----------
-    metadata : Path
-        An ``_MTL.xml``, ``_MTL.json``, or ``_MTL.txt`` file. The syntax is
-        chosen by suffix, since all three carry identical content.
+    source : ProductSource
+        Where to read the file from.
+    metadata : PurePosixPath
+        An ``_MTL.xml``, ``_MTL.json``, or ``_MTL.txt`` file, relative to
+        ``source``. The syntax is chosen by suffix, since all three carry
+        identical content.
 
     Returns
     -------
@@ -241,7 +257,7 @@ def read_metadata_groups(metadata: Path) -> dict[str, dict[str, str]]:
     ValidationError
         If the file cannot be parsed in its syntax.
     """
-    text = metadata.read_text(errors="replace")
+    text = source.read_bytes(metadata).decode(errors="replace")
     parsers = {".xml": _parse_xml, ".json": _parse_json}
     parser = parsers.get(metadata.suffix.lower(), _parse_odl)
     try:
@@ -302,13 +318,14 @@ def _acquired(groups: Mapping[str, Mapping[str, str]]) -> dt.datetime:
     return parsed.replace(tzinfo=dt.timezone.utc)
 
 
-def read_product(path: StrPath, *, level: str | None = None) -> LandsatProduct:
+def read_product(path: StrPath | ProductSource, *, level: str | None = None) -> LandsatProduct:
     """Identify a Landsat Collection 2 product and read its metadata.
 
     Parameters
     ----------
-    path : str or pathlib.Path
-        A product directory, or a metadata file directly.
+    path : str or pathlib.Path or ProductSource
+        A product directory, a directory or archive holding one, a metadata
+        file, or an already-opened source.
     level : str or None, default None
         Assert the processing level rather than detecting it. Exists for a
         product whose metadata is damaged; when the metadata states a level and
@@ -337,8 +354,9 @@ def read_product(path: StrPath, *, level: str | None = None) -> LandsatProduct:
     >>> product.mission, product.level, product.wrs_row  # doctest: +SKIP
     (9, 'L2SP', '028')
     """
-    metadata = find_metadata(path)
-    groups = read_metadata_groups(metadata)
+    source = path if isinstance(path, ProductSource) else open_product(path, "Landsat")
+    metadata = find_metadata(source)
+    groups = read_metadata_groups(source, metadata)
 
     detected = groups.get(_CONTENTS, {}).get("PROCESSING_LEVEL", "").strip().upper()
     if level is not None:
@@ -378,11 +396,14 @@ def read_product(path: StrPath, *, level: str | None = None) -> LandsatProduct:
     band_files = {}
     for key, value in groups.get(_CONTENTS, {}).items():
         if key.startswith("FILE_NAME_") and value.upper().endswith(".TIF"):
-            token = Path(value).stem
+            token = PurePosixPath(value).stem
             band_files[token.removeprefix(f"{product_id}_")] = value
 
+    root = metadata.parent
     return LandsatProduct(
-        path=metadata.parent,
+        source=source,
+        root=root,
+        name=root.name or source.name,
         metadata=metadata,
         product_id=product_id,
         level=detected,

--- a/eeo/io/_landsat.py
+++ b/eeo/io/_landsat.py
@@ -177,10 +177,19 @@ def find_metadata(source: StrPath | ProductSource) -> PurePosixPath:
         return opened.named_entry
 
     # A USGS tar holds its files at the root; a directory the product was
-    # unpacked into holds them one level down.
+    # unpacked into holds them one level down. Either way there must be exactly
+    # one — a download folder holding several scenes has no defensible answer,
+    # and picking the alphabetically first would silently analyse the wrong one.
     for depth in ("", "*/"):
         for suffix in _METADATA_SUFFIXES:
             matches = opened.glob(f"{depth}*{suffix}")
+            if len(matches) > 1:
+                raise ValidationError(
+                    f"{str(opened.location)!r} holds {len(matches)} Landsat products, so "
+                    f"which one to load cannot be told from the path alone: "
+                    f"{', '.join(sorted(found.name for found in matches))}. "
+                    f"Name the one you mean."
+                )
             if matches:
                 return matches[0]
 

--- a/eeo/io/_sentinel2.py
+++ b/eeo/io/_sentinel2.py
@@ -1,0 +1,419 @@
+"""Identifying and reading the metadata of a Sentinel-2 product.
+
+A downloaded Sentinel-2 product is a ``.SAFE`` directory whose root holds one
+product manifest — ``MTD_MSIL2A.xml`` for Level-2A, ``MTD_MSIL1C.xml`` for
+Level-1C — and whose ``GRANULE/<granule id>/`` subdirectory holds a tile
+manifest, ``MTD_TL.xml``, carrying the projection. Between them they say what
+the product is, when it was acquired, and how its bands are laid out, without
+opening a single image file.
+
+Processing level is **detected, never assumed**. The manifest's own filename
+distinguishes the two levels, but a renamed file must not be able to mislead the
+reader, so the authority is ``<PRODUCT_TYPE>`` inside the document and the
+filename is only a fallback. Level-1C is identified precisely so it can be
+refused with an explanation, rather than failing later on a directory layout
+that was never going to be there.
+
+Namespaces are matched by local name throughout. The manifest's root element
+sits in a namespace whose URI carries the Product Specification Document
+version (``.../PSD/User_Product_Level-2A.xsd`` under a versioned host), so
+pinning a URI would break on the next PSD revision, while its children sit in no
+namespace at all. Comparing local names is stable across both.
+
+Every element and attribute read here was checked against real ESA output
+rather than taken from documentation, using three products: an L2A scene at
+baseline 05.11 (``S2B_MSIL2A_20240929T100719_R022_T32TPS``), an L2A scene at
+baseline 02.12 (``S2B_MSIL2A_20200930T100729_R022_T32TPS``), and the matching
+L1C product (``S2B_MSIL1C_20240929T100719_N0511_R022_T32TPS``). Three details
+that would otherwise be easy to get wrong were confirmed there: the offset list
+keys bands by ``band_id`` while the spectral list keys them by ``bandId``;
+``physicalBand`` spells single-digit bands ``B1`` where the image files spell
+them ``B01``; and a pre-04.00 product carries no ``BOA_ADD_OFFSET_VALUES_LIST``
+element at all, rather than one holding zeros. Note also that L1C names its
+equivalents ``QUANTIFICATION_VALUE`` and ``RADIO_ADD_OFFSET`` — not the ``BOA_``
+spellings — which does not arise here only because L1C is refused first.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from eeo.core.exceptions import ValidationError
+from eeo.core.types import StrPath
+
+#: Product manifests, newest level first, as found at a ``.SAFE`` root.
+_MANIFESTS = ("MTD_MSIL2A.xml", "MTD_MSIL1C.xml")
+
+#: ``<PRODUCT_TYPE>`` values mapped to the short level names used in messages.
+_PRODUCT_TYPES = {"S2MSI2A": "L2A", "S2MSI1C": "L1C"}
+
+#: Levels this reader supports. Level-1C is recognised only to refuse it.
+_SUPPORTED_LEVELS = ("L2A",)
+
+# Spectral_Information spells the single-digit bands "B1".."B9" while the image
+# files spell them "B01".."B09"; "B8A" is spelled the same in both.
+_SINGLE_DIGIT_BAND = re.compile(r"^B(\d)$")
+
+
+@dataclass(frozen=True)
+class Sentinel2Product:
+    """What a Sentinel-2 product's manifests say about it.
+
+    Attributes
+    ----------
+    path : Path
+        The ``.SAFE`` directory.
+    manifest : Path
+        The product manifest that was read.
+    level : str
+        Processing level, ``"L2A"`` or ``"L1C"``.
+    product_type : str
+        The manifest's own ``<PRODUCT_TYPE>``, e.g. ``"S2MSI2A"``.
+    tile_id : str
+        MGRS tile, e.g. ``"T32TPS"``.
+    sensing_time : datetime.datetime
+        Acquisition time, timezone-aware in UTC.
+    processing_baseline : str
+        Baseline the product was processed with, e.g. ``"05.11"``. The band
+        encoding changed at ``"04.00"``.
+    crs : str
+        The tile's projection as an authority code, e.g. ``"EPSG:32632"``.
+    quantification_value : float or None
+        Digital numbers per unit reflectance, normally 10000.
+    band_offsets : dict of str to float
+        Per-band additive offset in digital numbers, keyed by the band's image
+        file spelling (``"B04"``, ``"B8A"``). Empty for products predating
+        baseline 04.00, which carry no offset element because they have none.
+    image_files : tuple of str
+        Image paths the manifest lists, relative to :attr:`path` and without
+        their file extension, in manifest order.
+    granule : Path or None
+        The granule directory whose tile manifest was read.
+    """
+
+    path: Path
+    manifest: Path
+    level: str
+    product_type: str
+    tile_id: str
+    sensing_time: dt.datetime
+    processing_baseline: str
+    crs: str
+    quantification_value: float | None
+    band_offsets: dict[str, float]
+    image_files: tuple[str, ...]
+    granule: Path | None
+
+
+def _local(tag: str) -> str:
+    """Strip any namespace from an element tag, leaving its local name."""
+    return tag.rpartition("}")[2]
+
+
+def _iter_named(root: ET.Element, name: str) -> Iterator[ET.Element]:
+    """Yield every descendant whose local name matches, root included."""
+    for element in root.iter():
+        if _local(element.tag) == name:
+            yield element
+
+
+def _text(root: ET.Element, name: str) -> str | None:
+    """Return the stripped text of the first element with this local name."""
+    for element in _iter_named(root, name):
+        if element.text is not None and element.text.strip():
+            return element.text.strip()
+    return None
+
+
+def _parse_time(value: str, *, source: str) -> dt.datetime:
+    """Parse a Sentinel-2 timestamp into a timezone-aware UTC datetime.
+
+    Parameters
+    ----------
+    value : str
+        An ISO 8601 instant as the manifests write it, ending in ``Z``.
+    source : str
+        Element name the value came from, for the error message.
+
+    Returns
+    -------
+    datetime.datetime
+        The instant, in UTC.
+
+    Raises
+    ------
+    ValidationError
+        If the value is not a parseable instant.
+    """
+    # Python 3.10's fromisoformat rejects a trailing "Z"; the package supports
+    # 3.10, so normalise it rather than relying on 3.11+ behaviour.
+    text = value.strip()
+    normalised = f"{text[:-1]}+00:00" if text.endswith(("Z", "z")) else text
+    try:
+        parsed = dt.datetime.fromisoformat(normalised)
+    except ValueError as err:
+        raise ValidationError(f"could not read {source} as a date and time; got {value!r}") from err
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
+
+
+def find_manifest(path: StrPath) -> Path:
+    """Locate a Sentinel-2 product manifest.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A ``.SAFE`` directory, a directory holding one, or a manifest file
+        directly.
+
+    Returns
+    -------
+    Path
+        The manifest file.
+
+    Raises
+    ------
+    ValidationError
+        If the path does not exist, or holds no recognisable manifest.
+
+    Examples
+    --------
+    >>> find_manifest("S2B_MSIL2A_20240830T100559.SAFE")  # doctest: +SKIP
+    PosixPath('S2B_MSIL2A_20240830T100559.SAFE/MTD_MSIL2A.xml')
+    """
+    candidate = Path(path)
+    if not candidate.exists():
+        raise ValidationError(f"no such Sentinel-2 product: {str(path)!r}")
+
+    if candidate.is_file():
+        return candidate
+
+    for name in _MANIFESTS:
+        manifest = candidate / name
+        if manifest.is_file():
+            return manifest
+
+    # A user may point at the folder the .SAFE was unpacked into.
+    nested = sorted(candidate.glob("*.SAFE"))
+    for safe in nested:
+        for name in _MANIFESTS:
+            manifest = safe / name
+            if manifest.is_file():
+                return manifest
+
+    raise ValidationError(
+        f"{str(path)!r} holds no Sentinel-2 product manifest; expected one of "
+        f"{', '.join(_MANIFESTS)} at the root of a .SAFE directory"
+    )
+
+
+def _detect_level(root: ET.Element, manifest: Path, override: str | None) -> tuple[str, str]:
+    """Determine the processing level, preferring the document over the filename.
+
+    Returns
+    -------
+    tuple of str
+        ``(level, product_type)``.
+
+    Raises
+    ------
+    ValidationError
+        If the level cannot be determined at all, or if ``override``
+        contradicts what the document states.
+    """
+    product_type = _text(root, "PRODUCT_TYPE")
+    detected = _PRODUCT_TYPES.get(product_type or "")
+
+    if detected is None:
+        # An unreadable or absent PRODUCT_TYPE is the only case where the
+        # filename, or a caller's override, gets to decide.
+        for name, level in (("MTD_MSIL2A.xml", "L2A"), ("MTD_MSIL1C.xml", "L1C")):
+            if manifest.name == name:
+                detected = level
+                break
+
+    if override is not None:
+        wanted = override.strip().upper()
+        if wanted not in _PRODUCT_TYPES.values():
+            raise ValidationError(
+                f"level must be one of {', '.join(sorted(_PRODUCT_TYPES.values()))}; "
+                f"got {override!r}"
+            )
+        if detected is not None and detected != wanted:
+            raise ValidationError(
+                f"level={override!r} contradicts the product, which reports "
+                f"{detected} ({product_type or 'no PRODUCT_TYPE'}) in "
+                f"{manifest.name}. Remove the override to use the product's own level."
+            )
+        detected = wanted
+
+    if detected is None:
+        raise ValidationError(
+            f"{manifest.name} states no PRODUCT_TYPE and its name identifies no "
+            f"processing level, so the product cannot be identified"
+        )
+    return detected, product_type or ""
+
+
+def _band_offsets(root: ET.Element) -> dict[str, float]:
+    """Map each band's image-file name to its additive offset in digital numbers.
+
+    The offsets are keyed by numeric ``band_id`` in the manifest, and the
+    ``band_id``-to-band mapping lives in a separate spectral information list,
+    so the two are joined here. A product from before baseline 04.00 carries no
+    offset element and yields an empty mapping — it has no offset, rather than
+    an unknown one.
+    """
+    by_id: dict[str, str] = {}
+    for element in _iter_named(root, "Spectral_Information"):
+        band_id = element.get("bandId")
+        physical = element.get("physicalBand")
+        if band_id is not None and physical is not None:
+            by_id[band_id] = _SINGLE_DIGIT_BAND.sub(r"B0\1", physical.strip())
+
+    offsets: dict[str, float] = {}
+    for element in _iter_named(root, "BOA_ADD_OFFSET"):
+        band_id = element.get("band_id")
+        if band_id is None or element.text is None:
+            continue
+        name = by_id.get(band_id)
+        if name is None:
+            continue
+        try:
+            offsets[name] = float(element.text.strip())
+        except ValueError as err:
+            raise ValidationError(
+                f"BOA_ADD_OFFSET for band {name} is not a number; got {element.text!r}"
+            ) from err
+    return offsets
+
+
+def _granule_directory(safe: Path, image_files: tuple[str, ...]) -> Path | None:
+    """Find the granule directory, from the manifest's paths or the layout."""
+    for relative in image_files:
+        parts = Path(relative).parts
+        if len(parts) >= 2 and parts[0] == "GRANULE":
+            granule = safe / parts[0] / parts[1]
+            if granule.is_dir():
+                return granule
+
+    granules = sorted(p for p in (safe / "GRANULE").glob("*") if p.is_dir())
+    return granules[0] if granules else None
+
+
+def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product:
+    """Identify a Sentinel-2 product and read its metadata.
+
+    Reads the product manifest and, where present, the granule's tile manifest
+    for the projection. No image data is opened.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A ``.SAFE`` directory, a directory holding one, or a manifest file.
+    level : str or None, default None
+        Assert the processing level rather than detecting it. Exists for a
+        product whose manifest is damaged; when the manifest states a level and
+        this contradicts it, the manifest wins and this raises.
+
+    Returns
+    -------
+    Sentinel2Product
+        The product's identity and metadata.
+
+    Raises
+    ------
+    ValidationError
+        If no manifest is found, the manifest is not readable XML, the
+        processing level cannot be determined, ``level`` contradicts the
+        manifest, or the product is a level this reader does not support.
+
+    Notes
+    -----
+    Level-1C is recognised and refused. It is top-of-atmosphere radiance with no
+    atmospheric correction, and its band layout differs from Level-2A's
+    resolution subdirectories.
+
+    Examples
+    --------
+    >>> product = read_product("S2B_MSIL2A_20240830T100559.SAFE")  # doctest: +SKIP
+    >>> product.level, product.tile_id, product.processing_baseline  # doctest: +SKIP
+    ('L2A', 'T32TPS', '05.11')
+    """
+    manifest = find_manifest(path)
+    try:
+        root = ET.parse(manifest).getroot()
+    except ET.ParseError as err:
+        raise ValidationError(f"{manifest.name} is not readable XML: {err}") from err
+
+    detected, product_type = _detect_level(root, manifest, level)
+    if detected not in _SUPPORTED_LEVELS:
+        raise ValidationError(
+            f"Level-1C is not supported; {manifest.name} reports a {detected} product. "
+            f"Easy-EO reads Level-2A surface reflectance, so download the L2A product "
+            f"for this scene."
+        )
+
+    safe = manifest.parent
+    image_files = tuple(
+        element.text.strip() for element in _iter_named(root, "IMAGE_FILE") if element.text
+    )
+    granule = _granule_directory(safe, image_files)
+
+    quantification = _text(root, "BOA_QUANTIFICATION_VALUE")
+    if quantification is not None:
+        try:
+            quantification_value: float | None = float(quantification)
+        except ValueError as err:
+            raise ValidationError(
+                f"BOA_QUANTIFICATION_VALUE is not a number; got {quantification!r}"
+            ) from err
+    else:
+        quantification_value = None
+
+    # The tile manifest carries the projection and the tile's own sensing time;
+    # the product manifest carries the datatake's start. Prefer the tile's.
+    crs = None
+    tile_time = None
+    if granule is not None and (tile_manifest := granule / "MTD_TL.xml").is_file():
+        try:
+            tile_root = ET.parse(tile_manifest).getroot()
+        except ET.ParseError as err:
+            raise ValidationError(f"{tile_manifest.name} is not readable XML: {err}") from err
+        crs = _text(tile_root, "HORIZONTAL_CS_CODE")
+        tile_time = _text(tile_root, "SENSING_TIME")
+
+    if crs is None:
+        raise ValidationError(
+            f"the product states no projection; expected HORIZONTAL_CS_CODE in the "
+            f"granule's MTD_TL.xml under {safe / 'GRANULE'}"
+        )
+
+    when = tile_time or _text(root, "PRODUCT_START_TIME")
+    if when is None:
+        raise ValidationError(
+            f"{manifest.name} states no acquisition time; expected SENSING_TIME or "
+            f"PRODUCT_START_TIME"
+        )
+
+    uri = _text(root, "PRODUCT_URI") or manifest.parent.name
+    tile_match = re.search(r"_(T\d{2}[A-Z]{3})_", uri)
+
+    return Sentinel2Product(
+        path=safe,
+        manifest=manifest,
+        level=detected,
+        product_type=product_type,
+        tile_id=tile_match.group(1) if tile_match else "",
+        sensing_time=_parse_time(when, source="the acquisition time"),
+        processing_baseline=_text(root, "PROCESSING_BASELINE") or "",
+        crs=crs,
+        quantification_value=quantification_value,
+        band_offsets=_band_offsets(root),
+        image_files=image_files,
+        granule=granule,
+    )

--- a/eeo/io/_sentinel2.py
+++ b/eeo/io/_sentinel2.py
@@ -206,9 +206,19 @@ def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
         if opened.exists(name):
             return PurePosixPath(name)
 
-    # A user may point at the folder, or the zip, the .SAFE sits inside.
+    # A user may point at the folder, or the zip, the .SAFE sits inside. That
+    # is only unambiguous while there is one: a download folder holding several
+    # scenes has no defensible answer, and picking the alphabetically first
+    # would silently analyse the wrong date.
     for name in _MANIFESTS:
         nested = opened.glob(f"*.SAFE/{name}")
+        if len(nested) > 1:
+            raise ValidationError(
+                f"{str(opened.location)!r} holds {len(nested)} Sentinel-2 products, so "
+                f"which one to load cannot be told from the path alone: "
+                f"{', '.join(sorted(found.parent.name for found in nested))}. "
+                f"Name the one you mean."
+            )
         if nested:
             return nested[0]
 

--- a/eeo/io/_sentinel2.py
+++ b/eeo/io/_sentinel2.py
@@ -45,7 +45,7 @@ from xml.etree import ElementTree as ET
 
 from eeo.core.exceptions import ValidationError
 from eeo.core.types import StrPath
-from eeo.io._archive import ProductSource, open_product
+from eeo.io._archive import Located, ProductSource, nested_archive, open_product
 
 #: Product manifests, newest level first, as found at a ``.SAFE`` root.
 _MANIFESTS = ("MTD_MSIL2A.xml", "MTD_MSIL1C.xml")
@@ -172,7 +172,7 @@ def _parse_time(value: str, *, source: str) -> dt.datetime:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
 
 
-def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
+def find_manifest(source: StrPath | ProductSource) -> Located:
     """Locate a Sentinel-2 product manifest within a source.
 
     Parameters
@@ -183,10 +183,12 @@ def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
 
     Returns
     -------
-    PurePosixPath
-        The manifest's path **relative to the source**. Its parent is the
-        ``.SAFE`` root, which every image path in the manifest is written
-        relative to.
+    Located
+        The source the manifest was found in, and its path **relative to that
+        source**. The path's parent is the ``.SAFE`` root, which every image
+        path in the manifest is written relative to. The source is not always
+        the one passed in: pointing at a folder that holds a ``.zip`` resolves
+        to the zip.
 
     Raises
     ------
@@ -195,16 +197,16 @@ def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
 
     Examples
     --------
-    >>> find_manifest("S2B_MSIL2A_20240830T100559.SAFE")  # doctest: +SKIP
+    >>> find_manifest("S2B_MSIL2A_20240830T100559.SAFE").path  # doctest: +SKIP
     PurePosixPath('MTD_MSIL2A.xml')
     """
     opened = source if isinstance(source, ProductSource) else open_product(source, "Sentinel-2")
     if opened.named_entry is not None:
-        return opened.named_entry
+        return Located(opened, opened.named_entry)
 
     for name in _MANIFESTS:
         if opened.exists(name):
-            return PurePosixPath(name)
+            return Located(opened, PurePosixPath(name))
 
     # A user may point at the folder, or the zip, the .SAFE sits inside. That
     # is only unambiguous while there is one: a download folder holding several
@@ -220,11 +222,16 @@ def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
                 f"Name the one you mean."
             )
         if nested:
-            return nested[0]
+            return Located(opened, nested[0])
+
+    # The folder may hold the product still zipped, which is how it arrives.
+    archive = nested_archive(opened, "Sentinel-2")
+    if archive is not None:
+        return find_manifest(archive)
 
     raise ValidationError(
         f"{str(opened.location)!r} holds no Sentinel-2 product manifest; expected one of "
-        f"{', '.join(_MANIFESTS)} at the root of a .SAFE directory"
+        f"{', '.join(_MANIFESTS)} at the root of a .SAFE directory, or a .zip holding one"
     )
 
 
@@ -370,8 +377,9 @@ def read_product(path: StrPath | ProductSource, *, level: str | None = None) -> 
     >>> product.level, product.tile_id, product.processing_baseline  # doctest: +SKIP
     ('L2A', 'T32TPS', '05.11')
     """
-    source = path if isinstance(path, ProductSource) else open_product(path, "Sentinel-2")
-    manifest = find_manifest(source)
+    source, manifest = find_manifest(
+        path if isinstance(path, ProductSource) else open_product(path, "Sentinel-2")
+    )
     try:
         root = ET.fromstring(source.read_bytes(manifest))
     except ET.ParseError as err:

--- a/eeo/io/_sentinel2.py
+++ b/eeo/io/_sentinel2.py
@@ -40,14 +40,18 @@ import datetime as dt
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import PurePosixPath
 from xml.etree import ElementTree as ET
 
 from eeo.core.exceptions import ValidationError
 from eeo.core.types import StrPath
+from eeo.io._archive import ProductSource, open_product
 
 #: Product manifests, newest level first, as found at a ``.SAFE`` root.
 _MANIFESTS = ("MTD_MSIL2A.xml", "MTD_MSIL1C.xml")
+
+#: The granule's own manifest, which carries the projection.
+_TILE_MANIFEST = "MTD_TL.xml"
 
 #: ``<PRODUCT_TYPE>`` values mapped to the short level names used in messages.
 _PRODUCT_TYPES = {"S2MSI2A": "L2A", "S2MSI1C": "L1C"}
@@ -66,10 +70,15 @@ class Sentinel2Product:
 
     Attributes
     ----------
-    path : Path
-        The ``.SAFE`` directory.
-    manifest : Path
-        The product manifest that was read.
+    source : ProductSource
+        Where the product's files are read from — a directory, a zip, or a tar.
+    root : PurePosixPath
+        The ``.SAFE`` root within that source. Every image path the manifest
+        lists is written relative to it.
+    name : str
+        The product's name, normally the ``.SAFE`` directory's.
+    manifest : PurePosixPath
+        The product manifest that was read, relative to :attr:`source`.
     level : str
         Processing level, ``"L2A"`` or ``"L1C"``.
     product_type : str
@@ -90,14 +99,16 @@ class Sentinel2Product:
         file spelling (``"B04"``, ``"B8A"``). Empty for products predating
         baseline 04.00, which carry no offset element because they have none.
     image_files : tuple of str
-        Image paths the manifest lists, relative to :attr:`path` and without
+        Image paths the manifest lists, relative to :attr:`root` and without
         their file extension, in manifest order.
-    granule : Path or None
+    granule : PurePosixPath or None
         The granule directory whose tile manifest was read.
     """
 
-    path: Path
-    manifest: Path
+    source: ProductSource
+    root: PurePosixPath
+    name: str
+    manifest: PurePosixPath
     level: str
     product_type: str
     tile_id: str
@@ -107,7 +118,7 @@ class Sentinel2Product:
     quantification_value: float | None
     band_offsets: dict[str, float]
     image_files: tuple[str, ...]
-    granule: Path | None
+    granule: PurePosixPath | None
 
 
 def _local(tag: str) -> str:
@@ -161,19 +172,21 @@ def _parse_time(value: str, *, source: str) -> dt.datetime:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
 
 
-def find_manifest(path: StrPath) -> Path:
-    """Locate a Sentinel-2 product manifest.
+def find_manifest(source: StrPath | ProductSource) -> PurePosixPath:
+    """Locate a Sentinel-2 product manifest within a source.
 
     Parameters
     ----------
-    path : str or pathlib.Path
-        A ``.SAFE`` directory, a directory holding one, or a manifest file
-        directly.
+    source : str or pathlib.Path or ProductSource
+        A ``.SAFE`` directory, a directory or archive holding one, a manifest
+        file directly, or an already-opened source.
 
     Returns
     -------
-    Path
-        The manifest file.
+    PurePosixPath
+        The manifest's path **relative to the source**. Its parent is the
+        ``.SAFE`` root, which every image path in the manifest is written
+        relative to.
 
     Raises
     ------
@@ -183,35 +196,31 @@ def find_manifest(path: StrPath) -> Path:
     Examples
     --------
     >>> find_manifest("S2B_MSIL2A_20240830T100559.SAFE")  # doctest: +SKIP
-    PosixPath('S2B_MSIL2A_20240830T100559.SAFE/MTD_MSIL2A.xml')
+    PurePosixPath('MTD_MSIL2A.xml')
     """
-    candidate = Path(path)
-    if not candidate.exists():
-        raise ValidationError(f"no such Sentinel-2 product: {str(path)!r}")
-
-    if candidate.is_file():
-        return candidate
+    opened = source if isinstance(source, ProductSource) else open_product(source, "Sentinel-2")
+    if opened.named_entry is not None:
+        return opened.named_entry
 
     for name in _MANIFESTS:
-        manifest = candidate / name
-        if manifest.is_file():
-            return manifest
+        if opened.exists(name):
+            return PurePosixPath(name)
 
-    # A user may point at the folder the .SAFE was unpacked into.
-    nested = sorted(candidate.glob("*.SAFE"))
-    for safe in nested:
-        for name in _MANIFESTS:
-            manifest = safe / name
-            if manifest.is_file():
-                return manifest
+    # A user may point at the folder, or the zip, the .SAFE sits inside.
+    for name in _MANIFESTS:
+        nested = opened.glob(f"*.SAFE/{name}")
+        if nested:
+            return nested[0]
 
     raise ValidationError(
-        f"{str(path)!r} holds no Sentinel-2 product manifest; expected one of "
+        f"{str(opened.location)!r} holds no Sentinel-2 product manifest; expected one of "
         f"{', '.join(_MANIFESTS)} at the root of a .SAFE directory"
     )
 
 
-def _detect_level(root: ET.Element, manifest: Path, override: str | None) -> tuple[str, str]:
+def _detect_level(
+    root: ET.Element, manifest: PurePosixPath, override: str | None
+) -> tuple[str, str]:
     """Determine the processing level, preferring the document over the filename.
 
     Returns
@@ -292,20 +301,26 @@ def _band_offsets(root: ET.Element) -> dict[str, float]:
     return offsets
 
 
-def _granule_directory(safe: Path, image_files: tuple[str, ...]) -> Path | None:
-    """Find the granule directory, from the manifest's paths or the layout."""
+def _granule(
+    source: ProductSource, root: PurePosixPath, image_files: tuple[str, ...]
+) -> PurePosixPath | None:
+    """Find the granule whose tile manifest can be read.
+
+    Prefers the granule the manifest's own image paths name, and falls back to
+    searching the layout for a product whose manifest lists none.
+    """
     for relative in image_files:
-        parts = Path(relative).parts
+        parts = PurePosixPath(relative).parts
         if len(parts) >= 2 and parts[0] == "GRANULE":
-            granule = safe / parts[0] / parts[1]
-            if granule.is_dir():
+            granule = root / parts[0] / parts[1]
+            if source.exists(granule / _TILE_MANIFEST):
                 return granule
 
-    granules = sorted(p for p in (safe / "GRANULE").glob("*") if p.is_dir())
-    return granules[0] if granules else None
+    found = source.glob(str(root / "GRANULE" / "*" / _TILE_MANIFEST))
+    return found[0].parent if found else None
 
 
-def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product:
+def read_product(path: StrPath | ProductSource, *, level: str | None = None) -> Sentinel2Product:
     """Identify a Sentinel-2 product and read its metadata.
 
     Reads the product manifest and, where present, the granule's tile manifest
@@ -313,8 +328,9 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
 
     Parameters
     ----------
-    path : str or pathlib.Path
-        A ``.SAFE`` directory, a directory holding one, or a manifest file.
+    path : str or pathlib.Path or ProductSource
+        A ``.SAFE`` directory, a directory or archive holding one, a manifest
+        file, or an already-opened source.
     level : str or None, default None
         Assert the processing level rather than detecting it. Exists for a
         product whose manifest is damaged; when the manifest states a level and
@@ -344,9 +360,10 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
     >>> product.level, product.tile_id, product.processing_baseline  # doctest: +SKIP
     ('L2A', 'T32TPS', '05.11')
     """
-    manifest = find_manifest(path)
+    source = path if isinstance(path, ProductSource) else open_product(path, "Sentinel-2")
+    manifest = find_manifest(source)
     try:
-        root = ET.parse(manifest).getroot()
+        root = ET.fromstring(source.read_bytes(manifest))
     except ET.ParseError as err:
         raise ValidationError(f"{manifest.name} is not readable XML: {err}") from err
 
@@ -362,7 +379,7 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
     image_files = tuple(
         element.text.strip() for element in _iter_named(root, "IMAGE_FILE") if element.text
     )
-    granule = _granule_directory(safe, image_files)
+    granule = _granule(source, safe, image_files)
 
     quantification = _text(root, "BOA_QUANTIFICATION_VALUE")
     if quantification is not None:
@@ -379,9 +396,10 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
     # the product manifest carries the datatake's start. Prefer the tile's.
     crs = None
     tile_time = None
-    if granule is not None and (tile_manifest := granule / "MTD_TL.xml").is_file():
+    if granule is not None:
+        tile_manifest = granule / _TILE_MANIFEST
         try:
-            tile_root = ET.parse(tile_manifest).getroot()
+            tile_root = ET.fromstring(source.read_bytes(tile_manifest))
         except ET.ParseError as err:
             raise ValidationError(f"{tile_manifest.name} is not readable XML: {err}") from err
         crs = _text(tile_root, "HORIZONTAL_CS_CODE")
@@ -389,8 +407,8 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
 
     if crs is None:
         raise ValidationError(
-            f"the product states no projection; expected HORIZONTAL_CS_CODE in the "
-            f"granule's MTD_TL.xml under {safe / 'GRANULE'}"
+            f"the product states no projection; expected HORIZONTAL_CS_CODE in a "
+            f"granule's {_TILE_MANIFEST} under {source.location}"
         )
 
     when = tile_time or _text(root, "PRODUCT_START_TIME")
@@ -400,11 +418,14 @@ def read_product(path: StrPath, *, level: str | None = None) -> Sentinel2Product
             f"PRODUCT_START_TIME"
         )
 
-    uri = _text(root, "PRODUCT_URI") or manifest.parent.name
+    name = safe.name or source.name
+    uri = _text(root, "PRODUCT_URI") or name
     tile_match = re.search(r"_(T\d{2}[A-Z]{3})_", uri)
 
     return Sentinel2Product(
-        path=safe,
+        source=source,
+        root=safe,
+        name=name,
         manifest=manifest,
         level=detected,
         product_type=product_type,

--- a/eeo/io/_stacking.py
+++ b/eeo/io/_stacking.py
@@ -24,9 +24,12 @@ Notes
 The GDAL configuration in :data:`_GDAL_HTTP_ENV` is tuned for cloud-optimized
 GeoTIFFs over HTTP. ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`` stops an object
 store from listing a whole container to answer a directory probe, but it also
-stops GDAL from finding a local file's siblings — which a multi-file product
-format relies on. A local-product reader must revisit this setting rather than
-inherit it unexamined.
+stops GDAL from finding a local file's siblings, which a multi-file format
+would rely on. The local-product loaders in :mod:`eeo.io.products` are
+unaffected and share this setting deliberately: each band is a self-contained
+JPEG 2000 or GeoTIFF named in full by the product's own metadata, so nothing is
+ever discovered by probing a directory. A format that did resolve a sidecar by
+sibling lookup would have to override this rather than inherit it.
 """
 
 from __future__ import annotations

--- a/eeo/io/_stacking.py
+++ b/eeo/io/_stacking.py
@@ -186,8 +186,13 @@ def read_onto_common_grid(
     bbox : sequence of float or None
         Area to read as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
         degrees**, applied when opening the first source. None reads it whole.
-    resampling : rasterio.enums.Resampling
-        Method used when a later source has to be warped onto the grid.
+    resampling : rasterio.enums.Resampling or sequence
+        Method used when a later source has to be warped onto the grid. A
+        sequence gives one method per source, which is how a categorical band
+        travels alongside a continuous one: class numbers and packed bits must
+        be resampled by nearest neighbour whatever the others use, since any
+        blending of them invents classes that were never observed. The first
+        source's entry is unused — it defines the grid and is never warped.
 
     Returns
     -------
@@ -201,8 +206,9 @@ def read_onto_common_grid(
     Raises
     ------
     ValidationError
-        If ``sources`` is empty, if a source needing a crop declares no CRS, or
-        if ``bbox`` does not overlap the first source.
+        If ``sources`` is empty, if ``resampling`` is a sequence of a different
+        length, if a source needing a crop declares no CRS, or if ``bbox`` does
+        not overlap the first source.
 
     Notes
     -----
@@ -211,11 +217,21 @@ def read_onto_common_grid(
     if not sources:
         raise ValidationError("name at least one source to read; got an empty sequence")
 
+    if isinstance(resampling, (list, tuple)):
+        if len(resampling) != len(sources):
+            raise ValidationError(
+                f"expected one resampling method per source, or a single method for "
+                f"all of them; got {len(resampling)} for {len(sources)} sources"
+            )
+        methods = list(resampling)
+    else:
+        methods = [resampling] * len(sources)
+
     href, name = sources[0]
     array, grid, nodata, band_names = _read_first(href, name, bbox)
     arrays = [array]
-    for href, name in sources[1:]:
-        other, other_names = _read_onto_grid(href, name, grid, resampling)
+    for (href, name), method in zip(sources[1:], methods[1:], strict=True):
+        other, other_names = _read_onto_grid(href, name, grid, method)
         arrays.append(other)
         band_names.extend(other_names)
 

--- a/eeo/io/_stacking.py
+++ b/eeo/io/_stacking.py
@@ -1,0 +1,223 @@
+"""Reading several georeferenced sources onto one common grid.
+
+A scene arrives as one file per band — STAC assets over HTTP, or the JP2s and
+GeoTIFFs inside a downloaded product — and turning a chosen subset of them into
+a single multi-band raster is the same job either way. The rule this module
+implements is:
+
+* the **first** source defines the output grid (CRS, transform, size) and
+  supplies the result's nodata value;
+* every later source is read onto that grid — by a plain windowed read when it
+  already shares it, which is exact and cheap, and through a
+  :class:`~rasterio.vrt.WarpedVRT` otherwise, which covers a coarser
+  resolution, a different projection, a sub-pixel offset, or a footprint
+  smaller than the requested area;
+* the arrays are concatenated in the order given, and each contributes its band
+  names — the source's own name for a single-band file, its GDAL descriptions
+  (or ``name_1..name_n``) for a stack.
+
+Cropping is applied to the first source only, because the grid it produces then
+constrains every other read.
+
+Notes
+-----
+The GDAL configuration in :data:`_GDAL_HTTP_ENV` is tuned for cloud-optimized
+GeoTIFFs over HTTP. ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`` stops an object
+store from listing a whole container to answer a directory probe, but it also
+stops GDAL from finding a local file's siblings — which a multi-file product
+format relies on. A local-product reader must revisit this setting rather than
+inherit it unexamined.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any, NamedTuple
+
+import numpy as np
+import rasterio as rio
+from rasterio import windows as rio_windows
+from rasterio.transform import array_bounds
+from rasterio.vrt import WarpedVRT
+from rasterio.warp import transform_bounds
+
+from eeo.core.exceptions import ValidationError
+
+# GDAL settings for reading a remote COG efficiently. Object stores answer a
+# directory probe by listing the whole container, which costs far more than the
+# read itself; HTTP/2 multiplexing and the VSI cache keep the range requests for
+# the tiles we actually want.
+_GDAL_HTTP_ENV = {
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "GDAL_HTTP_MULTIPLEX": "YES",
+    "GDAL_HTTP_VERSION": "2",
+    "VSI_CACHE": "TRUE",
+}
+
+
+class Grid(NamedTuple):
+    """The output grid every source of one read is placed onto."""
+
+    crs: Any
+    transform: Any
+    width: int
+    height: int
+
+
+def _crop_window(src: Any, bbox: Sequence[float]) -> Any:
+    """Return the pixel window of ``src`` covering a WGS 84 lon/lat bbox."""
+    if src.crs is None:
+        raise ValidationError(
+            "cropping needs a georeferenced asset; this asset declares no CRS. "
+            "Pass crop=False to read it whole."
+        )
+
+    bounds = transform_bounds("EPSG:4326", src.crs, *bbox, densify_pts=21)
+    window = rio_windows.from_bounds(*bounds, transform=src.transform)
+
+    # Round outward to whole pixels so the AOI is fully covered.
+    col_off = math.floor(window.col_off)
+    row_off = math.floor(window.row_off)
+    requested = rio_windows.Window(
+        col_off,
+        row_off,
+        max(math.ceil(window.col_off + window.width) - col_off, 1),
+        max(math.ceil(window.row_off + window.height) - row_off, 1),
+    )
+
+    scene = rio_windows.Window(0, 0, src.width, src.height)
+    if not rio_windows.intersect(requested, scene):
+        raise ValidationError(
+            f"the requested area does not overlap this scene; got bbox {tuple(bbox)!r} "
+            f"in WGS 84 lon/lat, while the scene covers "
+            f"{transform_bounds(src.crs, 'EPSG:4326', *src.bounds, densify_pts=21)!r}"
+        )
+    return rio_windows.intersection(requested, scene)
+
+
+def _aligned_window(src: Any, grid: Grid) -> Any | None:
+    """Return an exact pixel window onto ``grid``, or None if a warp is needed.
+
+    A source sharing the target grid's CRS and resolution can be read directly,
+    which is both cheaper and exact; anything else goes through a warp.
+    """
+    if src.crs is None or src.crs != grid.crs:
+        return None
+    bounds = array_bounds(grid.height, grid.width, grid.transform)
+    window = rio_windows.from_bounds(*bounds, transform=src.transform)
+
+    tol = 1e-6
+    if abs(window.width - grid.width) > tol or abs(window.height - grid.height) > tol:
+        return None
+    if abs(window.col_off - round(window.col_off)) > tol:
+        return None
+    if abs(window.row_off - round(window.row_off)) > tol:
+        return None
+
+    col_off, row_off = round(window.col_off), round(window.row_off)
+    # A window running off the edge would come back short and break the grid;
+    # let the warp path fill those pixels with nodata instead.
+    if col_off < 0 or row_off < 0:
+        return None
+    if col_off + grid.width > src.width or row_off + grid.height > src.height:
+        return None
+    return rio_windows.Window(col_off, row_off, grid.width, grid.height)
+
+
+def _band_names(src: Any, name: str) -> list[str | None]:
+    """Name a single-band source after itself; number the bands of a stack."""
+    if src.count == 1:
+        return [name]
+    descriptions = list(src.descriptions or ())
+    names: list[str | None] = []
+    for index in range(src.count):
+        description = descriptions[index] if index < len(descriptions) else None
+        names.append(description or f"{name}_{index + 1}")
+    return names
+
+
+def _read_first(href: str, name: str, bbox: Sequence[float] | None) -> tuple:
+    """Read the leading source, which defines the grid the rest are read onto."""
+    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
+        window = None if bbox is None else _crop_window(src, bbox)
+        array = src.read(window=window)
+        transform = src.transform if window is None else src.window_transform(window)
+        grid = Grid(src.crs, transform, array.shape[-1], array.shape[-2])
+        return array, grid, src.nodata, _band_names(src, name)
+
+
+def _read_onto_grid(href: str, name: str, grid: Grid, resampling: Any) -> tuple:
+    """Read a further source onto ``grid``, warping only when it does not fit."""
+    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
+        window = _aligned_window(src, grid)
+        if window is not None:
+            return src.read(window=window), _band_names(src, name)
+
+        # Different CRS, resolution, or sub-pixel offset: let GDAL resample
+        # straight onto the target grid rather than reading and fixing up after.
+        with WarpedVRT(
+            src,
+            crs=grid.crs,
+            transform=grid.transform,
+            width=grid.width,
+            height=grid.height,
+            resampling=resampling,
+            src_nodata=src.nodata,
+            nodata=src.nodata,
+        ) as vrt:
+            return vrt.read(), _band_names(src, name)
+
+
+def read_onto_common_grid(
+    sources: Sequence[tuple[str, str]],
+    *,
+    bbox: Sequence[float] | None,
+    resampling: Any,
+) -> tuple[np.ndarray, Grid, float | None, list[str | None]]:
+    """Read several sources onto the grid of the first and stack them.
+
+    Parameters
+    ----------
+    sources : sequence of tuple of str
+        ``(href, name)`` pairs in the order they should become bands. The href
+        is anything rasterio can open — a local path or a remote URL — and the
+        name labels the bands that source contributes. Must not be empty.
+    bbox : sequence of float or None
+        Area to read as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+        degrees**, applied when opening the first source. None reads it whole.
+    resampling : rasterio.enums.Resampling
+        Method used when a later source has to be warped onto the grid.
+
+    Returns
+    -------
+    tuple
+        ``(array, grid, nodata, band_names)`` — the stacked bands as one array
+        of shape ``(bands, height, width)``, the grid they share, the first
+        source's nodata value, and one name per band. The dtype is the
+        sources' own; stacking sources of different dtypes promotes to their
+        common NumPy dtype.
+
+    Raises
+    ------
+    ValidationError
+        If ``sources`` is empty, if a source needing a crop declares no CRS, or
+        if ``bbox`` does not overlap the first source.
+
+    Notes
+    -----
+    Holds the stacked result in memory; a bbox is what keeps that bounded.
+    """
+    if not sources:
+        raise ValidationError("name at least one source to read; got an empty sequence")
+
+    href, name = sources[0]
+    array, grid, nodata, band_names = _read_first(href, name, bbox)
+    arrays = [array]
+    for href, name in sources[1:]:
+        other, other_names = _read_onto_grid(href, name, grid, resampling)
+        arrays.append(other)
+        band_names.extend(other_names)
+
+    stacked = arrays[0] if len(arrays) == 1 else np.concatenate(arrays, axis=0)
+    return stacked, grid, nodata, band_names

--- a/eeo/io/products.py
+++ b/eeo/io/products.py
@@ -27,12 +27,17 @@ There is one loader per mission family, not one per satellite. Landsat 8 and 9
 share a product format exactly, and Landsat 4, 5, and 7 differ from them only
 in which band number carries which wavelength — a difference the band table
 already holds, so four functions would be four copies of one.
+
+Either loader reads a product as it was downloaded — the unpacked directory,
+or the archive it arrived in — because :mod:`eeo.io._archive` answers the
+questions about *where a file is* that identifying a product asks. A compressed
+archive is the one container refused, and refused with instructions; see that
+module for why.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any
 
 from eeo.common import normalize_resampling_method
@@ -69,15 +74,15 @@ _LANDSAT_RESOLUTION = 30
 _IMAGE_SUFFIXES = (".jp2", ".JP2", ".tif", ".TIF", ".tiff", ".TIFF")
 
 
-def _image_path(safe: Path, relative: str) -> str:
+def _image_path(product: Sentinel2Product, relative: str) -> str:
     """Resolve a manifest image path, which is recorded without its extension."""
     for suffix in _IMAGE_SUFFIXES:
-        candidate = safe / f"{relative}{suffix}"
-        if candidate.is_file():
-            return str(candidate)
+        candidate = product.root / f"{relative}{suffix}"
+        if product.source.exists(candidate):
+            return product.source.href(candidate)
     raise ValidationError(
         f"the manifest lists an image the product does not hold: "
-        f"{relative!r} (tried {', '.join(_IMAGE_SUFFIXES)} under {safe})"
+        f"{relative!r} (tried {', '.join(_IMAGE_SUFFIXES)} in {product.source.location})"
     )
 
 
@@ -95,7 +100,7 @@ def _band_source(product: Sentinel2Product, band: BandInfo, resolution: int) -> 
             f"this product holds no {band.common_name!r} ({band.band_id}) band at all"
         )
     chosen = resolution if resolution in available else available[0]
-    return _image_path(product.path, sentinel2_band_file(product.image_files, band, chosen)), chosen
+    return _image_path(product, sentinel2_band_file(product.image_files, band, chosen)), chosen
 
 
 def load_sentinel2(
@@ -112,8 +117,9 @@ def load_sentinel2(
     Parameters
     ----------
     path : str or pathlib.Path
-        A ``.SAFE`` directory, a directory holding one, or its product
-        manifest.
+        A ``.SAFE`` directory, a directory or ``.zip`` holding one, or the
+        product manifest itself. A Copernicus download is read as it arrives,
+        zipped, without being unpacked first.
     bands : sequence of str
         Bands to load, in the order they should become bands of the result.
         Named by common name (``"red"``, ``"nir"``, ``"swir16"``, ``"scl"``) or
@@ -156,11 +162,21 @@ def load_sentinel2(
         not present, ``resolution`` is not 10, 20, or 60, no requested band
         exists at ``resolution``, or ``bbox`` does not overlap the tile.
 
+    See Also
+    --------
+    load_landsat : The same call for a USGS Collection 2 Level-2 product.
+
     Notes
     -----
     Holds the requested window in memory. A ``bbox`` is what keeps that
     bounded; without one, an all-band load of a whole tile will not fit on a
     laptop.
+
+    Reading straight from the ``.zip`` costs something: a deflated member is
+    decompressed from its own start, so a small window of one band still pays
+    for the image ahead of it. It is bounded by the size of one image, and it
+    saves unpacking a product to read two bands of it. Unpack first if the same
+    scene will be read many times.
 
     Examples
     --------
@@ -220,7 +236,7 @@ def load_sentinel2(
         nodata=nodata,
         timestamp=product.sensing_time,
         attrs={
-            "product": product.path.name,
+            "product": product.name,
             "mission": "Sentinel-2",
             "level": product.level,
             "tile": product.tile_id,
@@ -239,13 +255,13 @@ def load_sentinel2(
 def _landsat_image_path(product: LandsatProduct, band: BandInfo) -> str:
     """Resolve one Landsat band to a file, which the metadata names in full."""
     filename = landsat_band_file(product.band_files, band)
-    candidate = product.path / filename
-    if not candidate.is_file():
+    candidate = product.root / filename
+    if not product.source.exists(candidate):
         raise ValidationError(
             f"the metadata lists {filename!r} for {band.common_name!r}, but the "
-            f"product directory does not hold it ({product.path})"
+            f"product does not hold it ({product.source.location})"
         )
-    return str(candidate)
+    return product.source.href(candidate)
 
 
 def load_landsat(
@@ -266,8 +282,11 @@ def load_landsat(
     Parameters
     ----------
     path : str or pathlib.Path
-        A product directory, or its ``*_MTL.xml``, ``*_MTL.json``, or
-        ``*_MTL.txt`` metadata file.
+        A product directory, a directory or ``.tar`` holding one, or the
+        ``*_MTL.xml``, ``*_MTL.json``, or ``*_MTL.txt`` metadata file itself. A
+        USGS download is read as it arrives, tarred, without being unpacked
+        first — and an uncompressed tar costs nothing to read this way, since
+        its members are stored whole.
     bands : sequence of str
         Bands to load, in the order they should become bands of the result.
         Named by common name (``"red"``, ``"nir08"``, ``"swir16"``,

--- a/eeo/io/products.py
+++ b/eeo/io/products.py
@@ -117,9 +117,10 @@ def load_sentinel2(
     Parameters
     ----------
     path : str or pathlib.Path
-        A ``.SAFE`` directory, a directory or ``.zip`` holding one, or the
-        product manifest itself. A Copernicus download is read as it arrives,
-        zipped, without being unpacked first.
+        A ``.SAFE`` directory, a ``.zip``, a directory holding either of those,
+        or the product manifest itself. A Copernicus download is read as it
+        arrives, zipped, without being unpacked first — including when it is
+        still sitting in the folder it was downloaded into.
     bands : sequence of str
         Bands to load, in the order they should become bands of the result.
         Named by common name (``"red"``, ``"nir"``, ``"swir16"``, ``"scl"``) or
@@ -283,11 +284,12 @@ def load_landsat(
     Parameters
     ----------
     path : str or pathlib.Path
-        A product directory, a directory or ``.tar`` holding one, or the
-        ``*_MTL.xml``, ``*_MTL.json``, or ``*_MTL.txt`` metadata file itself. A
-        USGS download is read as it arrives, tarred, without being unpacked
-        first — and an uncompressed tar costs nothing to read this way, since
-        its members are stored whole.
+        A product directory, a ``.tar``, a directory holding either of those,
+        or the ``*_MTL.xml``, ``*_MTL.json``, or ``*_MTL.txt`` metadata file
+        itself. A USGS download is read as it arrives, tarred, without being
+        unpacked first — including when it is still sitting in the folder it
+        was downloaded into — and an uncompressed tar costs nothing to read
+        this way, since its members are stored whole.
     bands : sequence of str
         Bands to load, in the order they should become bands of the result.
         Named by common name (``"red"``, ``"nir08"``, ``"swir16"``,

--- a/eeo/io/products.py
+++ b/eeo/io/products.py
@@ -124,8 +124,9 @@ def load_sentinel2(
         Bands to load, in the order they should become bands of the result.
         Named by common name (``"red"``, ``"nir"``, ``"swir16"``, ``"scl"``) or
         by the product's own id (``"B04"``, ``"B8A"``). **There is no default**:
-        a full Level-2A product is roughly 2.9 GB of imagery at 10 m, so the
-        set to read is always an explicit choice.
+        a Level-2A product holds several gigabytes of imagery — one 10 m band
+        alone is about 241 MB — so the set to read is always an explicit
+        choice.
     bbox : sequence of float or None, default None
         Area to read, as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
         degrees**. None reads the whole 110 km tile, which for a 10 m band is

--- a/eeo/io/products.py
+++ b/eeo/io/products.py
@@ -1,13 +1,16 @@
 """Load a satellite scene from a product downloaded to disk.
 
-:func:`load_sentinel2` opens a Copernicus ``.SAFE`` product the way
-:mod:`eeo.io.stac` opens a catalogue item, and returns the same kind of
-:class:`~eeo.core.core.EEORasterDataset`. Both paths share one reader, so a
+:func:`load_sentinel2` opens a Copernicus ``.SAFE`` product and
+:func:`load_landsat` a USGS Collection 2 Level-2 product, the way
+:mod:`eeo.io.stac` opens a catalogue item, and all three return the same kind
+of :class:`~eeo.core.core.EEORasterDataset`. Every path shares one reader, so a
 scene loaded from a folder and the same scene loaded from a catalogue land on
 the same grid with the same values and the same band names.
 
 Bands are named, never numbered. ``load_sentinel2(path, ["red", "nir"])`` says
-what it means on any sensor, where band 4 does not: see :mod:`eeo.io._bands`.
+what it means on any sensor, where band 4 does not — and it is the same call on
+Landsat, where ``"red"`` is band 4 on Landsat 8 and band 3 on Landsat 7: see
+:mod:`eeo.io._bands`.
 
 **Values are the product's stored integers** — the digital numbers a GIS shows,
 not reflectance. Converting them is a documented one-liner rather than a
@@ -15,8 +18,15 @@ default, because the default here is to read what the file holds. See the
 loading guide for the per-mission encodings; the coefficients for the product
 in hand are carried on the result's ``attrs``.
 
-Only Level-2A is read. Level-1C is top-of-atmosphere radiance with a different
-layout, and is refused by name rather than failing on a missing directory.
+Only surface-reflectance levels are read: Sentinel-2 Level-2A and Landsat
+Level-2 (``L2SP``/``L2SR``). Their top-of-atmosphere counterparts hold
+different quantities under a different layout, and are refused by name rather
+than left to fail on a missing directory.
+
+There is one loader per mission family, not one per satellite. Landsat 8 and 9
+share a product format exactly, and Landsat 4, 5, and 7 differ from them only
+in which band number carries which wavelength — a difference the band table
+already holds, so four functions would be four copies of one.
 """
 
 from __future__ import annotations
@@ -34,16 +44,25 @@ from eeo.io._bands import (
     SENTINEL2,
     BandInfo,
     finest_resolution,
+    landsat_band_file,
+    landsat_bands,
     resolve_bands,
     sentinel2_available_resolutions,
     sentinel2_band_file,
 )
+from eeo.io._landsat import LandsatProduct
+from eeo.io._landsat import read_product as read_landsat_product
 from eeo.io._sentinel2 import Sentinel2Product
 from eeo.io._sentinel2 import read_product as read_sentinel2_product
 from eeo.io._stacking import read_onto_common_grid
 
 #: Resolutions a Sentinel-2 Level-2A product is written at.
 _S2_RESOLUTIONS = (10, 20, 60)
+
+#: The single grid every Collection 2 Level-2 band is delivered on, in metres.
+#: The thermal band reaches it by USGS resampling from its coarser native
+#: sampling — 120 m on TM, 60 m on ETM+, 100 m on TIRS — before delivery.
+_LANDSAT_RESOLUTION = 30
 
 #: Extensions to try for an image the manifest lists without one. Products are
 #: JPEG 2000; a few pipelines rewrite them as GeoTIFF while keeping the layout.
@@ -211,6 +230,161 @@ def load_sentinel2(
             "band_ids": [band.band_id for band in resolved],
             "quantification_value": product.quantification_value,
             "band_offsets": product.band_offsets,
+        },
+        band_names=[band.common_name for band in resolved],
+    )
+    return dataset.to_rasterio()
+
+
+def _landsat_image_path(product: LandsatProduct, band: BandInfo) -> str:
+    """Resolve one Landsat band to a file, which the metadata names in full."""
+    filename = landsat_band_file(product.band_files, band)
+    candidate = product.path / filename
+    if not candidate.is_file():
+        raise ValidationError(
+            f"the metadata lists {filename!r} for {band.common_name!r}, but the "
+            f"product directory does not hold it ({product.path})"
+        )
+    return str(candidate)
+
+
+def load_landsat(
+    path: StrPath,
+    bands: Sequence[str],
+    *,
+    bbox: Sequence[float] | None = None,
+    level: str | None = None,
+) -> EEORasterDataset:
+    """Load bands from a downloaded Landsat Collection 2 Level-2 product.
+
+    One function covers Landsat 4, 5, 7, 8, and 9. The mission is read from the
+    product's own metadata and only decides which band table the names are
+    resolved against, so ``["red", "nir08"]`` is the same request on every one
+    of them even though it means bands 3 and 4 on Landsat 7 and bands 4 and 5
+    on Landsat 8.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A product directory, or its ``*_MTL.xml``, ``*_MTL.json``, or
+        ``*_MTL.txt`` metadata file.
+    bands : sequence of str
+        Bands to load, in the order they should become bands of the result.
+        Named by common name (``"red"``, ``"nir08"``, ``"swir16"``,
+        ``"qa_pixel"``) or by the product's own token (``"SR_B4"``,
+        ``"ST_B10"``), with or without its prefix (``"B4"``). **There is no
+        default**: the set to read is always an explicit choice.
+    bbox : sequence of float or None, default None
+        Area to read, as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+        degrees**. None reads the whole scene, which is roughly 7700 x 7900
+        pixels — about 120 MB per band.
+    level : str or None, default None
+        Assert the processing level rather than detecting it. The metadata is
+        the authority, so this raises if it disagrees.
+
+    Returns
+    -------
+    EEORasterDataset
+        Rasterio-backed dataset holding the requested bands as the product's
+        own ``uint16`` digital numbers — the values a GIS shows, not
+        reflectance or kelvin. Carries the scene's CRS, a transform matching
+        the requested window, a nodata value, the acquisition time as
+        ``timestamp``, common names as ``band_names``, and the product's
+        identity plus its scaling coefficients in ``attrs``.
+
+    Raises
+    ------
+    ValidationError
+        If no product is found, it is not Collection 2 Level-2, its mission has
+        no band table, a band is not recognised or not present in the product,
+        a listed file is missing from the directory, or ``bbox`` does not
+        overlap the scene.
+
+    See Also
+    --------
+    load_sentinel2 : The same call for a Copernicus ``.SAFE`` product.
+
+    Notes
+    -----
+    **There is no resolution or resampling parameter, because nothing is ever
+    resampled.** Every band of a Collection 2 Level-2 product — reflectance,
+    surface temperature, and the quality rasters alike — is delivered on one
+    30 m grid of identical size and origin, the thermal band having already
+    been resampled onto it by USGS from its coarser native sampling. So the
+    bands are read by exact windows and stacked, and a parameter offering to
+    choose a method would describe something that never happens.
+
+    **A reflectance-only product has no thermal band.** ``L2SR`` is issued for
+    scenes where surface temperature could not be produced, so asking for
+    ``"lwir11"`` there fails on a band the product genuinely does not hold
+    rather than on a bad name.
+
+    **Landsat 7 after 31 May 2003 is missing about 22% of each scene.** The
+    scan line corrector failed, leaving wedge-shaped gaps that widen toward the
+    scene edges. Those pixels carry the fill value, not a measurement, so they
+    are nodata and must be excluded from statistics rather than read as zero
+    reflectance. It is a property of the sensor, not of the product or of this
+    reader.
+
+    Fill is ``0`` in the reflectance and temperature bands but ``1`` in the
+    quality rasters, and a dataset carries one nodata value. The first band
+    read supplies it, and a data band is always read first when one was asked
+    for, so the value on the result describes the imagery.
+
+    Holds the requested window in memory. A ``bbox`` is what keeps that
+    bounded.
+
+    Examples
+    --------
+    >>> scene = load_landsat(
+    ...     "LC09_L2SP_193028_20260822_20260823_02_T1", ["red", "nir08"]
+    ... )  # doctest: +SKIP
+    >>> scene.band_names  # doctest: +SKIP
+    ['red', 'nir08']
+    >>> ndvi = scene.ndvi(red="red", nir="nir08")  # doctest: +SKIP
+    """
+    product = read_landsat_product(path, level=level)
+    resolved = resolve_bands(bands, landsat_bands(product.mission))
+
+    # Quality rasters declare a fill value of 1 where the imagery declares 0,
+    # and the first source read is the one that supplies the result's nodata.
+    # Leading with a data band keeps that value describing the measurements.
+    # The caller's order is restored afterwards, so this is invisible outside.
+    lead = next((i for i, band in enumerate(resolved) if band.kind != "quality"), 0)
+    order = [lead] + [i for i in range(len(resolved)) if i != lead]
+    sources = [(_landsat_image_path(product, resolved[i]), resolved[i].common_name) for i in order]
+
+    stacked, grid, nodata, _ = read_onto_common_grid(
+        sources,
+        bbox=bbox,
+        # Every band shares one grid, so this is never reached. Nearest is what
+        # it should be if a reprocessed product ever breaks that assumption:
+        # it is the only method that cannot invent a class number.
+        resampling=normalize_resampling_method("nearest"),
+    )
+
+    restore = [order.index(i) for i in range(len(resolved))]
+    dataset = load_array(
+        stacked[restore],
+        transform=grid.transform,
+        crs=grid.crs,
+        nodata=nodata,
+        timestamp=product.acquired,
+        attrs={
+            "product": product.product_id,
+            "mission": f"Landsat {product.mission}",
+            "instrument": product.instrument,
+            "spacecraft": product.spacecraft,
+            "level": product.level,
+            "wrs_path": product.wrs_path,
+            "wrs_row": product.wrs_row,
+            "collection_number": product.collection_number,
+            "collection_category": product.collection_category,
+            "resolution": _LANDSAT_RESOLUTION,
+            "bands": [band.common_name for band in resolved],
+            "band_ids": [band.band_id for band in resolved],
+            "reflectance_scaling": product.reflectance_scaling,
+            "temperature_scaling": product.temperature_scaling,
         },
         band_names=[band.common_name for band in resolved],
     )

--- a/eeo/io/products.py
+++ b/eeo/io/products.py
@@ -1,0 +1,217 @@
+"""Load a satellite scene from a product downloaded to disk.
+
+:func:`load_sentinel2` opens a Copernicus ``.SAFE`` product the way
+:mod:`eeo.io.stac` opens a catalogue item, and returns the same kind of
+:class:`~eeo.core.core.EEORasterDataset`. Both paths share one reader, so a
+scene loaded from a folder and the same scene loaded from a catalogue land on
+the same grid with the same values and the same band names.
+
+Bands are named, never numbered. ``load_sentinel2(path, ["red", "nir"])`` says
+what it means on any sensor, where band 4 does not: see :mod:`eeo.io._bands`.
+
+**Values are the product's stored integers** — the digital numbers a GIS shows,
+not reflectance. Converting them is a documented one-liner rather than a
+default, because the default here is to read what the file holds. See the
+loading guide for the per-mission encodings; the coefficients for the product
+in hand are carried on the result's ``attrs``.
+
+Only Level-2A is read. Level-1C is top-of-atmosphere radiance with a different
+layout, and is refused by name rather than failing on a missing directory.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from eeo.common import normalize_resampling_method
+from eeo.core.core import EEORasterDataset
+from eeo.core.exceptions import ValidationError
+from eeo.core.loader import load_array
+from eeo.core.types import ResamplingMethod, StrPath
+from eeo.io._bands import (
+    SENTINEL2,
+    BandInfo,
+    finest_resolution,
+    resolve_bands,
+    sentinel2_available_resolutions,
+    sentinel2_band_file,
+)
+from eeo.io._sentinel2 import Sentinel2Product
+from eeo.io._sentinel2 import read_product as read_sentinel2_product
+from eeo.io._stacking import read_onto_common_grid
+
+#: Resolutions a Sentinel-2 Level-2A product is written at.
+_S2_RESOLUTIONS = (10, 20, 60)
+
+#: Extensions to try for an image the manifest lists without one. Products are
+#: JPEG 2000; a few pipelines rewrite them as GeoTIFF while keeping the layout.
+_IMAGE_SUFFIXES = (".jp2", ".JP2", ".tif", ".TIF", ".tiff", ".TIFF")
+
+
+def _image_path(safe: Path, relative: str) -> str:
+    """Resolve a manifest image path, which is recorded without its extension."""
+    for suffix in _IMAGE_SUFFIXES:
+        candidate = safe / f"{relative}{suffix}"
+        if candidate.is_file():
+            return str(candidate)
+    raise ValidationError(
+        f"the manifest lists an image the product does not hold: "
+        f"{relative!r} (tried {', '.join(_IMAGE_SUFFIXES)} under {safe})"
+    )
+
+
+def _band_source(product: Sentinel2Product, band: BandInfo, resolution: int) -> tuple[str, int]:
+    """Pick the file for one band, and report the resolution it was found at.
+
+    Prefers the requested resolution, and otherwise takes the finest the
+    product actually holds — a 20 m band asked for at 10 m is read at 20 m and
+    warped onto the 10 m grid, exactly as the catalogue path does with a 20 m
+    asset stacked onto a 10 m one.
+    """
+    available = sentinel2_available_resolutions(product.image_files, band)
+    if not available:
+        raise ValidationError(
+            f"this product holds no {band.common_name!r} ({band.band_id}) band at all"
+        )
+    chosen = resolution if resolution in available else available[0]
+    return _image_path(product.path, sentinel2_band_file(product.image_files, band, chosen)), chosen
+
+
+def load_sentinel2(
+    path: StrPath,
+    bands: Sequence[str],
+    *,
+    bbox: Sequence[float] | None = None,
+    resolution: int | None = None,
+    resampling: ResamplingMethod | Any = "nearest",
+    level: str | None = None,
+) -> EEORasterDataset:
+    """Load bands from a downloaded Sentinel-2 Level-2A product.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        A ``.SAFE`` directory, a directory holding one, or its product
+        manifest.
+    bands : sequence of str
+        Bands to load, in the order they should become bands of the result.
+        Named by common name (``"red"``, ``"nir"``, ``"swir16"``, ``"scl"``) or
+        by the product's own id (``"B04"``, ``"B8A"``). **There is no default**:
+        a full Level-2A product is roughly 2.9 GB of imagery at 10 m, so the
+        set to read is always an explicit choice.
+    bbox : sequence of float or None, default None
+        Area to read, as ``(minx, miny, maxx, maxy)`` in **WGS 84 lon/lat
+        degrees**. None reads the whole 110 km tile, which for a 10 m band is
+        about 240 MB before any others are stacked onto it.
+    resolution : int or None, default None
+        Output pixel size in metres — 10, 20, or 60. None picks the finest
+        *native* resolution among the bands actually requested, so a load never
+        upsamples every band to a resolution only one of them was sensed at.
+        A band the product does not hold at the chosen resolution is read at
+        the finest it does hold and warped onto the grid.
+    resampling : str or rasterio.enums.Resampling, default "nearest"
+        Method used where a band has to be warped onto the output grid. Applied
+        to continuous bands only: a quality band such as ``"scl"`` holds class
+        numbers, so it is always read by nearest neighbour whatever is asked
+        for here, since blending class numbers invents classes.
+    level : str or None, default None
+        Assert the processing level rather than detecting it. The manifest is
+        the authority, so this raises if it disagrees.
+
+    Returns
+    -------
+    EEORasterDataset
+        Rasterio-backed dataset holding the requested bands as the product's
+        own ``uint16`` digital numbers — the values a GIS shows, not
+        reflectance. Carries the tile's CRS, a transform matching the requested
+        window, the first band's nodata value, the granule's acquisition time
+        as ``timestamp``, common names as ``band_names``, and the product's
+        identity plus its reflectance coefficients in ``attrs``.
+
+    Raises
+    ------
+    ValidationError
+        If no product is found, it is not Level-2A, a band is not recognised or
+        not present, ``resolution`` is not 10, 20, or 60, no requested band
+        exists at ``resolution``, or ``bbox`` does not overlap the tile.
+
+    Notes
+    -----
+    Holds the requested window in memory. A ``bbox`` is what keeps that
+    bounded; without one, an all-band load of a whole tile will not fit on a
+    laptop.
+
+    Examples
+    --------
+    >>> scene = load_sentinel2(
+    ...     "S2B_MSIL2A_20240929T100719.SAFE", ["red", "nir"]
+    ... )  # doctest: +SKIP
+    >>> scene.band_names  # doctest: +SKIP
+    ['red', 'nir']
+    >>> ndvi = scene.ndvi(red="red", nir="nir")  # doctest: +SKIP
+    """
+    product = read_sentinel2_product(path, level=level)
+    resolved = resolve_bands(bands, SENTINEL2)
+
+    if resolution is None:
+        resolution = finest_resolution(resolved)
+    elif resolution not in _S2_RESOLUTIONS:
+        raise ValidationError(
+            f"resolution must be one of {', '.join(f'{r} m' for r in _S2_RESOLUTIONS)}; "
+            f"got {resolution!r}"
+        )
+
+    located = [_band_source(product, band, resolution) for band in resolved]
+
+    # The first source read defines the output grid, so it has to be a band the
+    # product actually holds at the requested resolution. The caller's order is
+    # restored afterwards, so which band leads is invisible from outside.
+    lead = next((i for i, (_, found) in enumerate(located) if found == resolution), None)
+    if lead is None:
+        holdings = ", ".join(
+            f"{band.common_name} at "
+            f"{', '.join(f'{r} m' for r in sentinel2_available_resolutions(product.image_files, band))}"
+            for band in resolved
+        )
+        raise ValidationError(
+            f"none of the requested bands is written at {resolution} m in this "
+            f"product, so there is no grid to read onto ({holdings}). Request a "
+            f"resolution one of them has, or add a band that does."
+        )
+
+    order = [lead] + [i for i in range(len(resolved)) if i != lead]
+    sources = [(located[i][0], resolved[i].common_name) for i in order]
+    # Class numbers and packed bits must never be blended.
+    methods = ["nearest" if resolved[i].kind == "quality" else resampling for i in order]
+
+    stacked, grid, nodata, _ = read_onto_common_grid(
+        sources,
+        bbox=bbox,
+        resampling=[normalize_resampling_method(m) for m in methods],
+    )
+
+    # Undo the read order so the bands come back as the caller asked for them.
+    restore = [order.index(i) for i in range(len(resolved))]
+    dataset = load_array(
+        stacked[restore],
+        transform=grid.transform,
+        crs=grid.crs,
+        nodata=nodata,
+        timestamp=product.sensing_time,
+        attrs={
+            "product": product.path.name,
+            "mission": "Sentinel-2",
+            "level": product.level,
+            "tile": product.tile_id,
+            "processing_baseline": product.processing_baseline,
+            "resolution": resolution,
+            "bands": [band.common_name for band in resolved],
+            "band_ids": [band.band_id for band in resolved],
+            "quantification_value": product.quantification_value,
+            "band_offsets": product.band_offsets,
+        },
+        band_names=[band.common_name for band in resolved],
+    )
+    return dataset.to_rasterio()

--- a/eeo/io/stac.py
+++ b/eeo/io/stac.py
@@ -30,19 +30,13 @@ Examples
 from __future__ import annotations
 
 import datetime as dt
-import math
 import os
 from collections.abc import Mapping, Sequence
-from typing import Any, NamedTuple, overload
+from typing import Any, overload
 
 import geopandas as gpd
 import numpy as np
-import rasterio as rio
 import shapely
-from rasterio import windows as rio_windows
-from rasterio.transform import array_bounds
-from rasterio.vrt import WarpedVRT
-from rasterio.warp import transform_bounds
 
 from eeo._optional import import_optional
 from eeo.common import normalize_resampling_method
@@ -50,6 +44,7 @@ from eeo.core.core import EEORasterDataset
 from eeo.core.exceptions import ValidationError
 from eeo.core.loader import load_array
 from eeo.core.types import ResamplingMethod
+from eeo.io._stacking import read_onto_common_grid
 
 #: Microsoft Planetary Computer's STAC API — the default ``catalog`` for
 #: :func:`stac_search`, and the only catalog contacted unless another is given.
@@ -182,87 +177,6 @@ def _sort_key(item: STACItem) -> tuple[bool, dt.datetime]:
     return (False, timestamp)
 
 
-# GDAL settings for reading a remote COG efficiently. Object stores answer a
-# directory probe by listing the whole container, which costs far more than the
-# read itself; HTTP/2 multiplexing and the VSI cache keep the range requests for
-# the tiles we actually want.
-_GDAL_HTTP_ENV = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_MULTIPLEX": "YES",
-    "GDAL_HTTP_VERSION": "2",
-    "VSI_CACHE": "TRUE",
-}
-
-
-class _Grid(NamedTuple):
-    """The output grid every asset of one load is read onto."""
-
-    crs: Any
-    transform: Any
-    width: int
-    height: int
-
-
-def _crop_window(src: Any, bbox: Sequence[float]) -> Any:
-    """Return the pixel window of ``src`` covering a WGS 84 lon/lat bbox."""
-    if src.crs is None:
-        raise ValidationError(
-            "cropping needs a georeferenced asset; this asset declares no CRS. "
-            "Pass crop=False to read it whole."
-        )
-
-    bounds = transform_bounds("EPSG:4326", src.crs, *bbox, densify_pts=21)
-    window = rio_windows.from_bounds(*bounds, transform=src.transform)
-
-    # Round outward to whole pixels so the AOI is fully covered.
-    col_off = math.floor(window.col_off)
-    row_off = math.floor(window.row_off)
-    requested = rio_windows.Window(
-        col_off,
-        row_off,
-        max(math.ceil(window.col_off + window.width) - col_off, 1),
-        max(math.ceil(window.row_off + window.height) - row_off, 1),
-    )
-
-    scene = rio_windows.Window(0, 0, src.width, src.height)
-    if not rio_windows.intersect(requested, scene):
-        raise ValidationError(
-            f"the requested area does not overlap this scene; got bbox {tuple(bbox)!r} "
-            f"in WGS 84 lon/lat, while the scene covers "
-            f"{transform_bounds(src.crs, 'EPSG:4326', *src.bounds, densify_pts=21)!r}"
-        )
-    return rio_windows.intersection(requested, scene)
-
-
-def _aligned_window(src: Any, grid: _Grid) -> Any | None:
-    """Return an exact pixel window onto ``grid``, or None if a warp is needed.
-
-    An asset sharing the target grid's CRS and resolution can be read directly,
-    which is both cheaper and exact; anything else goes through a warp.
-    """
-    if src.crs is None or src.crs != grid.crs:
-        return None
-    bounds = array_bounds(grid.height, grid.width, grid.transform)
-    window = rio_windows.from_bounds(*bounds, transform=src.transform)
-
-    tol = 1e-6
-    if abs(window.width - grid.width) > tol or abs(window.height - grid.height) > tol:
-        return None
-    if abs(window.col_off - round(window.col_off)) > tol:
-        return None
-    if abs(window.row_off - round(window.row_off)) > tol:
-        return None
-
-    col_off, row_off = round(window.col_off), round(window.row_off)
-    # A window running off the edge would come back short and break the grid;
-    # let the warp path fill those pixels with nodata instead.
-    if col_off < 0 or row_off < 0:
-        return None
-    if col_off + grid.width > src.width or row_off + grid.height > src.height:
-        return None
-    return rio_windows.Window(col_off, row_off, grid.width, grid.height)
-
-
 def _mask_fill(dataset: EEORasterDataset, nodata: float | None) -> float:
     """Choose the value masked-out pixels take, and that gets recorded as nodata.
 
@@ -277,50 +191,6 @@ def _mask_fill(dataset: EEORasterDataset, nodata: float | None) -> float:
     if np.issubdtype(np.dtype(dataset.get_metadata()["dtype"]), np.floating):
         return float("nan")
     return 0.0
-
-
-def _asset_band_names(src: Any, asset: str) -> list[str | None]:
-    """Name a single-band asset after itself; number the bands of a stack."""
-    if src.count == 1:
-        return [asset]
-    descriptions = list(src.descriptions or ())
-    names: list[str | None] = []
-    for index in range(src.count):
-        description = descriptions[index] if index < len(descriptions) else None
-        names.append(description or f"{asset}_{index + 1}")
-    return names
-
-
-def _read_first_asset(href: str, asset: str, bbox: Sequence[float] | None) -> tuple:
-    """Read the leading asset, which defines the grid the rest are read onto."""
-    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
-        window = None if bbox is None else _crop_window(src, bbox)
-        array = src.read(window=window)
-        transform = src.transform if window is None else src.window_transform(window)
-        grid = _Grid(src.crs, transform, array.shape[-1], array.shape[-2])
-        return array, grid, src.nodata, _asset_band_names(src, asset)
-
-
-def _read_onto_grid(href: str, asset: str, grid: _Grid, resampling: Any) -> tuple:
-    """Read a further asset onto ``grid``, warping only when it does not fit."""
-    with rio.Env(**_GDAL_HTTP_ENV), rio.open(href) as src:
-        window = _aligned_window(src, grid)
-        if window is not None:
-            return src.read(window=window), _asset_band_names(src, asset)
-
-        # Different CRS, resolution, or sub-pixel offset: let GDAL resample
-        # straight onto the target grid rather than reading and fixing up after.
-        with WarpedVRT(
-            src,
-            crs=grid.crs,
-            transform=grid.transform,
-            width=grid.width,
-            height=grid.height,
-            resampling=resampling,
-            src_nodata=src.nodata,
-            nodata=src.nodata,
-        ) as vrt:
-            return vrt.read(), _asset_band_names(src, asset)
 
 
 class STACItem:
@@ -611,14 +481,11 @@ class STACItem:
 
         resampling_enum = normalize_resampling_method(resampling)
 
-        array, grid, nodata, band_names = _read_first_asset(self._href(keys[0]), keys[0], aoi)
-        arrays = [array]
-        for key in keys[1:]:
-            other, other_names = _read_onto_grid(self._href(key), key, grid, resampling_enum)
-            arrays.append(other)
-            band_names.extend(other_names)
-
-        stacked = arrays[0] if len(arrays) == 1 else np.concatenate(arrays, axis=0)
+        stacked, grid, nodata, band_names = read_onto_common_grid(
+            [(self._href(key), key) for key in keys],
+            bbox=aoi,
+            resampling=resampling_enum,
+        )
 
         dataset = load_array(
             stacked,

--- a/eeo/io/xarray.py
+++ b/eeo/io/xarray.py
@@ -285,7 +285,9 @@ def _transform_from(da: Any, y_dim: str, x_dim: str) -> Affine:
     y_geometry = _axis_geometry(da, y_dim)
     x_res, x_origin = (stored.a, stored.c) if x_geometry is None else x_geometry
     y_res, y_origin = (stored.e, stored.f) if y_geometry is None else y_geometry
-    derived = Affine.translation(x_origin, y_origin) * Affine.scale(x_res, y_res)
+    # Composed directly rather than as translation * scale: affine 3
+    # deprecates `*` for composition and affine 2 has no `@`.
+    derived = Affine(x_res, 0.0, x_origin, 0.0, y_res, y_origin)
 
     if np.allclose(tuple(derived)[:6], tuple(stored)[:6], rtol=1e-9, atol=0):
         return stored

--- a/eeo/preprocessing/resample.py
+++ b/eeo/preprocessing/resample.py
@@ -129,7 +129,19 @@ def resample(
         scale_x = ds.get_width() / new_width
         scale_y = ds.get_height() / new_height
 
-        transform = ds.get_transform() * Affine.scale(scale_x, scale_y)
+        # Scaled directly rather than as transform * scale: affine 3
+        # deprecates `*` for composition and affine 2 has no `@`. An Affine
+        # maps (col, row) -> (x, y), so the col terms (a, d) take scale_x and
+        # the row terms (b, e) take scale_y; the origin (c, f) is untouched.
+        base = ds.get_transform()
+        transform = Affine(
+            base.a * scale_x,
+            base.b * scale_y,
+            base.c,
+            base.d * scale_x,
+            base.e * scale_y,
+            base.f,
+        )
 
         # Save or return EEORasterDataset
         # Update metadata

--- a/eeo/viz/plot.py
+++ b/eeo/viz/plot.py
@@ -541,9 +541,23 @@ def _read_band_for_display(
     array = ds.read(band, out_shape=out_shape)
     height, width = ds.get_shape()
     out_height, out_width = out_shape
+    # Scaled directly rather than as transform * scale: affine 3 deprecates
+    # `*` for composition and affine 2 has no `@`.
+    # An Affine maps (col, row) -> (x, y) as x = a*col + b*row + c and
+    # y = d*col + e*row + f, so scaling the pixel grid multiplies the
+    # col terms (a, d) by scale_x and the row terms (b, e) by scale_y.
+    # The origin (c, f) is untouched: a pure scale has no translation.
+    scale_x, scale_y = width / out_width, height / out_height
     return (
         _mask_nodata_for_display(ds, array),
-        transform * Affine.scale(width / out_width, height / out_height),
+        Affine(
+            transform.a * scale_x,
+            transform.b * scale_y,
+            transform.c,
+            transform.d * scale_x,
+            transform.e * scale_y,
+            transform.f,
+        ),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,12 @@ filterwarnings = [
     # with a class-based Config, which pydantic 2 deprecates on import. Out of
     # our control until planetary-computer migrates.
     "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
+    # affine 3.0 deprecates `*` for composing transforms in favour of `@`, and
+    # rasterio's own helpers (from_origin, from_bounds) still use `*`. The
+    # affine floor, 2.4, has no `@` at all, so neither we nor rasterio can
+    # switch until that floor rises. Our own code composes transforms directly
+    # and never raises this; every occurrence comes from inside rasterio.
+    'ignore:Use `@` matmul instead of `\*` mul operator:PendingDeprecationWarning',
 ]
 
 # ---------------------

--- a/scripts/make_product_fixture.py
+++ b/scripts/make_product_fixture.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Materialise one of the suite's synthetic products into a real directory.
+
+Maintainer tool, not part of the shipped library. The test suite builds these
+products into a temporary directory and throws them away, which is right for
+tests and unhelpful the moment you want to open it in a GIS software.
+
+This writes the same products, from the same builders in
+``tests/product_fixtures.py``, somewhere they persist. There is no second
+definition to drift: change the fixture module and both the suite and this
+script follow.
+
+Usage
+-----
+    python scripts/make_product_fixture.py sentinel2 --out build/fixtures
+    python scripts/make_product_fixture.py landsat --mission 7 --out build/fixtures
+    python scripts/make_product_fixture.py sentinel2 --out build/fixtures --archive
+
+``--archive`` additionally packs the product the way it would have been
+downloaded: a ``.zip`` for Sentinel-2, a ``.tar`` for Landsat.
+
+Requires only rasterio + numpy (already runtime deps).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# The builders live with the tests, because that is what they exist for.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
+
+from product_fixtures import (  # noqa: E402
+    L7_ID,
+    L9_ID,
+    build_landsat,
+    build_safe,
+    pack_tar,
+    pack_zip,
+)
+
+#: Landsat missions with a band table, and the product id to build for each.
+_LANDSAT_IDS = {7: L7_ID, 9: L9_ID}
+
+
+def _sentinel2(out: Path, *, archive: bool) -> tuple[Path, Path | None]:
+    """Build a Level-2A .SAFE product, optionally zipped as Copernicus ships it."""
+    safe = build_safe(out)
+    if not archive:
+        return safe, None
+    return safe, pack_zip(safe, out / f"{safe.name[:-5]}.zip", base=out)
+
+
+def _landsat(out: Path, *, mission: int, archive: bool) -> tuple[Path, Path | None]:
+    """Build a Collection 2 Level-2 product, optionally tarred as USGS ships it."""
+    product = build_landsat(out, product_id=_LANDSAT_IDS[mission])
+    if not archive:
+        return product, None
+    # USGS tars a product's files at the root, with no enclosing directory.
+    return product, pack_tar(product, out / f"{product.name}.tar", base=product)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build one product and report where it landed."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("mission", choices=["sentinel2", "landsat"])
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("build/fixtures"),
+        help="directory to build into (default: build/fixtures)",
+    )
+    parser.add_argument(
+        "--landsat-mission",
+        dest="landsat_mission",
+        type=int,
+        choices=sorted(_LANDSAT_IDS),
+        default=9,
+        help="which Landsat to build; 7 uses the TM/ETM+ band table (default: 9)",
+    )
+    parser.add_argument(
+        "--archive",
+        action="store_true",
+        help="also pack the product as it would have been downloaded",
+    )
+    args = parser.parse_args(argv)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    if args.mission == "sentinel2":
+        built, packed = _sentinel2(args.out, archive=args.archive)
+    else:
+        built, packed = _landsat(args.out, mission=args.landsat_mission, archive=args.archive)
+
+    written = [path for path in built.rglob("*") if path.is_file()]
+    size = sum(path.stat().st_size for path in written)
+    print(f"built {built} ({len(written)} files, {size / 1e3:.0f} kB)")
+    if packed is not None:
+        print(f"packed {packed} ({packed.stat().st_size / 1e3:.0f} kB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 
@@ -107,7 +108,7 @@ def _silence_agg_show_warning():
 
 def _north_up(origin_x: float = ORIGIN_X, origin_y: float = ORIGIN_Y, res: float = RES) -> Affine:
     """Return a north-up affine transform with square pixels."""
-    return Affine.translation(origin_x, origin_y) * Affine.scale(res, -res)
+    return from_origin(origin_x, origin_y, res, res)
 
 
 def _gradient(shape: tuple[int, int], dtype) -> np.ndarray:
@@ -187,7 +188,7 @@ def crs_mismatch_pair():
     ).to_rasterio()
     geo = load_array(
         _gradient((6, 6), np.float32),
-        transform=Affine.translation(12.0, 42.0) * Affine.scale(0.0001, -0.0001),
+        transform=from_origin(12.0, 42.0, 0.0001, 0.0001),
         crs=GEO_CRS,
     ).to_rasterio()
     yield utm, geo
@@ -238,6 +239,6 @@ def raster_3x3():
     """
     return load_array(
         np.arange(1, 10, dtype=np.float32).reshape(3, 3),
-        transform=Affine.translation(0, 3) * Affine.scale(1, -1),
+        transform=from_origin(0, 3, 1, 1),
         crs=GEO_CRS,
     )

--- a/tests/product_fixtures.py
+++ b/tests/product_fixtures.py
@@ -1,0 +1,498 @@
+"""Synthetic Sentinel-2 and Landsat products, built for the test suite.
+
+The suite blocks sockets, so no real product can be downloaded into it. These
+builders stand in for one: structurally faithful, small enough to write in
+milliseconds, and deterministic. Every test that needs a product on disk gets
+it from here, so there is one answer to "what does a product look like" rather
+than one per test module that can drift out of agreement.
+
+Faithful means the parts a reader actually depends on, checked against real
+output rather than documentation:
+
+* Sentinel-2 — a namespaced manifest root over an unnamespaced body, the
+  ``band_id``/``bandId`` indirection between the offset list and the spectral
+  list, single-digit bands spelled ``B1`` in the spectral list and ``B01`` in
+  the image paths, a granule holding its own ``MTD_TL.xml``, and images in the
+  ``R10m``/``R20m``/``R60m`` layout at the resolutions each band is really
+  written at.
+* Landsat — the same content in all three metadata syntaxes, a Level-1 record
+  repeating the Level-2 key names with different values, a scene centre time
+  with seven fractional digits, and the fill values USGS declares: 0 in the
+  imagery and 1 in the quality rasters.
+
+Two levels of fixture are offered per mission, because the readers come in two
+layers. ``manifest_xml``/``landsat_groups`` and the ``write_*`` helpers build
+**metadata only**, for testing the parsers — including deliberately damaged
+variants. ``build_safe``/``build_landsat`` build a **whole product** with real
+images, for testing the loaders end to end.
+
+Nothing here is imported by the library. ``scripts/make_product_fixture.py``
+materialises one of these products into a directory you name, for looking at in
+a GIS or stepping through by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+import zipfile
+
+import numpy as np
+import rasterio as rio
+from rasterio.transform import from_origin
+
+# Sentinel-2
+
+S2_PRODUCT = "S2B_MSIL2A_20240830T100559_N0511_R022_T32TPS_20240830T134009.SAFE"
+S2_GRANULE = "L2A_T32TPS_A038765_20240830T100558"
+
+#: The stem every image filename in this product starts with.
+S2_STEM = "T32TPS_20240830T100559"
+
+#: One image path, as the manifest writes them: relative to the .SAFE root and
+#: without a file extension.
+S2_IMAGE = f"GRANULE/{S2_GRANULE}/IMG_DATA/R10m/{S2_STEM}_B04_10m"
+
+S2_CRS = "EPSG:32632"
+S2_ULX, S2_ULY = 300000.0, 5100000.0
+
+#: Width and height of the 10 m bands. Coarser bands are proportionally
+#: smaller, as they are in a real product.
+S2_SIZE_10M = 64
+
+#: Which bands this product holds and at which resolutions, mirroring a real
+#: one: B08 only at 10 m, B01 at 20 m and 60 m though it is sensed at 60, B09
+#: only at 60 m, SCL at 20 m and 60 m.
+S2_LAYOUT = {
+    "B02": (10, 20),
+    "B03": (10, 20),
+    "B04": (10, 20, 60),
+    "B08": (10,),
+    "B05": (20, 60),
+    "B11": (20, 60),
+    "B12": (20, 60),
+    "B8A": (20, 60),
+    "B01": (20, 60),
+    "B09": (60,),
+    "SCL": (20, 60),
+}
+
+#: The digital number filling each band. Distinct per band, so a band read in
+#: the wrong order shows up as a wrong value rather than a passing test.
+S2_FILL = {
+    "B02": 700,
+    "B03": 900,
+    "B04": 1234,
+    "B08": 4321,
+    "B05": 3000,
+    "B11": 2222,
+    "B12": 1800,
+    "B8A": 4000,
+    "B01": 1100,
+    "B09": 1500,
+}
+
+# Spectral_Information spells single-digit bands "B1"; the image files use "B01".
+S2_SPECTRAL = """
+      <Spectral_Information_List>
+        <Spectral_Information bandId="0" physicalBand="B1"/>
+        <Spectral_Information bandId="3" physicalBand="B4"/>
+        <Spectral_Information bandId="8" physicalBand="B8A"/>
+        <Spectral_Information bandId="12" physicalBand="B12"/>
+      </Spectral_Information_List>"""
+
+S2_OFFSETS = """
+      <BOA_ADD_OFFSET_VALUES_LIST>
+        <BOA_ADD_OFFSET band_id="0">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="3">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="8">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="12">-1000</BOA_ADD_OFFSET>
+      </BOA_ADD_OFFSET_VALUES_LIST>"""
+
+S2_TILE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<n1:Level-2A_Tile_ID
+    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/S2_PDI_Level-2A_Tile_Metadata.xsd">
+  <n1:General_Info>
+    <TILE_ID>S2B_OPER_MSI_L2A_TL_2BPS_20240830T134009_A038765_T32TPS_N05.11</TILE_ID>
+    <SENSING_TIME>2024-08-30T10:06:21.919283Z</SENSING_TIME>
+  </n1:General_Info>
+  <n1:Geometric_Info>
+    <Tile_Geocoding>
+      <HORIZONTAL_CS_NAME>WGS84 / UTM zone 32N</HORIZONTAL_CS_NAME>
+      <HORIZONTAL_CS_CODE>EPSG:32632</HORIZONTAL_CS_CODE>
+      <Size resolution="10"><NROWS>10980</NROWS><NCOLS>10980</NCOLS></Size>
+    </Tile_Geocoding>
+  </n1:Geometric_Info>
+</n1:Level-2A_Tile_ID>
+"""
+
+#: The tile manifest's sensing time, which a load reports as its timestamp.
+S2_SENSING_TIME = "2024-08-30T10:06:21.919283+00:00"
+
+
+def manifest_xml(
+    *,
+    level="2A",
+    product_type="S2MSI2A",
+    baseline="05.11",
+    quantification="10000",
+    offsets=S2_OFFSETS,
+    spectral=S2_SPECTRAL,
+    start_time="2024-08-30T10:05:59.024Z",
+    uri=S2_PRODUCT,
+    granule=S2_GRANULE,
+    image_files=(S2_IMAGE,),
+):
+    """Build a product manifest with the parts under test made adjustable."""
+    type_element = f"<PRODUCT_TYPE>{product_type}</PRODUCT_TYPE>" if product_type else ""
+    quant = (
+        f"""
+      <QUANTIFICATION_VALUES_LIST>
+        <BOA_QUANTIFICATION_VALUE unit="none">{quantification}</BOA_QUANTIFICATION_VALUE>
+      </QUANTIFICATION_VALUES_LIST>"""
+        if quantification
+        else ""
+    )
+    files = "".join(f"<IMAGE_FILE>{path}</IMAGE_FILE>" for path in image_files)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<n1:Level-{level}_User_Product
+    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/User_Product_Level-{level}.xsd">
+  <n1:General_Info>
+    <Product_Info>
+      <PRODUCT_START_TIME>{start_time}</PRODUCT_START_TIME>
+      <PRODUCT_URI>{uri}</PRODUCT_URI>
+      <PROCESSING_LEVEL>Level-{level}</PROCESSING_LEVEL>
+      {type_element}
+      <PROCESSING_BASELINE>{baseline}</PROCESSING_BASELINE>
+      <Product_Organisation>
+        <Granule_List>
+          <Granule granuleIdentifier="{granule}" imageFormat="JPEG2000">
+            {files}
+          </Granule>
+        </Granule_List>
+      </Product_Organisation>
+    </Product_Info>
+    <Product_Image_Characteristics>{quant}{offsets}{spectral}
+    </Product_Image_Characteristics>
+  </n1:General_Info>
+</n1:Level-{level}_User_Product>
+"""
+
+
+def write_safe(root, *, manifest_name="MTD_MSIL2A.xml", tile_xml=S2_TILE_XML, **kwargs):
+    """Write a .SAFE tree of metadata only, and return its directory.
+
+    No image is written: the metadata reader never opens one, so a parser test
+    should not pay to encode any.
+    """
+    safe = root / S2_PRODUCT
+    (safe / "GRANULE" / S2_GRANULE).mkdir(parents=True, exist_ok=True)
+    (safe / manifest_name).write_text(manifest_xml(**kwargs))
+    if tile_xml is not None:
+        (safe / "GRANULE" / S2_GRANULE / "MTD_TL.xml").write_text(tile_xml)
+    return safe
+
+
+def write_jp2(path, *, resolution, size, band):
+    """Write one georeferenced JPEG 2000 image, losslessly."""
+    if band == "SCL":
+        # Distinct class numbers in blocks, so any blending is detectable.
+        data = np.zeros((size, size), dtype="uint16")
+        data[: size // 2] = 4  # vegetation
+        data[size // 2 :] = 9  # cloud high probability
+        data = data[None]
+    else:
+        data = np.full((1, size, size), S2_FILL[band], dtype="uint16")
+    # Only the options JP2OpenJPEG accepts: copying a GeoTIFF profile would
+    # carry INTERLEAVE and tiling keys the driver rejects.
+    #
+    # REVERSIBLE and QUALITY are both required, and only together: the writer
+    # is lossy by default and stays lossy with either one alone, which quietly
+    # rewrites a class number 4 as 3 and would make a resampling test read as a
+    # loader bug. Real products are losslessly encoded, so the fixture must be
+    # too or it is testing the compressor rather than the reader.
+    profile = {
+        "driver": "JP2OpenJPEG",
+        "height": size,
+        "width": size,
+        "count": 1,
+        "dtype": "uint16",
+        "crs": S2_CRS,
+        "transform": from_origin(S2_ULX, S2_ULY, resolution, resolution),
+        "nodata": 0,
+        "REVERSIBLE": "YES",
+        "QUALITY": "100",
+    }
+    with rio.open(path, "w", **profile) as dst:
+        dst.write(data)
+
+
+def build_safe(root, *, level="2A", product_type="S2MSI2A", layout=None, omit_file=None):
+    """Build a whole .SAFE product, real images included, and return its path.
+
+    Parameters
+    ----------
+    root : Path
+        Directory to build the ``.SAFE`` inside.
+    level, product_type : str
+        The level to write into the manifest's name and body. They are set
+        separately so a product can be made to disagree with itself.
+    layout : dict or None
+        Band to the resolutions it is written at, defaulting to
+        :data:`S2_LAYOUT`.
+    omit_file : tuple or None
+        A ``(band, resolution)`` the manifest lists but the tree does not hold
+        — the state a truncated download leaves behind.
+    """
+    layout = S2_LAYOUT if layout is None else layout
+    safe = root / S2_PRODUCT
+    images = safe / "GRANULE" / S2_GRANULE / "IMG_DATA"
+
+    entries = []
+    for band, resolutions in layout.items():
+        for resolution in resolutions:
+            (images / f"R{resolution}m").mkdir(parents=True, exist_ok=True)
+            relative = (
+                f"GRANULE/{S2_GRANULE}/IMG_DATA/R{resolution}m/{S2_STEM}_{band}_{resolution}m"
+            )
+            entries.append(relative)
+            if omit_file == (band, resolution):
+                continue
+            write_jp2(
+                safe / f"{relative}.jp2",
+                resolution=resolution,
+                size=S2_SIZE_10M * 10 // resolution,
+                band=band,
+            )
+
+    (safe / f"MTD_MSIL{level}.xml").write_text(
+        manifest_xml(level=level, product_type=product_type, image_files=entries)
+    )
+    (safe / "GRANULE" / S2_GRANULE / "MTD_TL.xml").write_text(S2_TILE_XML)
+    return safe
+
+
+# Landsat
+
+L9_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
+L7_ID = "LE07_L2SP_193028_20231024_20231119_02_T2"
+L1_ID = "LC09_L1TP_193028_20260822_20260823_02_T1"
+
+LANDSAT_CRS = "EPSG:32633"
+LANDSAT_ULX, LANDSAT_ULY = 300000.0, 5100000.0
+
+#: The single grid every Collection 2 Level-2 band is delivered on.
+LANDSAT_RES = 30.0
+LANDSAT_SIZE = 64
+
+#: Bands an OLI/TIRS product holds, with the digital number filling each.
+OLI_BANDS = {
+    "SR_B1": 8000,
+    "SR_B2": 8100,
+    "SR_B3": 9000,
+    "SR_B4": 10000,
+    "SR_B5": 25000,
+    "SR_B6": 15000,
+    "SR_B7": 12000,
+    "ST_B10": 44000,
+    "QA_PIXEL": 21824,
+    "QA_RADSAT": 0,
+    "SR_QA_AEROSOL": 96,
+}
+
+#: Bands a TM/ETM+ product holds. The band numbers carry different wavelengths
+#: from OLI's, which is the whole reason bands are requested by name.
+TM_BANDS = {
+    "SR_B1": 8100,
+    "SR_B2": 9000,
+    "SR_B3": 10000,
+    "SR_B4": 25000,
+    "SR_B5": 15000,
+    "SR_B7": 12000,
+    "ST_B6": 44000,
+    "QA_PIXEL": 5440,
+    "QA_RADSAT": 0,
+    "SR_ATMOS_OPACITY": 120,
+    "SR_CLOUD_QA": 0,
+}
+
+#: Bands whose fill value is 1 rather than 0, as USGS declares them.
+LANDSAT_QUALITY_FILL = {"QA_PIXEL"}
+
+#: The three file tokens a metadata-only fixture lists, enough to exercise
+#: reflectance, temperature, and quality without writing eleven of them.
+LANDSAT_DEFAULT_TOKENS = ("SR_B4", "ST_B10", "QA_PIXEL")
+
+
+def landsat_groups(
+    *,
+    level="L2SP",
+    product_id=L9_ID,
+    row="028",
+    mission_prefix=None,
+    tokens=LANDSAT_DEFAULT_TOKENS,
+    date="2026-08-22",
+):
+    """Describe a Landsat product as the groups of key-value pairs it holds.
+
+    The Level-1 groups are the point of the fixture as much as the Level-2 ones
+    are: they repeat the same key names with different values, so a reader that
+    searches for a bare key name passes or fails here by accident of ordering.
+    """
+    if mission_prefix:
+        product_id = mission_prefix + product_id[4:]
+    return {
+        "PRODUCT_CONTENTS": {
+            "LANDSAT_PRODUCT_ID": product_id,
+            "PROCESSING_LEVEL": level,
+            "COLLECTION_NUMBER": "02",
+            "COLLECTION_CATEGORY": product_id[-2:],
+            **{f"FILE_NAME_{token}": f"{product_id}_{token}.TIF" for token in tokens},
+            "FILE_NAME_METADATA_ODL": f"{product_id}_MTL.txt",
+        },
+        "IMAGE_ATTRIBUTES": {
+            "SPACECRAFT_ID": f"LANDSAT_{product_id[3]}",
+            "SENSOR_ID": "OLI_TIRS",
+            "WRS_PATH": "193",
+            "WRS_ROW": row,
+            "DATE_ACQUIRED": date,
+            # USGS writes seven fractional digits.
+            "SCENE_CENTER_TIME": "10:04:22.1183580Z",
+        },
+        "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS": {
+            "REFLECTANCE_MULT_BAND_4": "2.75e-05",
+            "REFLECTANCE_ADD_BAND_4": "-0.2",
+        },
+        "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS": {
+            "TEMPERATURE_MULT_BAND_ST_B10": "0.00341802",
+            "TEMPERATURE_ADD_BAND_ST_B10": "149.0",
+        },
+        # The Level-1 record repeats the same key names with different values.
+        # Everything above must win over everything here.
+        "LEVEL1_PROCESSING_RECORD": {
+            "LANDSAT_PRODUCT_ID": L1_ID,
+            "PROCESSING_LEVEL": "L1TP",
+        },
+        "LEVEL1_RADIOMETRIC_RESCALING": {
+            "REFLECTANCE_MULT_BAND_4": "2.0000E-05",
+            "REFLECTANCE_ADD_BAND_4": "-0.100000",
+        },
+    }
+
+
+def as_odl(groups):
+    """Render groups in the ODL text syntax."""
+    lines = ["GROUP = LANDSAT_METADATA_FILE"]
+    for group, members in groups.items():
+        lines.append(f"  GROUP = {group}")
+        lines += [f'    {key} = "{value}"' for key, value in members.items()]
+        lines.append(f"  END_GROUP = {group}")
+    lines += ["END_GROUP = LANDSAT_METADATA_FILE", "END"]
+    return "\n".join(lines)
+
+
+def as_json(groups):
+    """Render groups in the JSON syntax."""
+    return json.dumps({"LANDSAT_METADATA_FILE": groups}, indent=2)
+
+
+def as_xml(groups):
+    """Render groups in the XML syntax."""
+    body = "".join(
+        f"<{group}>"
+        + "".join(f"<{key}>{value}</{key}>" for key, value in members.items())
+        + f"</{group}>"
+        for group, members in groups.items()
+    )
+    return f"<LANDSAT_METADATA_FILE>{body}</LANDSAT_METADATA_FILE>"
+
+
+RENDERERS = {"xml": as_xml, "json": as_json, "txt": as_odl}
+
+
+def write_landsat_metadata(root, syntax="xml", **kwargs):
+    """Write a product directory holding one metadata file and no imagery."""
+    groups = landsat_groups(**kwargs)
+    name = groups["PRODUCT_CONTENTS"]["LANDSAT_PRODUCT_ID"]
+    directory = root / name
+    directory.mkdir(exist_ok=True)
+    (directory / f"{name}_MTL.{syntax}").write_text(RENDERERS[syntax](groups))
+    return directory
+
+
+def write_landsat_tif(path, token, table):
+    """Write one georeferenced 30 m GeoTIFF for a band."""
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=LANDSAT_SIZE,
+        width=LANDSAT_SIZE,
+        count=1,
+        dtype="uint16",
+        crs=LANDSAT_CRS,
+        transform=from_origin(LANDSAT_ULX, LANDSAT_ULY, LANDSAT_RES, LANDSAT_RES),
+        nodata=1 if token in LANDSAT_QUALITY_FILL else 0,
+    ) as dst:
+        dst.write(np.full((1, LANDSAT_SIZE, LANDSAT_SIZE), table[token], dtype="uint16"))
+
+
+def landsat_table(product_id):
+    """The band table a product's mission uses."""
+    return OLI_BANDS if product_id.startswith("LC0") else TM_BANDS
+
+
+def build_landsat(
+    root, *, product_id=L9_ID, tokens=None, level="L2SP", syntax="json", omit_file=None
+):
+    """Build a whole Landsat product, real images included, and return its path.
+
+    Parameters
+    ----------
+    root : Path
+        Directory to build the product inside.
+    product_id : str
+        Which mission and scene to build. The prefix chooses the band table.
+    tokens : sequence of str or None
+        File tokens to write, defaulting to every band the mission holds.
+        Dropping the ``ST_`` tokens makes a reflectance-only ``L2SR`` product.
+    level : str
+        Processing level to record, e.g. ``"L2SR"`` or ``"L1TP"``.
+    syntax : str
+        Which of the three metadata syntaxes to write.
+    omit_file : str or None
+        A token the metadata lists but the directory does not hold.
+    """
+    table = landsat_table(product_id)
+    if tokens is None:
+        tokens = list(table)
+    directory = root / product_id
+    directory.mkdir()
+    date = "2026-08-22" if product_id.startswith("LC09") else "2023-10-24"
+    groups = landsat_groups(product_id=product_id, tokens=tokens, level=level, date=date)
+    (directory / f"{product_id}_MTL.{syntax}").write_text(RENDERERS[syntax](groups))
+    for token in tokens:
+        if token != omit_file:
+            write_landsat_tif(directory / f"{product_id}_{token}.TIF", token, table)
+    return directory
+
+
+# Packing a built product into the archive it would have arrived in
+
+
+def pack_zip(tree, archive, *, base):
+    """Zip a directory tree, naming members relative to ``base``."""
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zipped:
+        for path in sorted(tree.rglob("*")):
+            if path.is_file():
+                zipped.write(path, path.relative_to(base).as_posix())
+    return archive
+
+
+def pack_tar(tree, archive, *, base, compress=False):
+    """Tar a directory tree, naming members relative to ``base``."""
+    with tarfile.open(archive, "w:gz" if compress else "w") as tarred:
+        for path in sorted(tree.rglob("*")):
+            if path.is_file():
+                tarred.add(path, arcname=path.relative_to(base).as_posix())
+    return archive

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,8 +2,8 @@ import math
 
 import numpy as np
 import pytest
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 from eeo.core.exceptions import ValidationError
@@ -31,7 +31,7 @@ def test_normalized_difference_returns_ndarray(raster_3x3):
 # divide-by-zero safety
 def test_normalized_difference_divide_by_zero():
     zeros = np.zeros((3, 3), dtype=np.float32)
-    transform = Affine.translation(0, 3) * Affine.scale(1, -1)
+    transform = from_origin(0, 3, 1, 1)
     crs = CRS.from_epsg(4326)
 
     ds1 = load_array(zeros, transform=transform, crs=crs)
@@ -208,7 +208,7 @@ def test_normalized_difference_nodata_is_contagious():
     a[:2, :2] = -9999.0
     b = np.arange(1, 37, dtype=np.float32).reshape(6, 6)
     b[4:, 4:] = -9999.0
-    transform = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+    transform = from_origin(500_000.0, 4_200_000.0, 10.0, 10.0)
     crs = CRS.from_epsg(32633)
     ds_a = load_array(a, transform=transform, crs=crs, nodata=-9999.0).to_rasterio()
     ds_b = load_array(b, transform=transform, crs=crs, nodata=-9999.0).to_rasterio()

--- a/tests/test_band_names.py
+++ b/tests/test_band_names.py
@@ -3,9 +3,9 @@
 import numpy as np
 import pytest
 import rasterio as rio
-from affine import Affine
 from rasterio.crs import CRS
 from rasterio.io import MemoryFile
+from rasterio.transform import from_origin
 
 from eeo import load_array, load_raster
 from eeo.common import resolve_band_index
@@ -14,7 +14,7 @@ from eeo.core.exceptions import ValidationError
 from eeo.viz.plot import _band_label, _normalize_bands
 
 CRS_4326 = CRS.from_epsg(4326)
-TRANSFORM = Affine.translation(0, 4) * Affine.scale(1, -1)
+TRANSFORM = from_origin(0, 4, 1, 1)
 
 
 def _numpy_ds(count=3, **kwargs):

--- a/tests/test_band_names_matrix.py
+++ b/tests/test_band_names_matrix.py
@@ -9,9 +9,9 @@ and on both backends, so no op silently drops or mislabels a name.
 import geopandas as gpd
 import numpy as np
 import pytest
-from affine import Affine
 from matplotlib.axes import Axes
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 from shapely.geometry import box
 
 from eeo import load_array, load_raster
@@ -19,7 +19,7 @@ from eeo.core.decorators import _OP_REGISTRY
 from eeo.core.exceptions import ValidationError
 
 UTM_CRS = CRS.from_epsg(32633)
-TRANSFORM = Affine.translation(500_000, 4_200_000) * Affine.scale(10, -10)
+TRANSFORM = from_origin(500_000, 4_200_000, 10, 10)
 
 # A 6-band scene covers every index's band requirements at once.
 SCENE_NAMES = ["blue", "green", "red", "nir", "swir", "extra"]

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -1,0 +1,274 @@
+"""Tests for the per-sensor band tables (eeo/io/_bands.py).
+
+The tables are the place a cross-sensor mistake becomes invisible, so the
+checks here are mostly invariants rather than spot values: that a common name
+means the same wavelength on every sensor that has it, that no name is used
+twice within one sensor, and that the Landsat 7 / Landsat 8-9 numbering
+divergence resolves in both directions.
+"""
+
+import pytest
+
+from eeo.core.exceptions import ValidationError
+from eeo.io._bands import (
+    LANDSAT_OLI,
+    LANDSAT_TM,
+    SENTINEL2,
+    finest_resolution,
+    landsat_band_file,
+    landsat_bands,
+    resolve_band,
+    resolve_bands,
+    sentinel2_available_resolutions,
+    sentinel2_band_file,
+)
+
+ALL_TABLES = {"sentinel-2": SENTINEL2, "landsat-oli": LANDSAT_OLI, "landsat-tm": LANDSAT_TM}
+
+# Wavelength ranges for each common name, from the STAC Electro-Optical
+# extension. A band whose centre falls outside its name's range is mislabelled.
+STAC_RANGES = {
+    "coastal": (0.40, 0.45),
+    "blue": (0.45, 0.53),
+    "green": (0.51, 0.60),
+    "red": (0.62, 0.69),
+    "rededge1": (0.69, 0.79),
+    "rededge2": (0.69, 0.79),
+    "rededge3": (0.69, 0.79),
+    "nir": (0.76, 1.00),
+    "nir08": (0.80, 0.90),
+    "nir09": (0.90, 1.00),
+    "swir16": (1.55, 1.75),
+    "swir22": (2.08, 2.35),
+    "lwir": (10.4, 12.5),
+    "lwir11": (10.5, 11.5),
+}
+
+# Real Sentinel-2 image paths, one per resolution the product writes the band
+# at. Availability is irregular: B01 is sensed at 60 m but written at 20 m too,
+# B08 only at 10 m, B09 only at 60 m.
+S2_FILES = [
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R10m/T32TPS_20240929T100719_B04_10m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R20m/T32TPS_20240929T100719_B04_20m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R60m/T32TPS_20240929T100719_B04_60m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R10m/T32TPS_20240929T100719_B08_10m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R20m/T32TPS_20240929T100719_B11_20m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R60m/T32TPS_20240929T100719_B11_60m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R20m/T32TPS_20240929T100719_B01_20m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R60m/T32TPS_20240929T100719_B01_60m",
+    "GRANULE/L2A_T32TPS_A039/IMG_DATA/R20m/T32TPS_20240929T100719_SCL_20m",
+]
+
+L9_FILES = {
+    t: f"LC09_L2SP_193028_20260822_20260823_02_T1_{t}.TIF"
+    for t in (
+        "SR_B1",
+        "SR_B2",
+        "SR_B3",
+        "SR_B4",
+        "SR_B5",
+        "SR_B6",
+        "SR_B7",
+        "ST_B10",
+        "QA_PIXEL",
+        "QA_RADSAT",
+        "SR_QA_AEROSOL",
+    )
+}
+
+
+class TestTheBandNumberingTrap:
+    """Landsat 7 and Landsat 8/9 number the same wavelengths differently."""
+
+    def test_red_is_a_different_band_number_per_sensor(self):
+        assert landsat_bands(7)["red"].band_id == "SR_B3"
+        assert landsat_bands(8)["red"].band_id == "SR_B4"
+        assert landsat_bands(9)["red"].band_id == "SR_B4"
+
+    def test_the_same_native_id_means_different_things(self):
+        # This is the whole reason common names are the primary spelling.
+        assert resolve_band("SR_B4", landsat_bands(7)).common_name == "nir08"
+        assert resolve_band("SR_B4", landsat_bands(9)).common_name == "red"
+
+    def test_landsat_8_and_9_share_one_table(self):
+        assert landsat_bands(8) is landsat_bands(9)
+
+    def test_landsat_4_5_and_7_share_one_table(self):
+        assert landsat_bands(4) is landsat_bands(5) is landsat_bands(7)
+
+    def test_older_sensors_have_no_coastal_band(self):
+        assert "coastal" not in landsat_bands(7)
+        assert "coastal" in landsat_bands(9)
+
+    def test_unknown_mission_rejected(self):
+        with pytest.raises(ValidationError, match="no band table for Landsat 3"):
+            landsat_bands(3)
+
+
+class TestTableInvariants:
+    """Properties that must hold for every table, whatever the sensor."""
+
+    @pytest.mark.parametrize("label", sorted(ALL_TABLES))
+    def test_common_names_are_unique(self, label):
+        # The EO extension requires it, and a duplicate would make a name
+        # ambiguous exactly where it is meant to disambiguate.
+        table = ALL_TABLES[label]
+        assert len(table) == len({band.common_name for band in table.values()})
+
+    @pytest.mark.parametrize("label", sorted(ALL_TABLES))
+    def test_native_ids_are_unique(self, label):
+        table = ALL_TABLES[label]
+        assert len(table) == len({band.band_id for band in table.values()})
+
+    @pytest.mark.parametrize("label", sorted(ALL_TABLES))
+    def test_wavelengths_match_their_common_name(self, label):
+        for band in ALL_TABLES[label].values():
+            if band.wavelength is None:
+                continue
+            low, high = STAC_RANGES[band.common_name]
+            assert low <= band.wavelength <= high, (
+                f"{label} {band.common_name} at {band.wavelength} um is outside "
+                f"the {low}-{high} um range that name denotes"
+            )
+
+    @pytest.mark.parametrize("label", sorted(ALL_TABLES))
+    def test_the_table_key_matches_the_band(self, label):
+        for name, band in ALL_TABLES[label].items():
+            assert name == band.common_name
+
+    @pytest.mark.parametrize("label", sorted(ALL_TABLES))
+    def test_quality_bands_carry_no_wavelength(self, label):
+        for band in ALL_TABLES[label].values():
+            if band.kind in ("quality", "ancillary"):
+                assert band.wavelength is None
+
+    def test_red_means_the_same_wavelength_on_every_sensor(self):
+        centres = [table["red"].wavelength for table in ALL_TABLES.values()]
+        assert max(centres) - min(centres) < 0.03
+
+    def test_sentinel2_level2a_has_no_cirrus_band(self):
+        # B10 is consumed by the atmospheric correction and never written.
+        assert all(band.band_id != "B10" for band in SENTINEL2.values())
+
+
+class TestResolveBand:
+    """Names resolve exactly, in several spellings, and fail loudly otherwise."""
+
+    @pytest.mark.parametrize("spec", ["red", "RED", "  Red  ", "B04", "b04", "B4"])
+    def test_sentinel2_spellings(self, spec):
+        assert resolve_band(spec, SENTINEL2).band_id == "B04"
+
+    @pytest.mark.parametrize("spec", ["red", "SR_B4", "sr_b4", "B4", " b4 "])
+    def test_landsat_spellings(self, spec):
+        assert resolve_band(spec, LANDSAT_OLI).band_id == "SR_B4"
+
+    def test_unknown_band_lists_what_is_available(self):
+        with pytest.raises(ValidationError) as excinfo:
+            resolve_band("purple", SENTINEL2)
+        message = str(excinfo.value)
+        assert "no band 'purple'" in message
+        assert "red" in message and "B04" in message
+
+    def test_a_band_from_another_sensor_is_not_found(self):
+        # "coastal" exists on OLI but not on ETM+.
+        with pytest.raises(ValidationError, match="no band 'coastal'"):
+            resolve_band("coastal", LANDSAT_TM)
+
+    @pytest.mark.parametrize("spec", [4, None, 4.0, ["red"]])
+    def test_non_string_rejected(self, spec):
+        with pytest.raises(ValidationError, match="must be named by a string"):
+            resolve_band(spec, SENTINEL2)
+
+
+class TestResolveBands:
+    """Several bands at once: order kept, duplicates refused."""
+
+    def test_order_is_preserved(self):
+        got = resolve_bands(["nir", "red", "swir16"], SENTINEL2)
+        assert [b.band_id for b in got] == ["B08", "B04", "B11"]
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValidationError, match="at least one band"):
+            resolve_bands([], SENTINEL2)
+
+    def test_a_bare_string_is_not_a_sequence_of_bands(self):
+        # "red" would otherwise iterate as ['r', 'e', 'd'].
+        with pytest.raises(ValidationError, match="expected a sequence of band names"):
+            resolve_bands("red", SENTINEL2)
+
+    def test_duplicate_under_the_same_spelling_rejected(self):
+        with pytest.raises(ValidationError, match="named twice"):
+            resolve_bands(["red", "red"], SENTINEL2)
+
+    def test_duplicate_under_different_spellings_rejected(self):
+        # "red" and "B04" are the same band; loading it twice is a mistake.
+        with pytest.raises(ValidationError, match="named twice"):
+            resolve_bands(["red", "B04"], SENTINEL2)
+
+
+class TestFinestResolution:
+    """The default output grid keeps the finest detail actually requested."""
+
+    def test_ten_metre_bands(self):
+        assert finest_resolution(resolve_bands(["red", "nir"], SENTINEL2)) == 10
+
+    def test_mixed_resolutions_take_the_finest(self):
+        assert finest_resolution(resolve_bands(["red", "swir16"], SENTINEL2)) == 10
+
+    def test_all_coarse_bands_stay_coarse(self):
+        # Nothing here was sensed at 10 m, so upsampling would invent detail.
+        assert finest_resolution(resolve_bands(["swir16", "swir22"], SENTINEL2)) == 20
+        assert finest_resolution(resolve_bands(["coastal", "nir09"], SENTINEL2)) == 60
+
+    def test_landsat_is_uniform(self):
+        assert finest_resolution(resolve_bands(["red", "lwir11"], LANDSAT_OLI)) == 30
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValidationError, match="at least one band"):
+            finest_resolution([])
+
+
+class TestSentinel2Files:
+    """Band-to-file resolution reads availability from the product."""
+
+    def test_band_written_at_every_resolution(self):
+        assert sentinel2_available_resolutions(S2_FILES, SENTINEL2["red"]) == [10, 20, 60]
+
+    def test_band_written_only_at_ten_metres(self):
+        assert sentinel2_available_resolutions(S2_FILES, SENTINEL2["nir"]) == [10]
+
+    def test_coarse_band_written_finer_than_it_was_sensed(self):
+        # B01 is a 60 m band, but baseline 04.00 onward also writes it at 20 m.
+        assert SENTINEL2["coastal"].resolution == 60
+        assert sentinel2_available_resolutions(S2_FILES, SENTINEL2["coastal"]) == [20, 60]
+
+    def test_file_is_found_at_a_requested_resolution(self):
+        path = sentinel2_band_file(S2_FILES, SENTINEL2["swir16"], 20)
+        assert path.endswith("R20m/T32TPS_20240929T100719_B11_20m")
+
+    def test_wrong_resolution_names_the_ones_that_exist(self):
+        with pytest.raises(ValidationError) as excinfo:
+            sentinel2_band_file(S2_FILES, SENTINEL2["swir16"], 10)
+        message = str(excinfo.value)
+        assert "not available at 10 m" in message
+        assert "20 m, 60 m" in message
+
+    def test_band_absent_from_the_product(self):
+        with pytest.raises(ValidationError, match="no 'nir09' \\(B09\\) band at all"):
+            sentinel2_band_file(S2_FILES, SENTINEL2["nir09"], 60)
+
+
+class TestLandsatFiles:
+    """Band-to-file resolution reads the metadata's own file list."""
+
+    def test_file_is_found(self):
+        assert landsat_band_file(L9_FILES, LANDSAT_OLI["red"]).endswith("_SR_B4.TIF")
+        assert landsat_band_file(L9_FILES, LANDSAT_OLI["lwir11"]).endswith("_ST_B10.TIF")
+
+    def test_absent_band_lists_what_the_product_holds(self):
+        # An L2SR product carries no thermal band; that is normal, not damage.
+        without_thermal = {k: v for k, v in L9_FILES.items() if k != "ST_B10"}
+        with pytest.raises(ValidationError) as excinfo:
+            landsat_band_file(without_thermal, LANDSAT_OLI["lwir11"])
+        assert "no 'lwir11'" in str(excinfo.value)
+        assert "SR_B4" in str(excinfo.value)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,8 +15,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 import rasterio
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 import eeo
 from eeo.datasets import _cache, _registry, _samples
@@ -25,7 +25,7 @@ from eeo.datasets._registry import Asset, SampleFile
 from eeo.datasets._samples import SampleDataset, SamplePath, load_sample_dataset
 
 UTM = CRS.from_epsg(32633)
-TRANSFORM = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+TRANSFORM = from_origin(500_000.0, 4_200_000.0, 10.0, 10.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 import pytest
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 from eeo.core.core import EEORasterDataset
@@ -12,7 +12,7 @@ from eeo.core.exceptions import AlignmentError, ValidationError
 UTM_CRS = CRS.from_epsg(32633)
 
 # A north-up 2x2 grid shared by every band raster below.
-_TRANSFORM = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+_TRANSFORM = from_origin(500_000.0, 4_200_000.0, 10.0, 10.0)
 
 # Deterministic band values chosen so every index is hand-computable and no
 # denominator is zero.
@@ -167,7 +167,7 @@ def test_zero_denominator_maps_to_zero():
 def test_mismatched_grid_raises_without_auto_align():
     coarse = load_array(
         np.ones((1, 1), dtype=np.float32),
-        transform=Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(20.0, -20.0),
+        transform=from_origin(500_000.0, 4_200_000.0, 20.0, 20.0),
         crs=UTM_CRS,
     ).to_rasterio()
     with pytest.raises(AlignmentError):
@@ -177,7 +177,7 @@ def test_mismatched_grid_raises_without_auto_align():
 def test_mismatched_grid_auto_aligns_by_default():
     coarse = load_array(
         np.full((1, 1), 0.2, dtype=np.float32),
-        transform=Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(20.0, -20.0),
+        transform=from_origin(500_000.0, 4_200_000.0, 20.0, 20.0),
         crs=UTM_CRS,
     ).to_rasterio()
     result = _band(NIR).ndvi(coarse)  # auto_align=True by default

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -11,10 +11,12 @@ syntax but not in the JSON.
 
 import datetime as dt
 import json
+from pathlib import PurePosixPath
 
 import pytest
 
 from eeo.core.exceptions import ValidationError
+from eeo.io._archive import open_product
 from eeo.io._landsat import find_metadata, read_metadata_groups, read_product
 
 PRODUCT_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
@@ -117,10 +119,13 @@ class TestFindMetadata:
         write_product(tmp_path, "xml")
         assert find_metadata(directory).suffix == ".xml"
 
-    def test_metadata_given_directly(self, tmp_path):
-        directory = write_product(tmp_path, "json")
-        path = directory / f"{PRODUCT_ID}_MTL.json"
-        assert find_metadata(path) == path
+    def test_a_named_file_wins_over_the_preferred_suffix(self, tmp_path):
+        # Naming the .txt must select it even though .xml is preferred when
+        # searching, because the caller has already chosen.
+        write_product(tmp_path, "xml")
+        directory = write_product(tmp_path, "txt")
+        named = directory / f"{PRODUCT_ID}_MTL.txt"
+        assert find_metadata(named) == PurePosixPath(named.name)
 
     def test_missing_path_rejected(self, tmp_path):
         with pytest.raises(ValidationError, match="no such Landsat product"):
@@ -148,7 +153,8 @@ class TestSyntaxesAgree:
 
     def test_groups_are_unwrapped(self, tmp_path):
         directory = write_product(tmp_path, "json")
-        groups = read_metadata_groups(directory / f"{PRODUCT_ID}_MTL.json")
+        source = open_product(directory, "Landsat")
+        groups = read_metadata_groups(source, PurePosixPath(f"{PRODUCT_ID}_MTL.json"))
         assert "LANDSAT_METADATA_FILE" not in groups
         assert "PRODUCT_CONTENTS" in groups
 

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -40,13 +40,13 @@ class TestFindMetadata:
     @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
     def test_each_syntax_is_found(self, tmp_path, syntax):
         directory = write_product(tmp_path, syntax)
-        assert find_metadata(directory).suffix == f".{syntax}"
+        assert find_metadata(directory).path.suffix == f".{syntax}"
 
     def test_xml_wins_when_several_are_present(self, tmp_path):
         directory = write_product(tmp_path, "txt")
         write_product(tmp_path, "json")
         write_product(tmp_path, "xml")
-        assert find_metadata(directory).suffix == ".xml"
+        assert find_metadata(directory).path.suffix == ".xml"
 
     def test_a_named_file_wins_over_the_preferred_suffix(self, tmp_path):
         # Naming the .txt must select it even though .xml is preferred when
@@ -54,7 +54,7 @@ class TestFindMetadata:
         write_product(tmp_path, "xml")
         directory = write_product(tmp_path, "txt")
         named = directory / f"{PRODUCT_ID}_MTL.txt"
-        assert find_metadata(named) == PurePosixPath(named.name)
+        assert find_metadata(named).path == PurePosixPath(named.name)
 
     def test_two_products_in_one_folder_are_refused(self, tmp_path):
         write_product(tmp_path)

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -1,0 +1,299 @@
+"""Tests for Landsat product identification (eeo/io/_landsat.py).
+
+One canonical description of a product is rendered into all three metadata
+syntaxes, so "the three agree" is asserted rather than assumed. The group
+layout, key names, and value spellings follow real USGS output, including the
+parts most likely to catch a parser out: a Level-1 section carrying the same
+key names as the Level-2 one with different values, a scene centre time written
+with seven fractional digits, and a WRS row that is zero-padded in the text
+syntax but not in the JSON.
+"""
+
+import datetime as dt
+import json
+
+import pytest
+
+from eeo.core.exceptions import ValidationError
+from eeo.io._landsat import find_metadata, read_metadata_groups, read_product
+
+PRODUCT_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
+L1_PRODUCT_ID = "LC09_L1TP_193028_20260822_20260823_02_T1"
+
+
+def spec(*, level="L2SP", product_id=PRODUCT_ID, row="028", mission_prefix=None):
+    """Describe a product as groups of key-value pairs."""
+    if mission_prefix:
+        product_id = mission_prefix + product_id[4:]
+    return {
+        "PRODUCT_CONTENTS": {
+            "LANDSAT_PRODUCT_ID": product_id,
+            "PROCESSING_LEVEL": level,
+            "COLLECTION_NUMBER": "02",
+            "COLLECTION_CATEGORY": "T1",
+            "FILE_NAME_BAND_4": f"{product_id}_SR_B4.TIF",
+            "FILE_NAME_BAND_ST_B10": f"{product_id}_ST_B10.TIF",
+            "FILE_NAME_QUALITY_L1_PIXEL": f"{product_id}_QA_PIXEL.TIF",
+            "FILE_NAME_METADATA_ODL": f"{product_id}_MTL.txt",
+        },
+        "IMAGE_ATTRIBUTES": {
+            "SPACECRAFT_ID": "LANDSAT_9",
+            "SENSOR_ID": "OLI_TIRS",
+            "WRS_PATH": "193",
+            "WRS_ROW": row,
+            "DATE_ACQUIRED": "2026-08-22",
+            # USGS writes seven fractional digits.
+            "SCENE_CENTER_TIME": "10:04:22.1183580Z",
+        },
+        "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS": {
+            "REFLECTANCE_MULT_BAND_4": "2.75e-05",
+            "REFLECTANCE_ADD_BAND_4": "-0.2",
+        },
+        "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS": {
+            "TEMPERATURE_MULT_BAND_ST_B10": "0.00341802",
+            "TEMPERATURE_ADD_BAND_ST_B10": "149.0",
+        },
+        # The Level-1 record repeats the same key names with different values.
+        # Everything above must win over everything here.
+        "LEVEL1_PROCESSING_RECORD": {
+            "LANDSAT_PRODUCT_ID": L1_PRODUCT_ID,
+            "PROCESSING_LEVEL": "L1TP",
+        },
+        "LEVEL1_RADIOMETRIC_RESCALING": {
+            "REFLECTANCE_MULT_BAND_4": "2.0000E-05",
+            "REFLECTANCE_ADD_BAND_4": "-0.100000",
+        },
+    }
+
+
+def as_odl(groups):
+    lines = ["GROUP = LANDSAT_METADATA_FILE"]
+    for group, members in groups.items():
+        lines.append(f"  GROUP = {group}")
+        lines += [f'    {key} = "{value}"' for key, value in members.items()]
+        lines.append(f"  END_GROUP = {group}")
+    lines += ["END_GROUP = LANDSAT_METADATA_FILE", "END"]
+    return "\n".join(lines)
+
+
+def as_json(groups):
+    return json.dumps({"LANDSAT_METADATA_FILE": groups}, indent=2)
+
+
+def as_xml(groups):
+    body = "".join(
+        f"<{group}>"
+        + "".join(f"<{key}>{value}</{key}>" for key, value in members.items())
+        + f"</{group}>"
+        for group, members in groups.items()
+    )
+    return f"<LANDSAT_METADATA_FILE>{body}</LANDSAT_METADATA_FILE>"
+
+
+RENDERERS = {"xml": as_xml, "json": as_json, "txt": as_odl}
+
+
+def write_product(tmp_path, syntax="xml", **kwargs):
+    """Write a product directory holding one metadata file."""
+    groups = spec(**kwargs)
+    name = groups["PRODUCT_CONTENTS"]["LANDSAT_PRODUCT_ID"]
+    directory = tmp_path / name
+    directory.mkdir(exist_ok=True)
+    (directory / f"{name}_MTL.{syntax}").write_text(RENDERERS[syntax](groups))
+    return directory
+
+
+class TestFindMetadata:
+    """The metadata file is found by suffix, preferring XML."""
+
+    @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
+    def test_each_syntax_is_found(self, tmp_path, syntax):
+        directory = write_product(tmp_path, syntax)
+        assert find_metadata(directory).suffix == f".{syntax}"
+
+    def test_xml_wins_when_several_are_present(self, tmp_path):
+        directory = write_product(tmp_path, "txt")
+        write_product(tmp_path, "json")
+        write_product(tmp_path, "xml")
+        assert find_metadata(directory).suffix == ".xml"
+
+    def test_metadata_given_directly(self, tmp_path):
+        directory = write_product(tmp_path, "json")
+        path = directory / f"{PRODUCT_ID}_MTL.json"
+        assert find_metadata(path) == path
+
+    def test_missing_path_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match="no such Landsat product"):
+            find_metadata(tmp_path / "absent")
+
+    def test_directory_without_metadata_rejected(self, tmp_path):
+        (tmp_path / "empty").mkdir()
+        with pytest.raises(ValidationError, match="holds no Landsat metadata file"):
+            find_metadata(tmp_path / "empty")
+
+
+class TestSyntaxesAgree:
+    """All three syntaxes carry identical content and must parse identically."""
+
+    @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
+    def test_identity_is_the_same_in_every_syntax(self, tmp_path, syntax):
+        product = read_product(write_product(tmp_path, syntax))
+        assert product.product_id == PRODUCT_ID
+        assert product.level == "L2SP"
+        assert (product.mission, product.instrument) == (9, "OLI-2/TIRS-2")
+        assert product.spacecraft == "LANDSAT_9"
+        assert (product.wrs_path, product.wrs_row) == ("193", "028")
+        assert product.collection_number == "02"
+        assert product.collection_category == "T1"
+
+    def test_groups_are_unwrapped(self, tmp_path):
+        directory = write_product(tmp_path, "json")
+        groups = read_metadata_groups(directory / f"{PRODUCT_ID}_MTL.json")
+        assert "LANDSAT_METADATA_FILE" not in groups
+        assert "PRODUCT_CONTENTS" in groups
+
+
+class TestGroupScoping:
+    """Level-2 values must win over the Level-1 record's identical key names."""
+
+    @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
+    def test_level_comes_from_product_contents(self, tmp_path, syntax):
+        # LEVEL1_PROCESSING_RECORD also holds PROCESSING_LEVEL, as "L1TP".
+        assert read_product(write_product(tmp_path, syntax)).level == "L2SP"
+
+    @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
+    def test_product_id_comes_from_product_contents(self, tmp_path, syntax):
+        product = read_product(write_product(tmp_path, syntax))
+        assert product.product_id == PRODUCT_ID
+        assert product.product_id != L1_PRODUCT_ID
+
+    @pytest.mark.parametrize("syntax", ["xml", "json", "txt"])
+    def test_scaling_comes_from_the_level2_group(self, tmp_path, syntax):
+        # LEVEL1_RADIOMETRIC_RESCALING carries top-of-atmosphere coefficients
+        # under the same key names; picking those up would silently produce
+        # the wrong physical values.
+        product = read_product(write_product(tmp_path, syntax))
+        assert product.reflectance_scaling["SR_B4"] == (2.75e-05, -0.2)
+        assert product.reflectance_scaling["SR_B4"] != (2.0000e-05, -0.1)
+
+    def test_temperature_scaling_is_separate_from_reflectance(self, tmp_path):
+        product = read_product(write_product(tmp_path))
+        assert product.temperature_scaling == {"ST_B10": (0.00341802, 149.0)}
+        assert "ST_B10" not in product.reflectance_scaling
+
+
+class TestAwkwardValues:
+    """The spellings real products use, which naive parsing gets wrong."""
+
+    def test_seven_fractional_digits_are_truncated_not_rejected(self, tmp_path):
+        product = read_product(write_product(tmp_path))
+        assert product.acquired == dt.datetime(
+            2026, 8, 22, 10, 4, 22, 118358, tzinfo=dt.timezone.utc
+        )
+        assert product.acquired.tzinfo is not None
+
+    def test_unpadded_wrs_row_is_normalised(self, tmp_path):
+        # The JSON syntax writes "28" where the text syntax writes "028".
+        assert read_product(write_product(tmp_path, row="28")).wrs_row == "028"
+
+    def test_band_files_are_keyed_by_token(self, tmp_path):
+        product = read_product(write_product(tmp_path))
+        assert product.band_files["SR_B4"] == f"{PRODUCT_ID}_SR_B4.TIF"
+        assert product.band_files["ST_B10"] == f"{PRODUCT_ID}_ST_B10.TIF"
+        assert product.band_files["QA_PIXEL"] == f"{PRODUCT_ID}_QA_PIXEL.TIF"
+        # The metadata file itself is listed too, but is not a band.
+        assert not any(name.endswith("MTL.txt") for name in product.band_files.values())
+
+
+class TestRefusals:
+    """Unsupported products fail with a message naming the problem."""
+
+    @pytest.mark.parametrize("level", ["L1TP", "L1GT", "L1GS"])
+    def test_level1_is_refused(self, tmp_path, level):
+        with pytest.raises(ValidationError, match="Level-1 is not supported") as excinfo:
+            read_product(write_product(tmp_path, level=level))
+        assert "L2SP or L2SR" in str(excinfo.value)
+
+    def test_l2sr_is_accepted(self, tmp_path):
+        # Reflectance-only products are valid Level-2, just without thermal.
+        assert read_product(write_product(tmp_path, level="L2SR")).level == "L2SR"
+
+    def test_unknown_level_is_refused(self, tmp_path):
+        with pytest.raises(ValidationError, match="unrecognised Landsat processing level"):
+            read_product(write_product(tmp_path, level="L9XX"))
+
+    def test_unknown_mission_is_refused(self, tmp_path):
+        with pytest.raises(ValidationError, match="unrecognised Landsat mission"):
+            read_product(write_product(tmp_path, mission_prefix="LX99"))
+
+    @pytest.mark.parametrize("prefix", ["LT04", "LT05", "LE07", "LC08", "LC09"])
+    def test_supported_missions_are_recognised(self, tmp_path, prefix):
+        product = read_product(write_product(tmp_path, mission_prefix=prefix))
+        assert product.mission == int(prefix[2:])
+
+
+class TestOverrideAndDamage:
+    """`level=` asserts; damaged metadata fails clearly."""
+
+    def test_agreeing_override_accepted(self, tmp_path):
+        assert read_product(write_product(tmp_path), level="L2SP").level == "L2SP"
+
+    def test_contradicting_override_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match="contradicts the product"):
+            read_product(write_product(tmp_path), level="L2SR")
+
+    def test_missing_level_rejected(self, tmp_path):
+        groups = spec()
+        del groups["PRODUCT_CONTENTS"]["PROCESSING_LEVEL"]
+        directory = tmp_path / PRODUCT_ID
+        directory.mkdir()
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text(as_xml(groups))
+        with pytest.raises(ValidationError, match="states no PROCESSING_LEVEL"):
+            read_product(directory)
+
+    def test_missing_required_field_names_its_group(self, tmp_path):
+        groups = spec()
+        del groups["IMAGE_ATTRIBUTES"]["WRS_PATH"]
+        directory = tmp_path / PRODUCT_ID
+        directory.mkdir()
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text(as_xml(groups))
+        with pytest.raises(ValidationError, match="no WRS_PATH in IMAGE_ATTRIBUTES"):
+            read_product(directory)
+
+    def test_unparseable_xml_rejected(self, tmp_path):
+        directory = write_product(tmp_path, "xml")
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text("<not-closed>")
+        with pytest.raises(ValidationError, match="is not readable"):
+            read_product(directory)
+
+    def test_unparseable_json_rejected(self, tmp_path):
+        directory = write_product(tmp_path, "json")
+        (directory / f"{PRODUCT_ID}_MTL.json").write_text("{oops")
+        with pytest.raises(ValidationError, match="is not readable"):
+            read_product(directory)
+
+    def test_non_numeric_scaling_rejected(self, tmp_path):
+        groups = spec()
+        groups["LEVEL2_SURFACE_REFLECTANCE_PARAMETERS"]["REFLECTANCE_MULT_BAND_4"] = "lots"
+        directory = tmp_path / PRODUCT_ID
+        directory.mkdir()
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text(as_xml(groups))
+        with pytest.raises(ValidationError, match="are not numbers"):
+            read_product(directory)
+
+    def test_unreadable_time_rejected(self, tmp_path):
+        groups = spec()
+        groups["IMAGE_ATTRIBUTES"]["SCENE_CENTER_TIME"] = "half past ten"
+        directory = tmp_path / PRODUCT_ID
+        directory.mkdir()
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text(as_xml(groups))
+        with pytest.raises(ValidationError, match="could not read the acquisition time"):
+            read_product(directory)
+
+    def test_mult_without_a_matching_add_is_skipped(self, tmp_path):
+        groups = spec()
+        del groups["LEVEL2_SURFACE_REFLECTANCE_PARAMETERS"]["REFLECTANCE_ADD_BAND_4"]
+        directory = tmp_path / PRODUCT_ID
+        directory.mkdir()
+        (directory / f"{PRODUCT_ID}_MTL.xml").write_text(as_xml(groups))
+        assert read_product(directory).reflectance_scaling == {}

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -56,6 +56,12 @@ class TestFindMetadata:
         named = directory / f"{PRODUCT_ID}_MTL.txt"
         assert find_metadata(named) == PurePosixPath(named.name)
 
+    def test_two_products_in_one_folder_are_refused(self, tmp_path):
+        write_product(tmp_path)
+        write_product(tmp_path, mission_prefix="LE07")
+        with pytest.raises(ValidationError, match="holds 2 Landsat products"):
+            find_metadata(tmp_path)
+
     def test_missing_path_rejected(self, tmp_path):
         with pytest.raises(ValidationError, match="no such Landsat product"):
             find_metadata(tmp_path / "absent")
@@ -64,6 +70,25 @@ class TestFindMetadata:
         (tmp_path / "empty").mkdir()
         with pytest.raises(ValidationError, match="holds no Landsat metadata file"):
             find_metadata(tmp_path / "empty")
+
+
+class TestIdentityComesFromTheMetadata:
+    """A renamed directory must not change what the product is."""
+
+    def test_a_renamed_directory_is_ignored(self, tmp_path):
+        # Renaming a folder is something users do; it must not be able to
+        # change the mission, the level, or the scene the reader reports.
+        directory = write_product(tmp_path)
+        renamed = directory.rename(tmp_path / "landsat_scene")
+        product = read_product(renamed)
+        assert product.product_id == PRODUCT_ID
+        assert product.mission == 9
+        assert product.level == "L2SP"
+
+    def test_a_directory_named_after_another_mission_is_ignored(self, tmp_path):
+        directory = write_product(tmp_path)
+        renamed = directory.rename(tmp_path / "LE07_L2SP_193028_20231024_20231119_02_T2")
+        assert read_product(renamed).mission == 9
 
 
 class TestSyntaxesAgree:

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -1,16 +1,15 @@
 """Tests for Landsat product identification (eeo/io/_landsat.py).
 
-One canonical description of a product is rendered into all three metadata
-syntaxes, so "the three agree" is asserted rather than assumed. The group
-layout, key names, and value spellings follow real USGS output, including the
-parts most likely to catch a parser out: a Level-1 section carrying the same
-key names as the Level-2 one with different values, a scene centre time written
-with seven fractional digits, and a WRS row that is zero-padded in the text
-syntax but not in the JSON.
+One canonical description of a product, from :mod:`product_fixtures`, is
+rendered into all three metadata syntaxes, so "the three agree" is asserted
+rather than assumed. The group layout, key names, and value spellings follow
+real USGS output, including the parts most likely to catch a parser out: a
+Level-1 section carrying the same key names as the Level-2 one with different
+values, a scene centre time written with seven fractional digits, and a WRS row
+that is zero-padded in the text syntax but not in the JSON.
 """
 
 import datetime as dt
-import json
 from pathlib import PurePosixPath
 
 import pytest
@@ -18,91 +17,21 @@ import pytest
 from eeo.core.exceptions import ValidationError
 from eeo.io._archive import open_product
 from eeo.io._landsat import find_metadata, read_metadata_groups, read_product
-
-PRODUCT_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
-L1_PRODUCT_ID = "LC09_L1TP_193028_20260822_20260823_02_T1"
-
-
-def spec(*, level="L2SP", product_id=PRODUCT_ID, row="028", mission_prefix=None):
-    """Describe a product as groups of key-value pairs."""
-    if mission_prefix:
-        product_id = mission_prefix + product_id[4:]
-    return {
-        "PRODUCT_CONTENTS": {
-            "LANDSAT_PRODUCT_ID": product_id,
-            "PROCESSING_LEVEL": level,
-            "COLLECTION_NUMBER": "02",
-            "COLLECTION_CATEGORY": "T1",
-            "FILE_NAME_BAND_4": f"{product_id}_SR_B4.TIF",
-            "FILE_NAME_BAND_ST_B10": f"{product_id}_ST_B10.TIF",
-            "FILE_NAME_QUALITY_L1_PIXEL": f"{product_id}_QA_PIXEL.TIF",
-            "FILE_NAME_METADATA_ODL": f"{product_id}_MTL.txt",
-        },
-        "IMAGE_ATTRIBUTES": {
-            "SPACECRAFT_ID": "LANDSAT_9",
-            "SENSOR_ID": "OLI_TIRS",
-            "WRS_PATH": "193",
-            "WRS_ROW": row,
-            "DATE_ACQUIRED": "2026-08-22",
-            # USGS writes seven fractional digits.
-            "SCENE_CENTER_TIME": "10:04:22.1183580Z",
-        },
-        "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS": {
-            "REFLECTANCE_MULT_BAND_4": "2.75e-05",
-            "REFLECTANCE_ADD_BAND_4": "-0.2",
-        },
-        "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS": {
-            "TEMPERATURE_MULT_BAND_ST_B10": "0.00341802",
-            "TEMPERATURE_ADD_BAND_ST_B10": "149.0",
-        },
-        # The Level-1 record repeats the same key names with different values.
-        # Everything above must win over everything here.
-        "LEVEL1_PROCESSING_RECORD": {
-            "LANDSAT_PRODUCT_ID": L1_PRODUCT_ID,
-            "PROCESSING_LEVEL": "L1TP",
-        },
-        "LEVEL1_RADIOMETRIC_RESCALING": {
-            "REFLECTANCE_MULT_BAND_4": "2.0000E-05",
-            "REFLECTANCE_ADD_BAND_4": "-0.100000",
-        },
-    }
-
-
-def as_odl(groups):
-    lines = ["GROUP = LANDSAT_METADATA_FILE"]
-    for group, members in groups.items():
-        lines.append(f"  GROUP = {group}")
-        lines += [f'    {key} = "{value}"' for key, value in members.items()]
-        lines.append(f"  END_GROUP = {group}")
-    lines += ["END_GROUP = LANDSAT_METADATA_FILE", "END"]
-    return "\n".join(lines)
-
-
-def as_json(groups):
-    return json.dumps({"LANDSAT_METADATA_FILE": groups}, indent=2)
-
-
-def as_xml(groups):
-    body = "".join(
-        f"<{group}>"
-        + "".join(f"<{key}>{value}</{key}>" for key, value in members.items())
-        + f"</{group}>"
-        for group, members in groups.items()
-    )
-    return f"<LANDSAT_METADATA_FILE>{body}</LANDSAT_METADATA_FILE>"
-
-
-RENDERERS = {"xml": as_xml, "json": as_json, "txt": as_odl}
-
-
-def write_product(tmp_path, syntax="xml", **kwargs):
-    """Write a product directory holding one metadata file."""
-    groups = spec(**kwargs)
-    name = groups["PRODUCT_CONTENTS"]["LANDSAT_PRODUCT_ID"]
-    directory = tmp_path / name
-    directory.mkdir(exist_ok=True)
-    (directory / f"{name}_MTL.{syntax}").write_text(RENDERERS[syntax](groups))
-    return directory
+from product_fixtures import (
+    L1_ID as L1_PRODUCT_ID,
+)
+from product_fixtures import (
+    L9_ID as PRODUCT_ID,
+)
+from product_fixtures import (
+    as_xml,
+)
+from product_fixtures import (
+    landsat_groups as spec,
+)
+from product_fixtures import (
+    write_landsat_metadata as write_product,
+)
 
 
 class TestFindMetadata:

--- a/tests/test_load_landsat.py
+++ b/tests/test_load_landsat.py
@@ -1,136 +1,48 @@
 """Tests for load_landsat (eeo/io/products.py).
 
-The fixture is a real Collection 2 Level-2 product: genuine GeoTIFFs written
-through GDAL on one 30 m grid, beside a metadata file of the real shape, with
-the fill values USGS actually declares — 0 in the imagery and 1 in the quality
-rasters, which is what makes the choice of leading band observable. Two
-products are built, Landsat 9 and Landsat 7, because the whole point of naming
-bands is that ``"red"`` reaches band 4 on one and band 3 on the other.
+The fixture, from :mod:`product_fixtures`, is a real Collection 2 Level-2
+product: genuine GeoTIFFs written through GDAL on one 30 m grid, beside a
+metadata file of the real shape, with the fill values USGS actually declares —
+0 in the imagery and 1 in the quality rasters, which is what makes the choice
+of leading band observable. Two products are built, Landsat 9 and Landsat 7,
+because the whole point of naming bands is that ``"red"`` reaches band 4 on one
+and band 3 on the other.
 
 Nothing is downloaded.
 """
 
 import datetime as dt
-import json
 
 import numpy as np
 import pytest
-import rasterio as rio
-from rasterio.transform import from_origin
 from rasterio.warp import transform_bounds
 
 import eeo
 from eeo.core.exceptions import ValidationError
-
-L9_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
-L7_ID = "LE07_L2SP_193028_20231024_20231119_02_T2"
-
-CRS = "EPSG:32633"
-ULX, ULY = 300000.0, 5100000.0
-RES = 30.0
-SIZE = 64
-
-#: Bands each sensor's product holds, with the digital number filling each one.
-#: Distinct per band so a mix-up in ordering shows up as a wrong value.
-OLI_BANDS = {
-    "SR_B1": 8000,
-    "SR_B2": 8100,
-    "SR_B3": 9000,
-    "SR_B4": 10000,
-    "SR_B5": 25000,
-    "SR_B6": 15000,
-    "SR_B7": 12000,
-    "ST_B10": 44000,
-    "QA_PIXEL": 21824,
-    "QA_RADSAT": 0,
-    "SR_QA_AEROSOL": 96,
-}
-TM_BANDS = {
-    "SR_B1": 8100,
-    "SR_B2": 9000,
-    "SR_B3": 10000,
-    "SR_B4": 25000,
-    "SR_B5": 15000,
-    "SR_B7": 12000,
-    "ST_B6": 44000,
-    "QA_PIXEL": 5440,
-    "QA_RADSAT": 0,
-    "SR_ATMOS_OPACITY": 120,
-    "SR_CLOUD_QA": 0,
-}
-
-#: Fill differs between the imagery and the quality rasters, exactly as USGS
-#: declares it: surface reflectance and temperature use 0, QA_PIXEL uses 1.
-QUALITY_FILL = {"QA_PIXEL"}
-
-
-def _write_tif(path, token, table):
-    """Write one georeferenced 30 m GeoTIFF for a band."""
-    with rio.open(
-        path,
-        "w",
-        driver="GTiff",
-        height=SIZE,
-        width=SIZE,
-        count=1,
-        dtype="uint16",
-        crs=CRS,
-        transform=from_origin(ULX, ULY, RES, RES),
-        nodata=1 if token in QUALITY_FILL else 0,
-    ) as dst:
-        dst.write(np.full((1, SIZE, SIZE), table[token], dtype="uint16"))
-
-
-def spec(product_id, tokens, *, level="L2SP", spacecraft="LANDSAT_9"):
-    """Describe a product as the groups of key-value pairs its metadata holds."""
-    date = "2026-08-22" if product_id.startswith("LC09") else "2023-10-24"
-    return {
-        "PRODUCT_CONTENTS": {
-            "LANDSAT_PRODUCT_ID": product_id,
-            "PROCESSING_LEVEL": level,
-            "COLLECTION_NUMBER": "02",
-            "COLLECTION_CATEGORY": product_id[-2:],
-            **{f"FILE_NAME_{token}": f"{product_id}_{token}.TIF" for token in tokens},
-            "FILE_NAME_METADATA_ODL": f"{product_id}_MTL.txt",
-        },
-        "IMAGE_ATTRIBUTES": {
-            "SPACECRAFT_ID": spacecraft,
-            "WRS_PATH": "193",
-            "WRS_ROW": "028",
-            "DATE_ACQUIRED": date,
-            "SCENE_CENTER_TIME": "10:04:22.1183580Z",
-        },
-        "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS": {
-            "REFLECTANCE_MULT_BAND_4": "2.75e-05",
-            "REFLECTANCE_ADD_BAND_4": "-0.2",
-        },
-        "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS": {
-            "TEMPERATURE_MULT_BAND_ST_B10": "0.00341802",
-            "TEMPERATURE_ADD_BAND_ST_B10": "149.0",
-        },
-    }
-
-
-def build_product(tmp_path, *, product_id=L9_ID, tokens=None, level="L2SP", omit_file=None):
-    """Build a product directory of real GeoTIFFs and return its path.
-
-    ``omit_file`` names a band the metadata lists but the directory does not
-    hold — the state a truncated download leaves behind.
-    """
-    table = OLI_BANDS if product_id.startswith("LC0") else TM_BANDS
-    if tokens is None:
-        tokens = list(table)
-    spacecraft = f"LANDSAT_{product_id[3]}"
-    directory = tmp_path / product_id
-    directory.mkdir()
-    groups = spec(product_id, tokens, level=level, spacecraft=spacecraft)
-    (directory / f"{product_id}_MTL.json").write_text(
-        json.dumps({"LANDSAT_METADATA_FILE": groups}, indent=2)
-    )
-    for token in tokens:
-        if token != omit_file:
-            _write_tif(directory / f"{product_id}_{token}.TIF", token, table)
-    return directory
+from product_fixtures import (
+    L7_ID,
+    L9_ID,
+    OLI_BANDS,
+    TM_BANDS,
+)
+from product_fixtures import (
+    LANDSAT_CRS as CRS,
+)
+from product_fixtures import (
+    LANDSAT_RES as RES,
+)
+from product_fixtures import (
+    LANDSAT_SIZE as SIZE,
+)
+from product_fixtures import (
+    LANDSAT_ULX as ULX,
+)
+from product_fixtures import (
+    LANDSAT_ULY as ULY,
+)
+from product_fixtures import (
+    build_landsat as build_product,
+)
 
 
 @pytest.fixture

--- a/tests/test_load_landsat.py
+++ b/tests/test_load_landsat.py
@@ -15,6 +15,7 @@ import datetime as dt
 
 import numpy as np
 import pytest
+import rasterio as rio
 from rasterio.warp import transform_bounds
 
 import eeo
@@ -64,6 +65,15 @@ class TestLoading:
     def test_values_are_the_stored_digital_numbers(self, product):
         got = eeo.load_landsat(product, ["red"]).to_array()[0]
         assert np.all(got == OLI_BANDS["SR_B4"])
+
+    def test_the_values_match_the_file_on_disk_unscaled(self, product):
+        # The claim the whole "raw digital numbers by default" decision rests
+        # on: a load returns what the file holds, the values a GIS shows, with
+        # no scale or offset applied anywhere in the chain.
+        direct = product / f"{L9_ID}_SR_B4.TIF"
+        with rio.open(direct) as src:
+            stored = src.read(1)
+        np.testing.assert_array_equal(eeo.load_landsat(product, ["red"]).to_array()[0], stored)
 
     def test_band_names_are_the_common_names(self, product):
         assert eeo.load_landsat(product, ["red", "nir08"]).band_names == ["red", "nir08"]
@@ -245,3 +255,52 @@ class TestRefusals:
 
     def test_level_override_agreeing_with_the_metadata_is_accepted(self, product):
         assert eeo.load_landsat(product, ["red"], level="L2SP").band_names == ["red"]
+
+
+class TestFindingTheProduct:
+    """What the loader accepts as a path, and what it refuses."""
+
+    def test_the_folder_the_product_was_extracted_into(self, tmp_path, product):
+        from_parent = eeo.load_landsat(tmp_path, ["red"])
+        from_directory = eeo.load_landsat(product, ["red"])
+        np.testing.assert_array_equal(from_parent.to_array(), from_directory.to_array())
+
+    def test_a_folder_holding_two_products_is_refused(self, tmp_path, product):
+        build_product(tmp_path, product_id=L7_ID)
+        with pytest.raises(ValidationError, match="holds 2 Landsat products"):
+            eeo.load_landsat(tmp_path, ["red"])
+
+    def test_a_renamed_directory_still_reports_its_own_scene(self, tmp_path, product):
+        # The band table follows the metadata's product id, so a folder named
+        # after another mission must not change which band "red" resolves to.
+        renamed = product.rename(tmp_path / L7_ID)
+        loaded = eeo.load_landsat(renamed, ["red"])
+        assert loaded.attrs["product"] == L9_ID
+        assert loaded.attrs["mission"] == "Landsat 9"
+        assert loaded.to_array()[0].max() == OLI_BANDS["SR_B4"]
+
+    def test_no_bands_is_refused(self, product):
+        with pytest.raises(ValidationError, match="at least one band"):
+            eeo.load_landsat(product, [])
+
+
+class TestPartialOverlap:
+    """A bbox reaching past the scene returns the overlap, not padding."""
+
+    def test_a_bbox_straddling_the_edge_is_clipped(self, product):
+        extent = SIZE * RES
+        straddling = transform_bounds(
+            CRS,
+            "EPSG:4326",
+            ULX - extent / 2,
+            ULY - extent / 2,
+            ULX + extent / 2,
+            ULY,
+            densify_pts=21,
+        )
+        scene = eeo.load_landsat(product, ["red"], bbox=straddling)
+        height, width = scene.to_array().shape[-2:]
+        assert 0 < height < SIZE and 0 < width < SIZE
+        assert scene.get_transform()[2] == ULX
+        assert scene.get_transform()[5] == ULY
+        assert np.all(scene.to_array()[0] == OLI_BANDS["SR_B4"])

--- a/tests/test_load_landsat.py
+++ b/tests/test_load_landsat.py
@@ -1,0 +1,335 @@
+"""Tests for load_landsat (eeo/io/products.py).
+
+The fixture is a real Collection 2 Level-2 product: genuine GeoTIFFs written
+through GDAL on one 30 m grid, beside a metadata file of the real shape, with
+the fill values USGS actually declares — 0 in the imagery and 1 in the quality
+rasters, which is what makes the choice of leading band observable. Two
+products are built, Landsat 9 and Landsat 7, because the whole point of naming
+bands is that ``"red"`` reaches band 4 on one and band 3 on the other.
+
+Nothing is downloaded.
+"""
+
+import datetime as dt
+import json
+
+import numpy as np
+import pytest
+import rasterio as rio
+from rasterio.transform import from_origin
+from rasterio.warp import transform_bounds
+
+import eeo
+from eeo.core.exceptions import ValidationError
+
+L9_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"
+L7_ID = "LE07_L2SP_193028_20231024_20231119_02_T2"
+
+CRS = "EPSG:32633"
+ULX, ULY = 300000.0, 5100000.0
+RES = 30.0
+SIZE = 64
+
+#: Bands each sensor's product holds, with the digital number filling each one.
+#: Distinct per band so a mix-up in ordering shows up as a wrong value.
+OLI_BANDS = {
+    "SR_B1": 8000,
+    "SR_B2": 8100,
+    "SR_B3": 9000,
+    "SR_B4": 10000,
+    "SR_B5": 25000,
+    "SR_B6": 15000,
+    "SR_B7": 12000,
+    "ST_B10": 44000,
+    "QA_PIXEL": 21824,
+    "QA_RADSAT": 0,
+    "SR_QA_AEROSOL": 96,
+}
+TM_BANDS = {
+    "SR_B1": 8100,
+    "SR_B2": 9000,
+    "SR_B3": 10000,
+    "SR_B4": 25000,
+    "SR_B5": 15000,
+    "SR_B7": 12000,
+    "ST_B6": 44000,
+    "QA_PIXEL": 5440,
+    "QA_RADSAT": 0,
+    "SR_ATMOS_OPACITY": 120,
+    "SR_CLOUD_QA": 0,
+}
+
+#: Fill differs between the imagery and the quality rasters, exactly as USGS
+#: declares it: surface reflectance and temperature use 0, QA_PIXEL uses 1.
+QUALITY_FILL = {"QA_PIXEL"}
+
+
+def _write_tif(path, token, table):
+    """Write one georeferenced 30 m GeoTIFF for a band."""
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=SIZE,
+        width=SIZE,
+        count=1,
+        dtype="uint16",
+        crs=CRS,
+        transform=from_origin(ULX, ULY, RES, RES),
+        nodata=1 if token in QUALITY_FILL else 0,
+    ) as dst:
+        dst.write(np.full((1, SIZE, SIZE), table[token], dtype="uint16"))
+
+
+def spec(product_id, tokens, *, level="L2SP", spacecraft="LANDSAT_9"):
+    """Describe a product as the groups of key-value pairs its metadata holds."""
+    date = "2026-08-22" if product_id.startswith("LC09") else "2023-10-24"
+    return {
+        "PRODUCT_CONTENTS": {
+            "LANDSAT_PRODUCT_ID": product_id,
+            "PROCESSING_LEVEL": level,
+            "COLLECTION_NUMBER": "02",
+            "COLLECTION_CATEGORY": product_id[-2:],
+            **{f"FILE_NAME_{token}": f"{product_id}_{token}.TIF" for token in tokens},
+            "FILE_NAME_METADATA_ODL": f"{product_id}_MTL.txt",
+        },
+        "IMAGE_ATTRIBUTES": {
+            "SPACECRAFT_ID": spacecraft,
+            "WRS_PATH": "193",
+            "WRS_ROW": "028",
+            "DATE_ACQUIRED": date,
+            "SCENE_CENTER_TIME": "10:04:22.1183580Z",
+        },
+        "LEVEL2_SURFACE_REFLECTANCE_PARAMETERS": {
+            "REFLECTANCE_MULT_BAND_4": "2.75e-05",
+            "REFLECTANCE_ADD_BAND_4": "-0.2",
+        },
+        "LEVEL2_SURFACE_TEMPERATURE_PARAMETERS": {
+            "TEMPERATURE_MULT_BAND_ST_B10": "0.00341802",
+            "TEMPERATURE_ADD_BAND_ST_B10": "149.0",
+        },
+    }
+
+
+def build_product(tmp_path, *, product_id=L9_ID, tokens=None, level="L2SP", omit_file=None):
+    """Build a product directory of real GeoTIFFs and return its path.
+
+    ``omit_file`` names a band the metadata lists but the directory does not
+    hold — the state a truncated download leaves behind.
+    """
+    table = OLI_BANDS if product_id.startswith("LC0") else TM_BANDS
+    if tokens is None:
+        tokens = list(table)
+    spacecraft = f"LANDSAT_{product_id[3]}"
+    directory = tmp_path / product_id
+    directory.mkdir()
+    groups = spec(product_id, tokens, level=level, spacecraft=spacecraft)
+    (directory / f"{product_id}_MTL.json").write_text(
+        json.dumps({"LANDSAT_METADATA_FILE": groups}, indent=2)
+    )
+    for token in tokens:
+        if token != omit_file:
+            _write_tif(directory / f"{product_id}_{token}.TIF", token, table)
+    return directory
+
+
+@pytest.fixture
+def product(tmp_path):
+    """A Landsat 9 Level-2 science product."""
+    return build_product(tmp_path)
+
+
+class TestLoading:
+    """A product on disk becomes a dataset on the scene's own grid."""
+
+    def test_returns_a_rasterio_backed_dataset(self, product):
+        scene = eeo.load_landsat(product, ["red", "nir08"])
+        assert scene.to_array().shape == (2, SIZE, SIZE)
+        assert scene.get_crs().to_string() == CRS
+        assert scene.get_transform()[0] == RES
+        assert scene.get_transform()[2] == ULX
+
+    def test_values_are_the_stored_digital_numbers(self, product):
+        got = eeo.load_landsat(product, ["red"]).to_array()[0]
+        assert np.all(got == OLI_BANDS["SR_B4"])
+
+    def test_band_names_are_the_common_names(self, product):
+        assert eeo.load_landsat(product, ["red", "nir08"]).band_names == ["red", "nir08"]
+
+    def test_native_tokens_resolve_to_common_names(self, product):
+        assert eeo.load_landsat(product, ["SR_B4", "B5"]).band_names == ["red", "nir08"]
+
+    def test_band_order_follows_the_request(self, product):
+        scene = eeo.load_landsat(product, ["nir08", "red"])
+        assert scene.band_names == ["nir08", "red"]
+        assert scene.to_array()[0].max() == OLI_BANDS["SR_B5"]
+        assert scene.to_array()[1].max() == OLI_BANDS["SR_B4"]
+
+    def test_metadata_file_can_be_given_directly(self, product):
+        metadata = product / f"{L9_ID}_MTL.json"
+        assert eeo.load_landsat(metadata, ["red"]).band_names == ["red"]
+
+    def test_timestamp_is_the_acquisition_time(self, product):
+        scene = eeo.load_landsat(product, ["red"])
+        assert scene.timestamp == dt.datetime(
+            2026, 8, 22, 10, 4, 22, 118358, tzinfo=dt.timezone.utc
+        )
+
+    def test_a_thermal_band_loads_beside_a_reflectance_one(self, product):
+        scene = eeo.load_landsat(product, ["red", "lwir11"])
+        assert scene.band_names == ["red", "lwir11"]
+        assert scene.to_array()[1].max() == OLI_BANDS["ST_B10"]
+
+
+class TestOneLoaderAcrossMissions:
+    """The same band names reach different band numbers on different sensors."""
+
+    def test_red_is_band_4_on_landsat_9(self, product):
+        assert eeo.load_landsat(product, ["red"]).to_array()[0].max() == OLI_BANDS["SR_B4"]
+
+    def test_red_is_band_3_on_landsat_7(self, tmp_path):
+        seven = build_product(tmp_path, product_id=L7_ID)
+        assert eeo.load_landsat(seven, ["red"]).to_array()[0].max() == TM_BANDS["SR_B3"]
+
+    def test_the_same_request_works_on_both(self, tmp_path):
+        nine = build_product(tmp_path, product_id=L9_ID)
+        seven = build_product(tmp_path, product_id=L7_ID)
+        request = ["red", "nir08", "swir16"]
+        assert eeo.load_landsat(nine, request).band_names == request
+        assert eeo.load_landsat(seven, request).band_names == request
+
+    def test_the_mission_is_reported_from_the_metadata(self, tmp_path):
+        seven = build_product(tmp_path, product_id=L7_ID)
+        attrs = eeo.load_landsat(seven, ["red"]).attrs
+        assert attrs["mission"] == "Landsat 7"
+        assert attrs["instrument"] == "ETM+"
+        assert attrs["spacecraft"] == "LANDSAT_7"
+
+    def test_landsat_7_thermal_is_band_6(self, tmp_path):
+        seven = build_product(tmp_path, product_id=L7_ID)
+        scene = eeo.load_landsat(seven, ["lwir"])
+        assert scene.to_array()[0].max() == TM_BANDS["ST_B6"]
+
+    def test_a_landsat_9_band_name_is_refused_on_landsat_7(self, tmp_path):
+        # Landsat 7 has no band 9 at all, so this is a band table question
+        # rather than a missing-file one.
+        seven = build_product(tmp_path, product_id=L7_ID)
+        with pytest.raises(ValidationError, match="no band"):
+            eeo.load_landsat(seven, ["coastal"])
+
+
+class TestNodata:
+    """The result's nodata describes the imagery, not a quality raster."""
+
+    def test_imagery_fill_is_zero(self, product):
+        assert eeo.load_landsat(product, ["red"]).get_metadata()["nodata"] == 0
+
+    def test_a_leading_quality_band_does_not_supply_nodata(self, product):
+        # QA_PIXEL declares 1; asking for it first must not make 1 the fill
+        # value of the reflectance band travelling with it.
+        scene = eeo.load_landsat(product, ["qa_pixel", "red"])
+        assert scene.band_names == ["qa_pixel", "red"]
+        assert scene.get_metadata()["nodata"] == 0
+
+    def test_quality_values_survive_being_read_second(self, product):
+        scene = eeo.load_landsat(product, ["qa_pixel", "red"])
+        assert scene.to_array()[0].max() == OLI_BANDS["QA_PIXEL"]
+        assert scene.to_array()[1].max() == OLI_BANDS["SR_B4"]
+
+    def test_a_quality_only_request_keeps_its_own_fill(self, product):
+        assert eeo.load_landsat(product, ["qa_pixel"]).get_metadata()["nodata"] == 1
+
+
+class TestProvenance:
+    """The result carries enough to say which scene it came from."""
+
+    def test_identity_is_recorded(self, product):
+        attrs = eeo.load_landsat(product, ["red"]).attrs
+        assert attrs["product"] == L9_ID
+        assert attrs["mission"] == "Landsat 9"
+        assert attrs["level"] == "L2SP"
+        assert (attrs["wrs_path"], attrs["wrs_row"]) == ("193", "028")
+        assert attrs["collection_number"] == "02"
+        assert attrs["collection_category"] == "T1"
+        assert attrs["resolution"] == 30
+
+    def test_requested_bands_are_recorded_both_ways(self, product):
+        attrs = eeo.load_landsat(product, ["red", "nir08"]).attrs
+        assert attrs["bands"] == ["red", "nir08"]
+        assert attrs["band_ids"] == ["SR_B4", "SR_B5"]
+
+    def test_scaling_coefficients_travel_with_the_data(self, product):
+        # Carried, never applied: the values above are digital numbers.
+        attrs = eeo.load_landsat(product, ["red"]).attrs
+        assert attrs["reflectance_scaling"]["SR_B4"] == (2.75e-05, -0.2)
+        assert attrs["temperature_scaling"]["ST_B10"] == (0.00341802, 149.0)
+
+
+class TestCropping:
+    """A bbox in lon/lat degrees selects a window of the scene."""
+
+    def test_bbox_reads_a_smaller_window(self, product):
+        quarter = (ULX, ULY - SIZE / 2 * RES, ULX + SIZE / 2 * RES, ULY)
+        bounds = transform_bounds(CRS, "EPSG:4326", *quarter, densify_pts=21)
+        scene = eeo.load_landsat(product, ["red"], bbox=bounds)
+        height, width = scene.to_array().shape[-2:]
+        assert height < SIZE and width < SIZE
+        assert np.all(scene.to_array()[0] == OLI_BANDS["SR_B4"])
+
+    def test_bands_stay_aligned_under_a_bbox(self, product):
+        quarter = (ULX, ULY - SIZE / 2 * RES, ULX + SIZE / 2 * RES, ULY)
+        bounds = transform_bounds(CRS, "EPSG:4326", *quarter, densify_pts=21)
+        scene = eeo.load_landsat(product, ["red", "nir08"], bbox=bounds)
+        array = scene.to_array()
+        assert array.shape[0] == 2 and array.shape[1] < SIZE
+        assert array[1].max() == OLI_BANDS["SR_B5"]
+
+    def test_a_bbox_off_the_scene_is_refused(self, product):
+        with pytest.raises(ValidationError, match="does not overlap"):
+            eeo.load_landsat(product, ["red"], bbox=(-50.0, -30.0, -49.9, -29.9))
+
+
+class TestRefusals:
+    """What the loader will not do, and what it says instead."""
+
+    def test_a_missing_product_is_named(self, tmp_path):
+        with pytest.raises(ValidationError, match="no such Landsat product"):
+            eeo.load_landsat(tmp_path / "absent", ["red"])
+
+    def test_level_1_is_refused_by_name(self, tmp_path):
+        one = build_product(
+            tmp_path, product_id="LC09_L1TP_193028_20260822_20260823_02_T1", level="L1TP"
+        )
+        with pytest.raises(ValidationError, match="Level-1 is not supported"):
+            eeo.load_landsat(one, ["red"])
+
+    def test_an_unknown_band_name_is_refused(self, product):
+        with pytest.raises(ValidationError, match="no band"):
+            eeo.load_landsat(product, ["chlorophyll"])
+
+    def test_a_band_the_product_lacks_is_refused(self, tmp_path):
+        # L2SR: reflectance without surface temperature, which is a normal
+        # product rather than a damaged one.
+        tokens = [t for t in OLI_BANDS if not t.startswith("ST_")]
+        reflectance_only = build_product(tmp_path, tokens=tokens, level="L2SR")
+        with pytest.raises(ValidationError, match="holds no 'lwir11'"):
+            eeo.load_landsat(reflectance_only, ["lwir11"])
+
+    def test_a_reflectance_only_product_still_loads_its_bands(self, tmp_path):
+        tokens = [t for t in OLI_BANDS if not t.startswith("ST_")]
+        reflectance_only = build_product(tmp_path, tokens=tokens, level="L2SR")
+        scene = eeo.load_landsat(reflectance_only, ["red", "nir08"])
+        assert scene.attrs["level"] == "L2SR"
+        assert scene.band_names == ["red", "nir08"]
+
+    def test_a_listed_but_absent_file_is_named(self, tmp_path):
+        truncated = build_product(tmp_path, omit_file="SR_B4")
+        with pytest.raises(ValidationError, match="does not hold it"):
+            eeo.load_landsat(truncated, ["red"])
+
+    def test_level_override_contradicting_the_metadata_is_refused(self, product):
+        with pytest.raises(ValidationError, match="contradicts the product"):
+            eeo.load_landsat(product, ["red"], level="L2SR")
+
+    def test_level_override_agreeing_with_the_metadata_is_accepted(self, product):
+        assert eeo.load_landsat(product, ["red"], level="L2SP").band_names == ["red"]

--- a/tests/test_load_sentinel2.py
+++ b/tests/test_load_sentinel2.py
@@ -8,6 +8,8 @@ image reads, actual warping between resolutions, and actual georeferencing;
 nothing about the read path is stubbed. Nothing is downloaded.
 """
 
+import shutil
+
 import numpy as np
 import pytest
 import rasterio as rio
@@ -222,3 +224,46 @@ class TestChaining:
         out = tmp_path / "stack.tif"
         eeo.load_sentinel2(safe, ["red", "nir"]).save_raster(out)
         assert eeo.load_raster(out).band_names == ["red", "nir"]
+
+
+class TestFindingTheProduct:
+    """What the loader accepts as a path to a product."""
+
+    def test_the_folder_the_safe_was_unpacked_into(self, tmp_path, safe):
+        # Unzipping leaves a folder holding the .SAFE. Pointing at that folder
+        # must load the same scene as pointing at the .SAFE itself.
+        from_parent = eeo.load_sentinel2(tmp_path, ["red"])
+        from_safe = eeo.load_sentinel2(safe, ["red"])
+        np.testing.assert_array_equal(from_parent.to_array(), from_safe.to_array())
+        assert from_parent.attrs["product"] == from_safe.attrs["product"]
+
+    def test_a_folder_holding_two_products_is_refused(self, tmp_path, safe):
+        twin = tmp_path / "S2A_MSIL2A_20200101T100000_N0212_R022_T32TPS_20200101T120000.SAFE"
+        shutil.copytree(safe, twin)
+        with pytest.raises(ValidationError, match="holds 2 Sentinel-2 products"):
+            eeo.load_sentinel2(tmp_path, ["red"])
+
+
+class TestPartialOverlap:
+    """A bbox reaching past the tile returns the overlap, not padding."""
+
+    def test_a_bbox_straddling_the_edge_is_clipped(self, safe):
+        extent = SIZE_10M * 10
+        # Half the requested window lies west and south of the tile.
+        straddling = transform_bounds(
+            "EPSG:32632",
+            "EPSG:4326",
+            ULX - extent / 2,
+            ULY - extent / 2,
+            ULX + extent / 2,
+            ULY,
+            densify_pts=21,
+        )
+        scene = eeo.load_sentinel2(safe, ["red"], bbox=straddling)
+        height, width = scene.to_array().shape[-2:]
+        assert 0 < height < SIZE_10M and 0 < width < SIZE_10M
+        # The window starts at the tile's own corner, not at the requested one.
+        assert scene.get_transform()[2] == ULX
+        assert scene.get_transform()[5] == ULY
+        # Every pixel returned is real data, not fill.
+        assert np.all(scene.to_array()[0] == FILL["B04"])

--- a/tests/test_load_sentinel2.py
+++ b/tests/test_load_sentinel2.py
@@ -1,139 +1,50 @@
 """Tests for load_sentinel2 (eeo/io/products.py).
 
-The fixture is a real ``.SAFE`` tree: genuine JPEG 2000 images written through
-GDAL, laid out in the resolution subdirectories a product uses, under manifests
-of the real shape. So the loader is exercised over actual image reads, actual
-warping between resolutions, and actual georeferencing — nothing about the read
-path is stubbed. Nothing is downloaded.
+The fixture, from :mod:`product_fixtures`, is a real ``.SAFE`` tree: genuine
+JPEG 2000 images written through GDAL, laid out in the resolution
+subdirectories a product uses, under manifests of the real shape — the same
+manifests the metadata tests parse. So the loader is exercised over actual
+image reads, actual warping between resolutions, and actual georeferencing;
+nothing about the read path is stubbed. Nothing is downloaded.
 """
 
 import numpy as np
 import pytest
 import rasterio as rio
-from rasterio.transform import from_origin
+from rasterio.warp import transform_bounds
 
 import eeo
 from eeo.core.exceptions import ValidationError
-
-GRANULE = "L2A_T32TPS_A039516_20240929T101318"
-PRODUCT = "S2B_MSIL2A_20240929T100719_N0511_R022_T32TPS_20240929T133706.SAFE"
-STEM = "T32TPS_20240929T100719"
-ULX, ULY = 300000.0, 5100000.0
-SIZE_10M = 64
-
-# Which bands the fixture writes, and at which resolutions, mirroring a real
-# product: B08 only at 10 m, B01 at 20 m and 60 m though it is sensed at 60,
-# B09 only at 60 m, SCL at 20 m and 60 m.
-LAYOUT = {
-    "B02": (10, 20),
-    "B03": (10, 20),
-    "B04": (10, 20, 60),
-    "B08": (10,),
-    "B05": (20, 60),
-    "B11": (20, 60),
-    "B12": (20, 60),
-    "B8A": (20, 60),
-    "B01": (20, 60),
-    "B09": (60,),
-    "SCL": (20, 60),
-}
-FILL = {
-    "B02": 700,
-    "B03": 900,
-    "B04": 1234,
-    "B08": 4321,
-    "B05": 3000,
-    "B11": 2222,
-    "B12": 1800,
-    "B8A": 4000,
-    "B01": 1100,
-    "B09": 1500,
-}
-
-
-def _write_jp2(path, res, size, band):
-    """Write one georeferenced JPEG 2000 image."""
-    if band == "SCL":
-        # Distinct class numbers in blocks, so any blending is detectable.
-        data = np.zeros((size, size), dtype="uint16")
-        data[: size // 2] = 4  # vegetation
-        data[size // 2 :] = 9  # cloud high probability
-        data = data[None]
-    else:
-        data = np.full((1, size, size), FILL[band], dtype="uint16")
-    # Only the options JP2OpenJPEG accepts: copying a GeoTIFF profile would
-    # carry INTERLEAVE and tiling keys the driver rejects.
-    #
-    # REVERSIBLE and QUALITY are both required, and only together: the writer
-    # is lossy by default and stays lossy with either one alone, which quietly
-    # rewrites a class number 4 as 3 and would make a resampling test read as a
-    # loader bug. Real products are losslessly encoded, so the fixture must be
-    # too or it is testing the compressor rather than the reader.
-    profile = {
-        "driver": "JP2OpenJPEG",
-        "height": size,
-        "width": size,
-        "count": 1,
-        "dtype": "uint16",
-        "crs": "EPSG:32632",
-        "transform": from_origin(ULX, ULY, res, res),
-        "nodata": 0,
-        "REVERSIBLE": "YES",
-        "QUALITY": "100",
-    }
-    with rio.open(path, "w", **profile) as dst:
-        dst.write(data)
-
-
-def build_safe(tmp_path, *, level="2A", product_type="S2MSI2A", layout=None, omit_file=None):
-    """Build a .SAFE tree with real JPEG 2000 images and return its path."""
-    layout = LAYOUT if layout is None else layout
-    safe = tmp_path / PRODUCT
-    img = safe / "GRANULE" / GRANULE / "IMG_DATA"
-    entries = []
-    for band, resolutions in layout.items():
-        for res in resolutions:
-            (img / f"R{res}m").mkdir(parents=True, exist_ok=True)
-            relative = f"GRANULE/{GRANULE}/IMG_DATA/R{res}m/{STEM}_{band}_{res}m"
-            entries.append(relative)
-            if omit_file == (band, res):
-                continue
-            _write_jp2(safe / f"{relative}.jp2", res, SIZE_10M * 10 // res, band)
-
-    files = "".join(f"<IMAGE_FILE>{e}</IMAGE_FILE>" for e in entries)
-    (safe / f"MTD_MSIL{level}.xml").write_text(
-        f'<?xml version="1.0"?>'
-        f'<n1:Level-{level}_User_Product xmlns:n1="https://psd-15.sentinel2.eo.esa.int/'
-        f'PSD/User_Product_Level-{level}.xsd"><n1:General_Info><Product_Info>'
-        f"<PRODUCT_START_TIME>2024-09-29T10:07:19.024Z</PRODUCT_START_TIME>"
-        f"<PRODUCT_URI>{PRODUCT}</PRODUCT_URI>"
-        f"<PRODUCT_TYPE>{product_type}</PRODUCT_TYPE>"
-        f"<PROCESSING_BASELINE>05.11</PROCESSING_BASELINE>"
-        f'<Product_Organisation><Granule_List><Granule granuleIdentifier="{GRANULE}">'
-        f"{files}</Granule></Granule_List></Product_Organisation></Product_Info>"
-        f"<Product_Image_Characteristics><QUANTIFICATION_VALUES_LIST>"
-        f'<BOA_QUANTIFICATION_VALUE unit="none">10000</BOA_QUANTIFICATION_VALUE>'
-        f"</QUANTIFICATION_VALUES_LIST><BOA_ADD_OFFSET_VALUES_LIST>"
-        f'<BOA_ADD_OFFSET band_id="3">-1000</BOA_ADD_OFFSET>'
-        f"</BOA_ADD_OFFSET_VALUES_LIST><Spectral_Information_List>"
-        f'<Spectral_Information bandId="3" physicalBand="B4"/>'
-        f"</Spectral_Information_List></Product_Image_Characteristics>"
-        f"</n1:General_Info></n1:Level-{level}_User_Product>"
-    )
-    (safe / "GRANULE" / GRANULE / "MTD_TL.xml").write_text(
-        '<?xml version="1.0"?>'
-        '<n1:Level-2A_Tile_ID xmlns:n1="https://psd-15.sentinel2.eo.esa.int/'
-        'PSD/S2_PDI_Level-2A_Tile_Metadata.xsd"><n1:General_Info>'
-        "<SENSING_TIME>2024-09-29T10:17:59.919283Z</SENSING_TIME></n1:General_Info>"
-        "<n1:Geometric_Info><Tile_Geocoding>"
-        "<HORIZONTAL_CS_CODE>EPSG:32632</HORIZONTAL_CS_CODE>"
-        "</Tile_Geocoding></n1:Geometric_Info></n1:Level-2A_Tile_ID>"
-    )
-    return safe
+from product_fixtures import (
+    S2_FILL as FILL,
+)
+from product_fixtures import (
+    S2_GRANULE as GRANULE,
+)
+from product_fixtures import (
+    S2_LAYOUT as LAYOUT,
+)
+from product_fixtures import (
+    S2_SENSING_TIME,
+    build_safe,
+)
+from product_fixtures import (
+    S2_SIZE_10M as SIZE_10M,
+)
+from product_fixtures import (
+    S2_STEM as STEM,
+)
+from product_fixtures import (
+    S2_ULX as ULX,
+)
+from product_fixtures import (
+    S2_ULY as ULY,
+)
 
 
 @pytest.fixture
 def safe(tmp_path):
+    """A whole Level-2A product, images included."""
     return build_safe(tmp_path)
 
 
@@ -170,7 +81,7 @@ class TestValuesAndNaming:
         scene = eeo.load_sentinel2(safe, ["red"])
         assert scene.get_crs().to_string() == "EPSG:32632"
         assert scene.get_transform()[0] == 10.0
-        assert scene.timestamp.isoformat() == "2024-09-29T10:17:59.919283+00:00"
+        assert scene.timestamp.isoformat() == S2_SENSING_TIME
 
     def test_provenance_is_recorded(self, safe):
         attrs = eeo.load_sentinel2(safe, ["red"]).attrs
@@ -250,8 +161,6 @@ class TestCropping:
     """A bbox bounds what is read."""
 
     def test_bbox_reads_a_window(self, safe):
-        from rasterio.warp import transform_bounds
-
         bounds = transform_bounds(
             "EPSG:32632", "EPSG:4326", ULX, ULY - 200, ULX + 200, ULY, densify_pts=21
         )

--- a/tests/test_load_sentinel2.py
+++ b/tests/test_load_sentinel2.py
@@ -1,0 +1,315 @@
+"""Tests for load_sentinel2 (eeo/io/products.py).
+
+The fixture is a real ``.SAFE`` tree: genuine JPEG 2000 images written through
+GDAL, laid out in the resolution subdirectories a product uses, under manifests
+of the real shape. So the loader is exercised over actual image reads, actual
+warping between resolutions, and actual georeferencing — nothing about the read
+path is stubbed. Nothing is downloaded.
+"""
+
+import numpy as np
+import pytest
+import rasterio as rio
+from rasterio.transform import from_origin
+
+import eeo
+from eeo.core.exceptions import ValidationError
+
+GRANULE = "L2A_T32TPS_A039516_20240929T101318"
+PRODUCT = "S2B_MSIL2A_20240929T100719_N0511_R022_T32TPS_20240929T133706.SAFE"
+STEM = "T32TPS_20240929T100719"
+ULX, ULY = 300000.0, 5100000.0
+SIZE_10M = 64
+
+# Which bands the fixture writes, and at which resolutions, mirroring a real
+# product: B08 only at 10 m, B01 at 20 m and 60 m though it is sensed at 60,
+# B09 only at 60 m, SCL at 20 m and 60 m.
+LAYOUT = {
+    "B02": (10, 20),
+    "B03": (10, 20),
+    "B04": (10, 20, 60),
+    "B08": (10,),
+    "B05": (20, 60),
+    "B11": (20, 60),
+    "B12": (20, 60),
+    "B8A": (20, 60),
+    "B01": (20, 60),
+    "B09": (60,),
+    "SCL": (20, 60),
+}
+FILL = {
+    "B02": 700,
+    "B03": 900,
+    "B04": 1234,
+    "B08": 4321,
+    "B05": 3000,
+    "B11": 2222,
+    "B12": 1800,
+    "B8A": 4000,
+    "B01": 1100,
+    "B09": 1500,
+}
+
+
+def _write_jp2(path, res, size, band):
+    """Write one georeferenced JPEG 2000 image."""
+    if band == "SCL":
+        # Distinct class numbers in blocks, so any blending is detectable.
+        data = np.zeros((size, size), dtype="uint16")
+        data[: size // 2] = 4  # vegetation
+        data[size // 2 :] = 9  # cloud high probability
+        data = data[None]
+    else:
+        data = np.full((1, size, size), FILL[band], dtype="uint16")
+    # Only the options JP2OpenJPEG accepts: copying a GeoTIFF profile would
+    # carry INTERLEAVE and tiling keys the driver rejects.
+    #
+    # REVERSIBLE and QUALITY are both required, and only together: the writer
+    # is lossy by default and stays lossy with either one alone, which quietly
+    # rewrites a class number 4 as 3 and would make a resampling test read as a
+    # loader bug. Real products are losslessly encoded, so the fixture must be
+    # too or it is testing the compressor rather than the reader.
+    profile = {
+        "driver": "JP2OpenJPEG",
+        "height": size,
+        "width": size,
+        "count": 1,
+        "dtype": "uint16",
+        "crs": "EPSG:32632",
+        "transform": from_origin(ULX, ULY, res, res),
+        "nodata": 0,
+        "REVERSIBLE": "YES",
+        "QUALITY": "100",
+    }
+    with rio.open(path, "w", **profile) as dst:
+        dst.write(data)
+
+
+def build_safe(tmp_path, *, level="2A", product_type="S2MSI2A", layout=None, omit_file=None):
+    """Build a .SAFE tree with real JPEG 2000 images and return its path."""
+    layout = LAYOUT if layout is None else layout
+    safe = tmp_path / PRODUCT
+    img = safe / "GRANULE" / GRANULE / "IMG_DATA"
+    entries = []
+    for band, resolutions in layout.items():
+        for res in resolutions:
+            (img / f"R{res}m").mkdir(parents=True, exist_ok=True)
+            relative = f"GRANULE/{GRANULE}/IMG_DATA/R{res}m/{STEM}_{band}_{res}m"
+            entries.append(relative)
+            if omit_file == (band, res):
+                continue
+            _write_jp2(safe / f"{relative}.jp2", res, SIZE_10M * 10 // res, band)
+
+    files = "".join(f"<IMAGE_FILE>{e}</IMAGE_FILE>" for e in entries)
+    (safe / f"MTD_MSIL{level}.xml").write_text(
+        f'<?xml version="1.0"?>'
+        f'<n1:Level-{level}_User_Product xmlns:n1="https://psd-15.sentinel2.eo.esa.int/'
+        f'PSD/User_Product_Level-{level}.xsd"><n1:General_Info><Product_Info>'
+        f"<PRODUCT_START_TIME>2024-09-29T10:07:19.024Z</PRODUCT_START_TIME>"
+        f"<PRODUCT_URI>{PRODUCT}</PRODUCT_URI>"
+        f"<PRODUCT_TYPE>{product_type}</PRODUCT_TYPE>"
+        f"<PROCESSING_BASELINE>05.11</PROCESSING_BASELINE>"
+        f'<Product_Organisation><Granule_List><Granule granuleIdentifier="{GRANULE}">'
+        f"{files}</Granule></Granule_List></Product_Organisation></Product_Info>"
+        f"<Product_Image_Characteristics><QUANTIFICATION_VALUES_LIST>"
+        f'<BOA_QUANTIFICATION_VALUE unit="none">10000</BOA_QUANTIFICATION_VALUE>'
+        f"</QUANTIFICATION_VALUES_LIST><BOA_ADD_OFFSET_VALUES_LIST>"
+        f'<BOA_ADD_OFFSET band_id="3">-1000</BOA_ADD_OFFSET>'
+        f"</BOA_ADD_OFFSET_VALUES_LIST><Spectral_Information_List>"
+        f'<Spectral_Information bandId="3" physicalBand="B4"/>'
+        f"</Spectral_Information_List></Product_Image_Characteristics>"
+        f"</n1:General_Info></n1:Level-{level}_User_Product>"
+    )
+    (safe / "GRANULE" / GRANULE / "MTD_TL.xml").write_text(
+        '<?xml version="1.0"?>'
+        '<n1:Level-2A_Tile_ID xmlns:n1="https://psd-15.sentinel2.eo.esa.int/'
+        'PSD/S2_PDI_Level-2A_Tile_Metadata.xsd"><n1:General_Info>'
+        "<SENSING_TIME>2024-09-29T10:17:59.919283Z</SENSING_TIME></n1:General_Info>"
+        "<n1:Geometric_Info><Tile_Geocoding>"
+        "<HORIZONTAL_CS_CODE>EPSG:32632</HORIZONTAL_CS_CODE>"
+        "</Tile_Geocoding></n1:Geometric_Info></n1:Level-2A_Tile_ID>"
+    )
+    return safe
+
+
+@pytest.fixture
+def safe(tmp_path):
+    return build_safe(tmp_path)
+
+
+class TestValuesAndNaming:
+    """A load returns the product's own numbers under common band names."""
+
+    def test_bands_come_back_as_stored_digital_numbers(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red", "nir"])
+        array = scene.to_array()
+        assert array.dtype == np.uint16
+        assert array[0][0, 0] == FILL["B04"]
+        assert array[1][0, 0] == FILL["B08"]
+
+    def test_values_match_reading_the_image_directly(self, safe):
+        # The contract: what a GIS shows is what comes back.
+        direct = safe / "GRANULE" / GRANULE / "IMG_DATA" / "R10m" / f"{STEM}_B04_10m.jp2"
+        with rio.open(direct) as src:
+            expected = src.read(1)
+        got = eeo.load_sentinel2(safe, ["red"]).to_array()[0]
+        assert np.array_equal(got, expected)
+
+    def test_band_names_are_common_names(self, safe):
+        assert eeo.load_sentinel2(safe, ["red", "nir"]).band_names == ["red", "nir"]
+
+    def test_native_ids_resolve_to_common_names(self, safe):
+        assert eeo.load_sentinel2(safe, ["B04", "B08"]).band_names == ["red", "nir"]
+
+    def test_order_follows_the_request(self, safe):
+        scene = eeo.load_sentinel2(safe, ["nir", "red"])
+        assert scene.band_names == ["nir", "red"]
+        assert scene.to_array()[0][0, 0] == FILL["B08"]
+
+    def test_georeferencing_and_timestamp(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red"])
+        assert scene.get_crs().to_string() == "EPSG:32632"
+        assert scene.get_transform()[0] == 10.0
+        assert scene.timestamp.isoformat() == "2024-09-29T10:17:59.919283+00:00"
+
+    def test_provenance_is_recorded(self, safe):
+        attrs = eeo.load_sentinel2(safe, ["red"]).attrs
+        assert attrs["mission"] == "Sentinel-2"
+        assert attrs["level"] == "L2A"
+        assert attrs["tile"] == "T32TPS"
+        assert attrs["processing_baseline"] == "05.11"
+        assert attrs["bands"] == ["red"] and attrs["band_ids"] == ["B04"]
+        # The coefficients a reader needs to convert to reflectance by hand.
+        assert attrs["quantification_value"] == 10000.0
+        assert attrs["band_offsets"]["B04"] == -1000.0
+
+
+class TestResolution:
+    """The output grid keeps the finest detail requested, and no more."""
+
+    def test_default_is_the_finest_native_resolution(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red", "swir16"])
+        assert scene.get_transform()[0] == 10.0
+        assert scene.to_array().shape == (2, SIZE_10M, SIZE_10M)
+
+    def test_all_coarse_bands_stay_coarse(self, safe):
+        # Nothing requested was sensed at 10 m, so upsampling would invent detail.
+        scene = eeo.load_sentinel2(safe, ["swir16", "swir22"])
+        assert scene.get_transform()[0] == 20.0
+
+    def test_explicit_resolution(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red", "swir16"], resolution=20)
+        assert scene.get_transform()[0] == 20.0
+        assert scene.to_array().shape == (2, SIZE_10M // 2, SIZE_10M // 2)
+
+    def test_coarse_band_is_warped_onto_the_fine_grid(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red", "swir16"], resolution=10)
+        array = scene.to_array()
+        assert array.shape == (2, SIZE_10M, SIZE_10M)
+        assert array[1][0, 0] == FILL["B11"]
+
+    def test_order_is_restored_when_a_coarse_band_leads(self, safe):
+        # swir16 cannot define a 10 m grid, so red leads internally; the
+        # caller's order must survive that.
+        scene = eeo.load_sentinel2(safe, ["swir16", "red"], resolution=10)
+        assert scene.band_names == ["swir16", "red"]
+        array = scene.to_array()
+        assert array[0][0, 0] == FILL["B11"]
+        assert array[1][0, 0] == FILL["B04"]
+
+    def test_invalid_resolution_rejected(self, safe):
+        with pytest.raises(ValidationError, match="resolution must be one of"):
+            eeo.load_sentinel2(safe, ["red"], resolution=15)
+
+    def test_no_band_at_the_requested_resolution(self, safe):
+        # B08 exists only at 10 m, so a 20 m request has no grid to read onto.
+        with pytest.raises(ValidationError) as excinfo:
+            eeo.load_sentinel2(safe, ["nir"], resolution=20)
+        message = str(excinfo.value)
+        assert "none of the requested bands is written at 20 m" in message
+        assert "nir at 10 m" in message
+
+
+class TestQualityBands:
+    """Class numbers are never blended, whatever resampling is asked for."""
+
+    def test_scl_keeps_its_classes_when_warped(self, safe):
+        # SCL is written at 20 m and must land on the 10 m grid by nearest
+        # neighbour even though bilinear was requested for the rest.
+        scene = eeo.load_sentinel2(safe, ["red", "scl"], resolution=10, resampling="bilinear")
+        classes = set(np.unique(scene.to_array()[1]))
+        assert classes <= {4, 9}, f"blending invented classes: {sorted(classes)}"
+
+    def test_scl_can_be_loaded_alone(self, safe):
+        scene = eeo.load_sentinel2(safe, ["scl"])
+        assert scene.band_names == ["scl"]
+        assert scene.get_transform()[0] == 20.0
+
+
+class TestCropping:
+    """A bbox bounds what is read."""
+
+    def test_bbox_reads_a_window(self, safe):
+        from rasterio.warp import transform_bounds
+
+        bounds = transform_bounds(
+            "EPSG:32632", "EPSG:4326", ULX, ULY - 200, ULX + 200, ULY, densify_pts=21
+        )
+        scene = eeo.load_sentinel2(safe, ["red"], bbox=bounds)
+        height, width = scene.to_array().shape[-2:]
+        assert height < SIZE_10M and width < SIZE_10M
+
+    def test_bbox_outside_the_tile_rejected(self, safe):
+        with pytest.raises(ValidationError, match="does not overlap"):
+            eeo.load_sentinel2(safe, ["red"], bbox=(-50.0, -30.0, -49.9, -29.9))
+
+
+class TestRefusals:
+    """Unsupported or malformed requests fail with an actionable message."""
+
+    def test_level1c_is_refused(self, tmp_path):
+        safe = build_safe(tmp_path, level="1C", product_type="S2MSI1C")
+        with pytest.raises(ValidationError, match="Level-1C is not supported"):
+            eeo.load_sentinel2(safe, ["red"])
+
+    def test_unknown_band_rejected(self, safe):
+        with pytest.raises(ValidationError, match="no band 'purple'"):
+            eeo.load_sentinel2(safe, ["purple"])
+
+    def test_duplicate_band_rejected(self, safe):
+        with pytest.raises(ValidationError, match="named twice"):
+            eeo.load_sentinel2(safe, ["red", "B04"])
+
+    def test_empty_band_list_rejected(self, safe):
+        with pytest.raises(ValidationError, match="at least one band"):
+            eeo.load_sentinel2(safe, [])
+
+    def test_a_bare_string_is_not_a_band_list(self, safe):
+        with pytest.raises(ValidationError, match="expected a sequence of band names"):
+            eeo.load_sentinel2(safe, "red")
+
+    def test_band_absent_from_the_product(self, tmp_path):
+        layout = {k: v for k, v in LAYOUT.items() if k != "B12"}
+        safe = build_safe(tmp_path, layout=layout)
+        with pytest.raises(ValidationError, match="no 'swir22' \\(B12\\) band at all"):
+            eeo.load_sentinel2(safe, ["swir22"])
+
+    def test_manifest_listing_a_file_that_is_missing(self, tmp_path):
+        safe = build_safe(tmp_path, omit_file=("B04", 10))
+        with pytest.raises(ValidationError, match="lists an image the product does not hold"):
+            eeo.load_sentinel2(safe, ["red"], resolution=10)
+
+
+class TestChaining:
+    """The result is an ordinary dataset and behaves like one."""
+
+    def test_ndvi_by_band_name(self, safe):
+        scene = eeo.load_sentinel2(safe, ["red", "nir"])
+        ndvi = scene.ndvi(red="red", nir="nir")
+        expected = (FILL["B08"] - FILL["B04"]) / (FILL["B08"] + FILL["B04"])
+        assert ndvi.to_array()[0][0, 0] == pytest.approx(expected, abs=1e-6)
+
+    def test_names_survive_a_save_and_reload(self, safe, tmp_path):
+        out = tmp_path / "stack.tif"
+        eeo.load_sentinel2(safe, ["red", "nir"]).save_raster(out)
+        assert eeo.load_raster(out).band_names == ["red", "nir"]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -3,6 +3,7 @@ import pytest
 import rasterio as rio
 from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array, load_raster
 from eeo.core.adapters import RasterioAdapter
@@ -12,7 +13,7 @@ from eeo.core.exceptions import BackendError, ValidationError
 
 def _write_tiny_tif(path):
     data = np.array([[1, 2], [3, 4]], dtype=np.uint8)
-    transform = Affine.translation(0, 2) * Affine.scale(1, -1)
+    transform = from_origin(0, 2, 1, 1)
 
     with rio.open(
         path,
@@ -50,7 +51,7 @@ def test_load_raster_success(tmp_path):
     path = tmp_path / "test.tif"
 
     data = np.array([[1, 2], [3, 4]], dtype=np.uint8)
-    transform = Affine.translation(0, 2) * Affine.scale(1, -1)
+    transform = from_origin(0, 2, 1, 1)
     crs = CRS.from_epsg(4326)
 
     with rio.open(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 import rasterio as rio
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array, load_raster
 from eeo.core.exceptions import CRSMismatchError
@@ -12,7 +12,7 @@ from eeo.ops.merge import mosaic
 def _write_tile(tmp_path, name, origin_x, value, res=10.0, nodata=None):
     path = tmp_path / name
     array = np.full((3, 3), value, dtype=np.float32)
-    transform = Affine.translation(origin_x, 30.0) * Affine.scale(res, -res)
+    transform = from_origin(origin_x, 30.0, res, res)
     with rio.open(
         path,
         "w",
@@ -100,7 +100,7 @@ def test_mosaic_preserves_nodata_value_and_dtype(tmp_path):
 
 def test_stack_preserves_nodata_and_dtype():
     """Stacking carries the base raster's nodata value and keeps its dtype."""
-    transform = Affine.translation(0.0, 30.0) * Affine.scale(10.0, -10.0)
+    transform = from_origin(0.0, 30.0, 10.0, 10.0)
     crs = CRS.from_epsg(32633)
     a = load_array(
         np.arange(1, 10, dtype=np.uint16).reshape(3, 3), transform=transform, crs=crs, nodata=0

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 
@@ -12,7 +12,7 @@ from eeo import load_array
 # for hand-checkable algebra (a + b is constant 5). General-purpose rasters
 # live in conftest.py.
 
-GRID = Affine.translation(0, 2) * Affine.scale(1, -1)
+GRID = from_origin(0, 2, 1, 1)
 
 
 @pytest.fixture

--- a/tests/test_ops_contract.py
+++ b/tests/test_ops_contract.py
@@ -11,13 +11,13 @@ import math
 
 import numpy as np
 import pytest
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 
 UTM = CRS.from_epsg(32633)
-GRID = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+GRID = from_origin(500_000.0, 4_200_000.0, 10.0, 10.0)
 
 
 def _rio(array, *, nodata=None):

--- a/tests/test_product_archives.py
+++ b/tests/test_product_archives.py
@@ -1,10 +1,10 @@
 """Tests for reading a product out of the archive it was downloaded as.
 
-The fixtures are the real ones: this module packs the same ``.SAFE`` tree
-``test_load_sentinel2`` builds, and the same Landsat product directory
-``test_load_landsat`` builds, into a zip and a tar. Importing them rather than
-copying them is deliberate — an archive test that quietly drifted from the
-directory test would be asserting that two different products agree.
+The fixtures are the real ones: this module packs the same ``.SAFE`` tree and
+the same Landsat product directory the loader tests use, from
+:mod:`product_fixtures`, into a zip and a tar. An archive fixture that drifted
+from the directory fixture would be asserting that two different products
+agree.
 
 The central claim is that the container makes no difference: the same request
 against a directory and against the archive of that directory must return the
@@ -25,27 +25,20 @@ from rasterio.warp import transform_bounds
 import eeo
 from eeo.core.exceptions import ValidationError
 from eeo.io._archive import ArchiveSource, DirectorySource, open_product
-from test_load_landsat import L9_ID, OLI_BANDS
-from test_load_landsat import build_product as build_landsat
-from test_load_sentinel2 import FILL, PRODUCT, build_safe
-
-
-def pack_zip(tree, archive, *, base):
-    """Zip a directory tree, naming members relative to ``base``."""
-    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zipped:
-        for path in sorted(tree.rglob("*")):
-            if path.is_file():
-                zipped.write(path, path.relative_to(base).as_posix())
-    return archive
-
-
-def pack_tar(tree, archive, *, base, compress=False):
-    """Tar a directory tree, naming members relative to ``base``."""
-    with tarfile.open(archive, "w:gz" if compress else "w") as tarred:
-        for path in sorted(tree.rglob("*")):
-            if path.is_file():
-                tarred.add(path, arcname=path.relative_to(base).as_posix())
-    return archive
+from product_fixtures import (
+    L9_ID,
+    OLI_BANDS,
+    build_landsat,
+    build_safe,
+    pack_tar,
+    pack_zip,
+)
+from product_fixtures import (
+    S2_FILL as FILL,
+)
+from product_fixtures import (
+    S2_PRODUCT as PRODUCT,
+)
 
 
 @pytest.fixture

--- a/tests/test_product_archives.py
+++ b/tests/test_product_archives.py
@@ -14,6 +14,7 @@ disagree about where the product is.
 Nothing is downloaded.
 """
 
+import shutil
 import tarfile
 import zipfile
 from pathlib import Path, PurePosixPath
@@ -288,3 +289,51 @@ class TestGlobParityForSingleCharacters:
         packed = open_product(safe_zip, "Sentinel-2")
         assert loose.glob(f"{PRODUCT}?MTD_MSIL2A.xml") == []
         assert packed.glob(f"{PRODUCT}?MTD_MSIL2A.xml") == []
+
+
+class TestAFolderHoldingAnArchive:
+    """A download that has not been unpacked still lives in a folder.
+
+    Pointing at that folder is what people actually do — the archive is the
+    only thing in it, so there is nothing ambiguous to resolve.
+    """
+
+    def test_a_folder_holding_a_zip_loads(self, tmp_path, safe):
+        folder = tmp_path / "downloads"
+        folder.mkdir()
+        pack_zip(safe, folder / f"{PRODUCT[:-5]}.zip", base=safe.parent)
+        shutil.rmtree(safe)
+        assert eeo.load_sentinel2(folder, ["red"]).attrs["product"] == PRODUCT
+
+    def test_it_matches_naming_the_zip_directly(self, tmp_path, safe):
+        folder = tmp_path / "downloads"
+        folder.mkdir()
+        archive = pack_zip(safe, folder / f"{PRODUCT[:-5]}.zip", base=safe.parent)
+        shutil.rmtree(safe)
+        np.testing.assert_array_equal(
+            eeo.load_sentinel2(folder, ["red"]).to_array(),
+            eeo.load_sentinel2(archive, ["red"]).to_array(),
+        )
+
+    def test_a_folder_holding_a_tar_loads(self, tmp_path, scene):
+        folder = tmp_path / "downloads"
+        folder.mkdir()
+        pack_tar(scene, folder / f"{L9_ID}.tar", base=scene)
+        shutil.rmtree(scene)
+        assert eeo.load_landsat(folder, ["red"]).attrs["product"] == L9_ID
+
+    def test_a_folder_holding_two_archives_is_refused(self, tmp_path, scene):
+        folder = tmp_path / "downloads"
+        folder.mkdir()
+        pack_tar(scene, folder / f"{L9_ID}.tar", base=scene)
+        pack_tar(scene, folder / "another_scene.tar", base=scene)
+        shutil.rmtree(scene)
+        with pytest.raises(ValidationError, match="holds 2 archives"):
+            eeo.load_landsat(folder, ["red"])
+
+    def test_an_unpacked_product_wins_over_an_archive_beside_it(self, tmp_path, safe):
+        # Having unzipped it, the folder holds both. The unpacked one is
+        # cheaper to read and is what the user is looking at.
+        pack_zip(safe, tmp_path / f"{PRODUCT[:-5]}.zip", base=safe.parent)
+        loaded = eeo.load_sentinel2(tmp_path, ["red"])
+        assert loaded.attrs["product"] == PRODUCT

--- a/tests/test_product_archives.py
+++ b/tests/test_product_archives.py
@@ -1,0 +1,297 @@
+"""Tests for reading a product out of the archive it was downloaded as.
+
+The fixtures are the real ones: this module packs the same ``.SAFE`` tree
+``test_load_sentinel2`` builds, and the same Landsat product directory
+``test_load_landsat`` builds, into a zip and a tar. Importing them rather than
+copying them is deliberate — an archive test that quietly drifted from the
+directory test would be asserting that two different products agree.
+
+The central claim is that the container makes no difference: the same request
+against a directory and against the archive of that directory must return the
+same values on the same grid. Anything else means discovery and reading
+disagree about where the product is.
+
+Nothing is downloaded.
+"""
+
+import tarfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+import numpy as np
+import pytest
+from rasterio.warp import transform_bounds
+
+import eeo
+from eeo.core.exceptions import ValidationError
+from eeo.io._archive import ArchiveSource, DirectorySource, open_product
+from test_load_landsat import L9_ID, OLI_BANDS
+from test_load_landsat import build_product as build_landsat
+from test_load_sentinel2 import FILL, PRODUCT, build_safe
+
+
+def pack_zip(tree, archive, *, base):
+    """Zip a directory tree, naming members relative to ``base``."""
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zipped:
+        for path in sorted(tree.rglob("*")):
+            if path.is_file():
+                zipped.write(path, path.relative_to(base).as_posix())
+    return archive
+
+
+def pack_tar(tree, archive, *, base, compress=False):
+    """Tar a directory tree, naming members relative to ``base``."""
+    with tarfile.open(archive, "w:gz" if compress else "w") as tarred:
+        for path in sorted(tree.rglob("*")):
+            if path.is_file():
+                tarred.add(path, arcname=path.relative_to(base).as_posix())
+    return archive
+
+
+@pytest.fixture
+def safe(tmp_path):
+    """An unpacked Sentinel-2 product."""
+    return build_safe(tmp_path)
+
+
+@pytest.fixture
+def safe_zip(tmp_path, safe):
+    """The same product as a Copernicus-style zip, the .SAFE at its root."""
+    return pack_zip(safe, tmp_path / "S2B_MSIL2A_20240929T100719.zip", base=safe.parent)
+
+
+@pytest.fixture
+def scene(tmp_path):
+    """An unpacked Landsat 9 product."""
+    return build_landsat(tmp_path)
+
+
+@pytest.fixture
+def scene_tar(tmp_path, scene):
+    """The same product as a USGS-style tar, its files at the tar's root."""
+    return pack_tar(scene, tmp_path / f"{L9_ID}.tar", base=scene)
+
+
+class TestOpenProduct:
+    """What a path is taken to be."""
+
+    def test_a_missing_path_names_the_mission(self, tmp_path):
+        with pytest.raises(ValidationError, match="no such Sentinel-2 product"):
+            open_product(tmp_path / "absent", "Sentinel-2")
+
+    def test_a_directory_becomes_a_directory_source(self, safe):
+        source = open_product(safe, "Sentinel-2")
+        assert isinstance(source, DirectorySource)
+        assert source.named_entry is None
+        assert source.name == PRODUCT
+
+    def test_a_named_file_is_remembered(self, safe):
+        source = open_product(safe / "MTD_MSIL2A.xml", "Sentinel-2")
+        assert isinstance(source, DirectorySource)
+        assert source.named_entry == PurePosixPath("MTD_MSIL2A.xml")
+        assert source.root == safe
+
+    def test_a_zip_becomes_an_archive_source(self, safe_zip):
+        source = open_product(safe_zip, "Sentinel-2")
+        assert isinstance(source, ArchiveSource)
+        assert source.exists(f"{PRODUCT}/MTD_MSIL2A.xml")
+
+    def test_a_tar_becomes_an_archive_source(self, scene_tar):
+        source = open_product(scene_tar, "Landsat")
+        assert isinstance(source, ArchiveSource)
+        assert source.exists(f"{L9_ID}_MTL.json")
+
+    def test_a_corrupt_archive_is_named(self, tmp_path):
+        broken = tmp_path / "broken.zip"
+        broken.write_bytes(b"not a zip file at all")
+        with pytest.raises(ValidationError, match="not a readable archive"):
+            open_product(broken, "Sentinel-2")
+
+
+class TestCompressedArchivesAreRefused:
+    """A gzipped tar is refused with instructions, not read slowly."""
+
+    def test_tar_gz_is_refused(self, tmp_path, scene):
+        archive = pack_tar(scene, tmp_path / f"{L9_ID}.tar.gz", base=scene, compress=True)
+        with pytest.raises(ValidationError, match="compressed archive"):
+            eeo.load_landsat(archive, ["red"])
+
+    def test_the_refusal_says_what_to_do(self, tmp_path, scene):
+        archive = pack_tar(scene, tmp_path / f"{L9_ID}.tar.gz", base=scene, compress=True)
+        with pytest.raises(ValidationError) as raised:
+            eeo.load_landsat(archive, ["red"])
+        message = str(raised.value)
+        assert "tar -xf" in message
+        # The directory the extraction will produce, so the next step is named.
+        assert f"'{L9_ID}.tar'" in message
+
+    def test_the_one_piece_spellings_are_refused_too(self, tmp_path, scene):
+        archive = pack_tar(scene, tmp_path / f"{L9_ID}.tgz", base=scene, compress=True)
+        with pytest.raises(ValidationError, match="compressed archive"):
+            open_product(archive, "Landsat")
+
+
+class TestGlobParity:
+    """A directory and its archive answer the same questions the same way."""
+
+    def test_the_same_pattern_finds_the_same_files(self, safe, safe_zip):
+        loose = open_product(safe.parent, "Sentinel-2")
+        packed = open_product(safe_zip, "Sentinel-2")
+        assert loose.glob("*.SAFE/MTD_MSIL2A.xml") == packed.glob("*.SAFE/MTD_MSIL2A.xml")
+
+    def test_a_star_does_not_cross_a_separator(self, safe, safe_zip):
+        # The manifest sits one level down, so a root-level pattern must not
+        # reach it — in either container.
+        loose = open_product(safe.parent, "Sentinel-2")
+        packed = open_product(safe_zip, "Sentinel-2")
+        assert loose.glob("*.xml") == []
+        assert packed.glob("*.xml") == []
+
+    def test_existence_agrees(self, safe, safe_zip):
+        loose = open_product(safe, "Sentinel-2")
+        packed = open_product(safe_zip, "Sentinel-2")
+        assert loose.exists("MTD_MSIL2A.xml")
+        assert packed.exists(f"{PRODUCT}/MTD_MSIL2A.xml")
+        assert not loose.exists("MTD_MSIL1C.xml")
+        assert not packed.exists(f"{PRODUCT}/MTD_MSIL1C.xml")
+
+
+class TestHref:
+    """What each source hands to rasterio."""
+
+    def test_a_directory_gives_a_plain_path(self, safe):
+        source = open_product(safe, "Sentinel-2")
+        assert source.href("MTD_MSIL2A.xml") == str(safe / "MTD_MSIL2A.xml")
+
+    def test_a_zip_gives_a_vsizip_path(self, safe_zip):
+        source = open_product(safe_zip, "Sentinel-2")
+        href = source.href(f"{PRODUCT}/MTD_MSIL2A.xml")
+        assert href == f"/vsizip/{safe_zip.as_posix()}/{PRODUCT}/MTD_MSIL2A.xml"
+
+    def test_a_tar_gives_a_vsitar_path(self, scene_tar):
+        source = open_product(scene_tar, "Landsat")
+        href = source.href(f"{L9_ID}_SR_B4.TIF")
+        assert href == f"/vsitar/{scene_tar.as_posix()}/{L9_ID}_SR_B4.TIF"
+
+
+class TestSentinel2FromAZip:
+    """A Copernicus zip loads without being unpacked."""
+
+    def test_bands_load(self, safe_zip):
+        scene = eeo.load_sentinel2(safe_zip, ["red", "nir"])
+        assert scene.band_names == ["red", "nir"]
+        assert scene.to_array()[0][0, 0] == FILL["B04"]
+        assert scene.to_array()[1][0, 0] == FILL["B08"]
+
+    def test_the_zip_matches_the_directory_exactly(self, safe, safe_zip):
+        loose = eeo.load_sentinel2(safe, ["red", "swir16"])
+        packed = eeo.load_sentinel2(safe_zip, ["red", "swir16"])
+        np.testing.assert_array_equal(loose.to_array(), packed.to_array())
+        assert loose.get_transform() == packed.get_transform()
+        assert loose.get_crs() == packed.get_crs()
+
+    def test_provenance_names_the_product_not_the_zip(self, safe_zip):
+        # The .SAFE inside is what identifies the scene; the zip is packaging.
+        assert eeo.load_sentinel2(safe_zip, ["red"]).attrs["product"] == PRODUCT
+
+    def test_a_zip_holding_no_product_is_refused(self, tmp_path):
+        empty = tmp_path / "empty.zip"
+        with zipfile.ZipFile(empty, "w") as zipped:
+            zipped.writestr("readme.txt", "nothing here")
+        with pytest.raises(ValidationError, match="holds no Sentinel-2 product manifest"):
+            eeo.load_sentinel2(empty, ["red"])
+
+
+class TestLandsatFromAnArchive:
+    """A USGS tar loads without being unpacked, and so does a zip of one."""
+
+    def test_bands_load_from_a_tar(self, scene_tar):
+        loaded = eeo.load_landsat(scene_tar, ["red", "nir08"])
+        assert loaded.band_names == ["red", "nir08"]
+        assert loaded.to_array()[0].max() == OLI_BANDS["SR_B4"]
+        assert loaded.to_array()[1].max() == OLI_BANDS["SR_B5"]
+
+    def test_the_tar_matches_the_directory_exactly(self, scene, scene_tar):
+        loose = eeo.load_landsat(scene, ["red", "lwir11"])
+        packed = eeo.load_landsat(scene_tar, ["red", "lwir11"])
+        np.testing.assert_array_equal(loose.to_array(), packed.to_array())
+        assert loose.get_transform() == packed.get_transform()
+        assert loose.attrs["product"] == packed.attrs["product"]
+
+    def test_nodata_still_comes_from_a_data_band(self, scene_tar):
+        loaded = eeo.load_landsat(scene_tar, ["qa_pixel", "red"])
+        assert loaded.get_metadata()["nodata"] == 0
+
+    def test_a_zipped_landsat_product_also_loads(self, tmp_path, scene):
+        # The container is orthogonal to the mission: nothing about the zip
+        # path is Sentinel-2 specific, and nothing about tar is Landsat's.
+        archive = pack_zip(scene, tmp_path / f"{L9_ID}.zip", base=scene.parent)
+        assert eeo.load_landsat(archive, ["red"]).band_names == ["red"]
+
+    def test_a_bbox_still_crops_inside_an_archive(self, scene, scene_tar):
+        bounds = eeo.load_landsat(scene, ["red"]).get_bounds()
+        lonlat = transform_bounds(
+            "EPSG:32633",
+            "EPSG:4326",
+            bounds.left,
+            (bounds.bottom + bounds.top) / 2,
+            (bounds.left + bounds.right) / 2,
+            bounds.top,
+            densify_pts=21,
+        )
+        cropped = eeo.load_landsat(scene_tar, ["red"], bbox=lonlat)
+        height, width = cropped.to_array().shape[-2:]
+        assert height < 64 and width < 64
+
+
+class TestNamedFilesInsideAProduct:
+    """Pointing at one file still selects that file."""
+
+    def test_a_named_manifest_is_used(self, safe):
+        loaded = eeo.load_sentinel2(safe / "MTD_MSIL2A.xml", ["red"])
+        assert loaded.band_names == ["red"]
+
+    def test_a_named_metadata_file_is_used(self, scene):
+        metadata = Path(scene) / f"{L9_ID}_MTL.json"
+        assert eeo.load_landsat(metadata, ["red"]).band_names == ["red"]
+
+
+class TestSourceReadFailures:
+    """What a source does when asked for something it cannot give."""
+
+    def test_a_directory_read_of_a_directory_is_reported(self, safe):
+        source = open_product(safe, "Sentinel-2")
+        with pytest.raises(ValidationError, match="could not read GRANULE"):
+            source.read_bytes("GRANULE")
+
+    def test_an_absent_zip_member_is_reported(self, safe_zip):
+        source = open_product(safe_zip, "Sentinel-2")
+        with pytest.raises(ValidationError, match="could not read absent.xml"):
+            source.read_bytes("absent.xml")
+
+    def test_a_tar_member_that_is_not_a_file_is_reported(self, tmp_path, scene):
+        # Directories are tar members too, and are not listed as files, so
+        # asking for one by name has to fail rather than return empty bytes.
+        archive = tmp_path / "with_dirs.tar"
+        with tarfile.open(archive, "w") as tarred:
+            tarred.add(scene, arcname=L9_ID, recursive=False)
+        source = open_product(archive, "Landsat")
+        with pytest.raises(ValidationError, match="not a file in"):
+            source.read_bytes(L9_ID)
+
+
+class TestGlobParityForSingleCharacters:
+    """`?` behaves the same in an archive as on disk, like the rest of glob."""
+
+    def test_a_question_mark_matches_one_character(self, safe, safe_zip):
+        loose = open_product(safe.parent, "Sentinel-2")
+        packed = open_product(safe_zip, "Sentinel-2")
+        pattern = f"{PRODUCT[:-1]}?/MTD_MSIL2A.xml"
+        assert loose.glob(pattern) == packed.glob(pattern)
+        assert loose.glob(pattern) == [PurePosixPath(PRODUCT) / "MTD_MSIL2A.xml"]
+
+    def test_a_question_mark_does_not_match_a_separator(self, safe, safe_zip):
+        loose = open_product(safe.parent, "Sentinel-2")
+        packed = open_product(safe_zip, "Sentinel-2")
+        assert loose.glob(f"{PRODUCT}?MTD_MSIL2A.xml") == []
+        assert packed.glob(f"{PRODUCT}?MTD_MSIL2A.xml") == []

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -9,14 +9,14 @@ from datetime import datetime
 
 import numpy as np
 import pytest
-from affine import Affine
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 
 TS = datetime(2023, 6, 1, 10, 30)
 UTM = CRS.from_epsg(32633)
-GRID = Affine.translation(500_000.0, 4_200_000.0) * Affine.scale(10.0, -10.0)
+GRID = from_origin(500_000.0, 4_200_000.0, 10.0, 10.0)
 
 
 def test_defaults_are_empty():

--- a/tests/test_sentinel2_metadata.py
+++ b/tests/test_sentinel2_metadata.py
@@ -1,0 +1,300 @@
+"""Tests for Sentinel-2 product identification (eeo/io/_sentinel2.py).
+
+The manifests here are trimmed but structurally faithful: the same namespaced
+root with an unnamespaced body, the same element names, the same ``band_id``
+indirection between the offset list and the spectral information list, and the
+same ``HORIZONTAL_CS_CODE`` in a granule's tile manifest. Nothing is downloaded
+and no image file is written — this layer never opens one.
+"""
+
+import datetime as dt
+
+import pytest
+
+from eeo.core.exceptions import ValidationError
+from eeo.io._sentinel2 import Sentinel2Product, find_manifest, read_product
+
+PRODUCT_URI = "S2B_MSIL2A_20240830T100559_N0511_R022_T32TPS_20240830T134009.SAFE"
+GRANULE_ID = "L2A_T32TPS_A038765_20240830T100558"
+IMAGE = f"GRANULE/{GRANULE_ID}/IMG_DATA/R10m/T32TPS_20240830T100559_B04_10m"
+
+# Spectral_Information spells single-digit bands "B1"; the image files use "B01".
+SPECTRAL = """
+      <Spectral_Information_List>
+        <Spectral_Information bandId="0" physicalBand="B1"/>
+        <Spectral_Information bandId="3" physicalBand="B4"/>
+        <Spectral_Information bandId="8" physicalBand="B8A"/>
+        <Spectral_Information bandId="12" physicalBand="B12"/>
+      </Spectral_Information_List>"""
+
+OFFSETS = """
+      <BOA_ADD_OFFSET_VALUES_LIST>
+        <BOA_ADD_OFFSET band_id="0">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="3">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="8">-1000</BOA_ADD_OFFSET>
+        <BOA_ADD_OFFSET band_id="12">-1000</BOA_ADD_OFFSET>
+      </BOA_ADD_OFFSET_VALUES_LIST>"""
+
+
+def manifest_xml(
+    *,
+    level="2A",
+    product_type="S2MSI2A",
+    baseline="05.11",
+    quantification="10000",
+    offsets=OFFSETS,
+    start_time="2024-08-30T10:05:59.024Z",
+    uri=PRODUCT_URI,
+):
+    """Build a product manifest with the parts under test made adjustable."""
+    type_element = f"<PRODUCT_TYPE>{product_type}</PRODUCT_TYPE>" if product_type else ""
+    quant = (
+        f"""
+      <QUANTIFICATION_VALUES_LIST>
+        <BOA_QUANTIFICATION_VALUE unit="none">{quantification}</BOA_QUANTIFICATION_VALUE>
+      </QUANTIFICATION_VALUES_LIST>"""
+        if quantification
+        else ""
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<n1:Level-{level}_User_Product
+    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/User_Product_Level-{level}.xsd">
+  <n1:General_Info>
+    <Product_Info>
+      <PRODUCT_START_TIME>{start_time}</PRODUCT_START_TIME>
+      <PRODUCT_URI>{uri}</PRODUCT_URI>
+      <PROCESSING_LEVEL>Level-{level}</PROCESSING_LEVEL>
+      {type_element}
+      <PROCESSING_BASELINE>{baseline}</PROCESSING_BASELINE>
+      <Product_Organisation>
+        <Granule_List>
+          <Granule granuleIdentifier="{GRANULE_ID}" imageFormat="JPEG2000">
+            <IMAGE_FILE>{IMAGE}</IMAGE_FILE>
+          </Granule>
+        </Granule_List>
+      </Product_Organisation>
+    </Product_Info>
+    <Product_Image_Characteristics>{quant}{offsets}{SPECTRAL}
+    </Product_Image_Characteristics>
+  </n1:General_Info>
+</n1:Level-{level}_User_Product>
+"""
+
+
+TILE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<n1:Level-2A_Tile_ID
+    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/S2_PDI_Level-2A_Tile_Metadata.xsd">
+  <n1:General_Info>
+    <TILE_ID>S2B_OPER_MSI_L2A_TL_2BPS_20240830T134009_A038765_T32TPS_N05.11</TILE_ID>
+    <SENSING_TIME>2024-08-30T10:06:21.919283Z</SENSING_TIME>
+  </n1:General_Info>
+  <n1:Geometric_Info>
+    <Tile_Geocoding>
+      <HORIZONTAL_CS_NAME>WGS84 / UTM zone 32N</HORIZONTAL_CS_NAME>
+      <HORIZONTAL_CS_CODE>EPSG:32632</HORIZONTAL_CS_CODE>
+      <Size resolution="10"><NROWS>10980</NROWS><NCOLS>10980</NCOLS></Size>
+    </Tile_Geocoding>
+  </n1:Geometric_Info>
+</n1:Level-2A_Tile_ID>
+"""
+
+
+def write_safe(tmp_path, *, manifest_name="MTD_MSIL2A.xml", tile_xml=TILE_XML, **kwargs):
+    """Write a minimal .SAFE tree and return its directory."""
+    safe = tmp_path / PRODUCT_URI
+    (safe / "GRANULE" / GRANULE_ID).mkdir(parents=True)
+    (safe / manifest_name).write_text(manifest_xml(**kwargs))
+    if tile_xml is not None:
+        (safe / "GRANULE" / GRANULE_ID / "MTD_TL.xml").write_text(tile_xml)
+    return safe
+
+
+class TestFindManifest:
+    """The manifest is found from the .SAFE directory, its parent, or directly."""
+
+    def test_safe_directory(self, tmp_path):
+        safe = write_safe(tmp_path)
+        assert find_manifest(safe).name == "MTD_MSIL2A.xml"
+
+    def test_directory_holding_a_safe(self, tmp_path):
+        write_safe(tmp_path)
+        assert find_manifest(tmp_path).name == "MTD_MSIL2A.xml"
+
+    def test_manifest_given_directly(self, tmp_path):
+        safe = write_safe(tmp_path)
+        assert find_manifest(safe / "MTD_MSIL2A.xml").name == "MTD_MSIL2A.xml"
+
+    def test_missing_path_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match="no such Sentinel-2 product"):
+            find_manifest(tmp_path / "absent.SAFE")
+
+    def test_directory_without_a_manifest_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match="holds no Sentinel-2 product manifest"):
+            find_manifest(tmp_path)
+
+
+class TestLevelDetection:
+    """Level comes from the document, with the filename only as a fallback."""
+
+    def test_l2a_is_read(self, tmp_path):
+        product = read_product(write_safe(tmp_path))
+        assert isinstance(product, Sentinel2Product)
+        assert (product.level, product.product_type) == ("L2A", "S2MSI2A")
+
+    def test_l1c_is_refused_with_an_explanation(self, tmp_path):
+        safe = write_safe(
+            tmp_path, manifest_name="MTD_MSIL1C.xml", level="1C", product_type="S2MSI1C"
+        )
+        with pytest.raises(ValidationError, match="Level-1C is not supported") as excinfo:
+            read_product(safe)
+        assert "download the L2A product" in str(excinfo.value)
+
+    def test_renamed_manifest_does_not_mislead(self, tmp_path):
+        # An L1C document saved under the L2A filename must still be refused:
+        # the document is the authority, not the name it was given.
+        safe = write_safe(tmp_path, manifest_name="MTD_MSIL2A.xml", product_type="S2MSI1C")
+        with pytest.raises(ValidationError, match="Level-1C is not supported"):
+            read_product(safe)
+
+    def test_absent_product_type_falls_back_to_the_filename(self, tmp_path):
+        safe = write_safe(tmp_path, product_type="")
+        assert read_product(safe).level == "L2A"
+
+    def test_unidentifiable_product_rejected(self, tmp_path):
+        safe = write_safe(tmp_path, manifest_name="MTD_SOMETHING.xml", product_type="")
+        with pytest.raises(ValidationError, match="identifies no\n?\\s*processing level"):
+            read_product(safe / "MTD_SOMETHING.xml")
+
+
+class TestLevelOverride:
+    """`level=` asserts rather than overrides whenever the manifest can speak."""
+
+    def test_agreeing_override_accepted(self, tmp_path):
+        assert read_product(write_safe(tmp_path), level="L2A").level == "L2A"
+
+    def test_contradicting_override_rejected(self, tmp_path):
+        safe = write_safe(tmp_path, manifest_name="MTD_MSIL1C.xml", product_type="S2MSI1C")
+        with pytest.raises(ValidationError, match="contradicts the product"):
+            read_product(safe, level="L2A")
+
+    def test_override_decides_when_the_manifest_is_silent(self, tmp_path):
+        safe = write_safe(tmp_path, manifest_name="MTD_SOMETHING.xml", product_type="")
+        assert read_product(safe / "MTD_SOMETHING.xml", level="l2a").level == "L2A"
+
+    def test_unknown_level_value_rejected(self, tmp_path):
+        with pytest.raises(ValidationError, match="level must be one of"):
+            read_product(write_safe(tmp_path), level="L3B")
+
+
+class TestMetadata:
+    """The fields a loader needs are read from both manifests."""
+
+    def test_identity_and_baseline(self, tmp_path):
+        product = read_product(write_safe(tmp_path))
+        assert product.tile_id == "T32TPS"
+        assert product.processing_baseline == "05.11"
+        assert product.crs == "EPSG:32632"
+
+    def test_sensing_time_prefers_the_tile_manifest(self, tmp_path):
+        # The product manifest carries the datatake's start (10:05:59); the
+        # tile manifest carries this granule's own time (10:06:21). Real
+        # granule manifests write microseconds, so the fixture does too.
+        product = read_product(write_safe(tmp_path))
+        assert product.sensing_time == dt.datetime(
+            2024, 8, 30, 10, 6, 21, 919283, tzinfo=dt.timezone.utc
+        )
+        assert product.sensing_time.tzinfo is not None
+
+    def test_millisecond_precision_also_parses(self, tmp_path):
+        # The product manifest writes milliseconds where the granule writes
+        # microseconds; Python 3.10's fromisoformat accepts 3 or 6 digits and
+        # nothing between, so both spellings are exercised.
+        tile = TILE_XML.replace("<SENSING_TIME>2024-08-30T10:06:21.919283Z</SENSING_TIME>", "")
+        product = read_product(write_safe(tmp_path, tile_xml=tile))
+        assert product.sensing_time == dt.datetime(
+            2024, 8, 30, 10, 5, 59, 24000, tzinfo=dt.timezone.utc
+        )
+
+    def test_quantification_and_image_files(self, tmp_path):
+        product = read_product(write_safe(tmp_path))
+        assert product.quantification_value == 10000.0
+        assert product.image_files == (IMAGE,)
+        assert product.granule is not None and product.granule.name == GRANULE_ID
+
+    def test_band_offsets_use_image_file_spelling(self, tmp_path):
+        # band_id 0 is physicalBand "B1", which the image files call "B01".
+        product = read_product(write_safe(tmp_path))
+        assert product.band_offsets == {
+            "B01": -1000.0,
+            "B04": -1000.0,
+            "B8A": -1000.0,
+            "B12": -1000.0,
+        }
+
+    def test_older_baseline_has_no_offsets(self, tmp_path):
+        # Products before baseline 04.00 carry no offset element at all, which
+        # means they have none — not that theirs is unknown.
+        product = read_product(write_safe(tmp_path, baseline="02.12", offsets=""))
+        assert product.band_offsets == {}
+        assert product.quantification_value == 10000.0
+
+
+class TestMalformedProducts:
+    """Damaged metadata fails with a message naming what is wrong."""
+
+    def test_unparseable_xml_rejected(self, tmp_path):
+        safe = write_safe(tmp_path)
+        (safe / "MTD_MSIL2A.xml").write_text("<not-closed>")
+        with pytest.raises(ValidationError, match="is not readable XML"):
+            read_product(safe)
+
+    def test_missing_tile_manifest_rejected(self, tmp_path):
+        safe = write_safe(tmp_path, tile_xml=None)
+        with pytest.raises(ValidationError, match="states no projection"):
+            read_product(safe)
+
+    def test_unparseable_tile_manifest_rejected(self, tmp_path):
+        safe = write_safe(tmp_path, tile_xml="<nope")
+        with pytest.raises(ValidationError, match="MTD_TL.xml is not readable XML"):
+            read_product(safe)
+
+    def test_non_numeric_quantification_rejected(self, tmp_path):
+        safe = write_safe(tmp_path, quantification="not-a-number")
+        with pytest.raises(ValidationError, match="BOA_QUANTIFICATION_VALUE is not a number"):
+            read_product(safe)
+
+    def test_non_numeric_offset_rejected(self, tmp_path):
+        bad = OFFSETS.replace(">-1000<", ">minus one thousand<", 1)
+        with pytest.raises(ValidationError, match="is not a number"):
+            read_product(write_safe(tmp_path, offsets=bad))
+
+    def test_unreadable_timestamp_rejected(self, tmp_path):
+        tile = TILE_XML.replace("2024-08-30T10:06:21.919283Z", "last Tuesday")
+        safe = write_safe(tmp_path, tile_xml=tile)
+        with pytest.raises(ValidationError, match="could not read the acquisition time"):
+            read_product(safe)
+
+    def test_absent_quantification_is_recorded_as_unknown(self, tmp_path):
+        product = read_product(write_safe(tmp_path, quantification=""))
+        assert product.quantification_value is None
+
+    def test_offsets_without_a_band_id_are_skipped(self, tmp_path):
+        # A real product always attributes an offset to a band; one that does
+        # not is unattributable, so it is dropped rather than guessed at.
+        stray = OFFSETS.replace('<BOA_ADD_OFFSET band_id="0">', "<BOA_ADD_OFFSET>", 1)
+        product = read_product(write_safe(tmp_path, offsets=stray))
+        assert "B01" not in product.band_offsets
+        assert product.band_offsets["B04"] == -1000.0
+
+    def test_offsets_for_an_unlisted_band_are_skipped(self, tmp_path):
+        # band_id 99 appears in no Spectral_Information entry, so there is no
+        # band name to key it by.
+        unlisted = OFFSETS.replace('band_id="0"', 'band_id="99"', 1)
+        product = read_product(write_safe(tmp_path, offsets=unlisted))
+        assert set(product.band_offsets) == {"B04", "B8A", "B12"}
+
+    def test_product_without_any_acquisition_time_rejected(self, tmp_path):
+        tile = TILE_XML.replace("<SENSING_TIME>2024-08-30T10:06:21.919283Z</SENSING_TIME>", "")
+        safe = write_safe(tmp_path, tile_xml=tile, start_time="")
+        with pytest.raises(ValidationError, match="states no acquisition time"):
+            read_product(safe)

--- a/tests/test_sentinel2_metadata.py
+++ b/tests/test_sentinel2_metadata.py
@@ -7,6 +7,7 @@ written — this layer never opens one.
 """
 
 import datetime as dt
+import shutil
 
 import pytest
 
@@ -43,6 +44,24 @@ class TestFindManifest:
     def test_manifest_given_directly(self, tmp_path):
         safe = write_safe(tmp_path)
         assert find_manifest(safe / "MTD_MSIL2A.xml").name == "MTD_MSIL2A.xml"
+
+    def test_two_products_in_one_folder_are_refused(self, tmp_path):
+        # A download folder with several scenes in it. Picking the first would
+        # load a different date than the caller believes they asked for.
+        safe = write_safe(tmp_path)
+        twin = tmp_path / "S2A_MSIL2A_20200101T100000_N0212_R022_T32TPS_20200101T120000.SAFE"
+        shutil.copytree(safe, twin)
+        with pytest.raises(ValidationError, match="holds 2 Sentinel-2 products"):
+            find_manifest(tmp_path)
+
+    def test_the_refusal_names_both_products(self, tmp_path):
+        safe = write_safe(tmp_path)
+        twin = tmp_path / "S2A_MSIL2A_20200101T100000_N0212_R022_T32TPS_20200101T120000.SAFE"
+        shutil.copytree(safe, twin)
+        with pytest.raises(ValidationError) as raised:
+            find_manifest(tmp_path)
+        assert safe.name in str(raised.value)
+        assert twin.name in str(raised.value)
 
     def test_missing_path_rejected(self, tmp_path):
         with pytest.raises(ValidationError, match="no such Sentinel-2 product"):

--- a/tests/test_sentinel2_metadata.py
+++ b/tests/test_sentinel2_metadata.py
@@ -1,10 +1,9 @@
 """Tests for Sentinel-2 product identification (eeo/io/_sentinel2.py).
 
-The manifests here are trimmed but structurally faithful: the same namespaced
-root with an unnamespaced body, the same element names, the same ``band_id``
-indirection between the offset list and the spectral information list, and the
-same ``HORIZONTAL_CS_CODE`` in a granule's tile manifest. Nothing is downloaded
-and no image file is written — this layer never opens one.
+The manifests come from :mod:`product_fixtures`: trimmed but structurally
+faithful, and shared with the loader tests so the two cannot drift into
+describing different products. Nothing is downloaded and no image file is
+written — this layer never opens one.
 """
 
 import datetime as dt
@@ -13,100 +12,21 @@ import pytest
 
 from eeo.core.exceptions import ValidationError
 from eeo.io._sentinel2 import Sentinel2Product, find_manifest, read_product
-
-PRODUCT_URI = "S2B_MSIL2A_20240830T100559_N0511_R022_T32TPS_20240830T134009.SAFE"
-GRANULE_ID = "L2A_T32TPS_A038765_20240830T100558"
-IMAGE = f"GRANULE/{GRANULE_ID}/IMG_DATA/R10m/T32TPS_20240830T100559_B04_10m"
-
-# Spectral_Information spells single-digit bands "B1"; the image files use "B01".
-SPECTRAL = """
-      <Spectral_Information_List>
-        <Spectral_Information bandId="0" physicalBand="B1"/>
-        <Spectral_Information bandId="3" physicalBand="B4"/>
-        <Spectral_Information bandId="8" physicalBand="B8A"/>
-        <Spectral_Information bandId="12" physicalBand="B12"/>
-      </Spectral_Information_List>"""
-
-OFFSETS = """
-      <BOA_ADD_OFFSET_VALUES_LIST>
-        <BOA_ADD_OFFSET band_id="0">-1000</BOA_ADD_OFFSET>
-        <BOA_ADD_OFFSET band_id="3">-1000</BOA_ADD_OFFSET>
-        <BOA_ADD_OFFSET band_id="8">-1000</BOA_ADD_OFFSET>
-        <BOA_ADD_OFFSET band_id="12">-1000</BOA_ADD_OFFSET>
-      </BOA_ADD_OFFSET_VALUES_LIST>"""
-
-
-def manifest_xml(
-    *,
-    level="2A",
-    product_type="S2MSI2A",
-    baseline="05.11",
-    quantification="10000",
-    offsets=OFFSETS,
-    start_time="2024-08-30T10:05:59.024Z",
-    uri=PRODUCT_URI,
-):
-    """Build a product manifest with the parts under test made adjustable."""
-    type_element = f"<PRODUCT_TYPE>{product_type}</PRODUCT_TYPE>" if product_type else ""
-    quant = (
-        f"""
-      <QUANTIFICATION_VALUES_LIST>
-        <BOA_QUANTIFICATION_VALUE unit="none">{quantification}</BOA_QUANTIFICATION_VALUE>
-      </QUANTIFICATION_VALUES_LIST>"""
-        if quantification
-        else ""
-    )
-    return f"""<?xml version="1.0" encoding="UTF-8"?>
-<n1:Level-{level}_User_Product
-    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/User_Product_Level-{level}.xsd">
-  <n1:General_Info>
-    <Product_Info>
-      <PRODUCT_START_TIME>{start_time}</PRODUCT_START_TIME>
-      <PRODUCT_URI>{uri}</PRODUCT_URI>
-      <PROCESSING_LEVEL>Level-{level}</PROCESSING_LEVEL>
-      {type_element}
-      <PROCESSING_BASELINE>{baseline}</PROCESSING_BASELINE>
-      <Product_Organisation>
-        <Granule_List>
-          <Granule granuleIdentifier="{GRANULE_ID}" imageFormat="JPEG2000">
-            <IMAGE_FILE>{IMAGE}</IMAGE_FILE>
-          </Granule>
-        </Granule_List>
-      </Product_Organisation>
-    </Product_Info>
-    <Product_Image_Characteristics>{quant}{offsets}{SPECTRAL}
-    </Product_Image_Characteristics>
-  </n1:General_Info>
-</n1:Level-{level}_User_Product>
-"""
-
-
-TILE_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<n1:Level-2A_Tile_ID
-    xmlns:n1="https://psd-15.sentinel2.eo.esa.int/PSD/S2_PDI_Level-2A_Tile_Metadata.xsd">
-  <n1:General_Info>
-    <TILE_ID>S2B_OPER_MSI_L2A_TL_2BPS_20240830T134009_A038765_T32TPS_N05.11</TILE_ID>
-    <SENSING_TIME>2024-08-30T10:06:21.919283Z</SENSING_TIME>
-  </n1:General_Info>
-  <n1:Geometric_Info>
-    <Tile_Geocoding>
-      <HORIZONTAL_CS_NAME>WGS84 / UTM zone 32N</HORIZONTAL_CS_NAME>
-      <HORIZONTAL_CS_CODE>EPSG:32632</HORIZONTAL_CS_CODE>
-      <Size resolution="10"><NROWS>10980</NROWS><NCOLS>10980</NCOLS></Size>
-    </Tile_Geocoding>
-  </n1:Geometric_Info>
-</n1:Level-2A_Tile_ID>
-"""
-
-
-def write_safe(tmp_path, *, manifest_name="MTD_MSIL2A.xml", tile_xml=TILE_XML, **kwargs):
-    """Write a minimal .SAFE tree and return its directory."""
-    safe = tmp_path / PRODUCT_URI
-    (safe / "GRANULE" / GRANULE_ID).mkdir(parents=True)
-    (safe / manifest_name).write_text(manifest_xml(**kwargs))
-    if tile_xml is not None:
-        (safe / "GRANULE" / GRANULE_ID / "MTD_TL.xml").write_text(tile_xml)
-    return safe
+from product_fixtures import (
+    S2_GRANULE as GRANULE_ID,
+)
+from product_fixtures import (
+    S2_IMAGE as IMAGE,
+)
+from product_fixtures import (
+    S2_OFFSETS as OFFSETS,
+)
+from product_fixtures import (
+    S2_TILE_XML as TILE_XML,
+)
+from product_fixtures import (
+    write_safe,
+)
 
 
 class TestFindManifest:

--- a/tests/test_sentinel2_metadata.py
+++ b/tests/test_sentinel2_metadata.py
@@ -35,15 +35,15 @@ class TestFindManifest:
 
     def test_safe_directory(self, tmp_path):
         safe = write_safe(tmp_path)
-        assert find_manifest(safe).name == "MTD_MSIL2A.xml"
+        assert find_manifest(safe).path.name == "MTD_MSIL2A.xml"
 
     def test_directory_holding_a_safe(self, tmp_path):
         write_safe(tmp_path)
-        assert find_manifest(tmp_path).name == "MTD_MSIL2A.xml"
+        assert find_manifest(tmp_path).path.name == "MTD_MSIL2A.xml"
 
     def test_manifest_given_directly(self, tmp_path):
         safe = write_safe(tmp_path)
-        assert find_manifest(safe / "MTD_MSIL2A.xml").name == "MTD_MSIL2A.xml"
+        assert find_manifest(safe / "MTD_MSIL2A.xml").path.name == "MTD_MSIL2A.xml"
 
     def test_two_products_in_one_folder_are_refused(self, tmp_path):
         # A download folder with several scenes in it. Picking the first would

--- a/tests/test_stacking.py
+++ b/tests/test_stacking.py
@@ -1,0 +1,184 @@
+"""Tests for the shared multi-source reader (eeo/io/_stacking.py).
+
+The STAC suite already exercises this code end to end, but only through
+``STACItem.load``, which validates its asset list first and always hands over
+sources that sit on tidy grids. These tests reach the module directly, covering
+the fallback branches that decide between an exact windowed read and a warp —
+the paths a local-product reader will hit as soon as it stacks a 20 m band onto
+a 10 m one.
+
+Everything is written to a temporary directory; no network, no fixtures outside
+the repo.
+"""
+
+import numpy as np
+import pytest
+import rasterio as rio
+from rasterio.enums import Resampling
+from rasterio.transform import from_origin
+
+from eeo.core.exceptions import ValidationError
+from eeo.io._stacking import Grid, _aligned_window, read_onto_common_grid
+
+CRS = "EPSG:32633"
+ORIGIN = (500000.0, 5000000.0)
+SIZE = 32
+RES = 10.0
+
+
+def write(path, *, origin=ORIGIN, size=SIZE, res=RES, count=1, crs=CRS, fill=None):
+    """Write a small synthetic GeoTIFF and return its path as a string."""
+    if fill is None:
+        band = np.arange(size * size, dtype="uint16").reshape(size, size)
+        data = np.stack([band + step for step in range(count)])
+    else:
+        data = np.full((count, size, size), fill, dtype="uint16")
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=count,
+        dtype="uint16",
+        crs=crs,
+        transform=from_origin(origin[0], origin[1], res, res),
+        nodata=0,
+    ) as dst:
+        dst.write(data)
+    return str(path)
+
+
+def grid_of(href):
+    """Build the Grid a source defines when read whole."""
+    with rio.open(href) as src:
+        return Grid(src.crs, src.transform, src.width, src.height)
+
+
+class TestAlignedWindowFallsBackToWarp:
+    """_aligned_window returns None wherever an exact read would be wrong.
+
+    Each None sends the read down the WarpedVRT path instead. These are the
+    branches the STAC suite never reached, and a silent regression here would
+    resample when it should not (or the reverse) rather than raise.
+    """
+
+    def test_matching_grid_reads_exactly(self, tmp_path):
+        href = write(tmp_path / "a.tif")
+        with rio.open(href) as src:
+            window = _aligned_window(src, grid_of(href))
+        assert window is not None
+        assert (window.col_off, window.row_off) == (0, 0)
+
+    def test_different_crs_warps(self, tmp_path):
+        href = write(tmp_path / "utm34.tif", crs="EPSG:32634")
+        target = grid_of(write(tmp_path / "utm33.tif"))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+    def test_different_resolution_warps(self, tmp_path):
+        href = write(tmp_path / "coarse.tif", res=20.0)
+        target = grid_of(write(tmp_path / "fine.tif", res=10.0))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+    def test_sub_pixel_column_offset_warps(self, tmp_path):
+        # Origin shifted half a pixel east: the window lands on x.5 columns.
+        href = write(tmp_path / "half_east.tif", origin=(ORIGIN[0] + RES / 2, ORIGIN[1]))
+        target = grid_of(write(tmp_path / "target.tif"))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+    def test_sub_pixel_row_offset_warps(self, tmp_path):
+        # Origin shifted half a pixel south: whole columns, fractional rows.
+        href = write(tmp_path / "half_south.tif", origin=(ORIGIN[0], ORIGIN[1] - RES / 2))
+        target = grid_of(write(tmp_path / "target.tif"))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+    def test_window_starting_before_the_source_warps(self, tmp_path):
+        # Source begins one pixel east/south of the grid, so the aligned window
+        # would need a negative offset and come back short.
+        href = write(tmp_path / "inset.tif", origin=(ORIGIN[0] + RES, ORIGIN[1] - RES))
+        target = grid_of(write(tmp_path / "target.tif"))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+    def test_window_running_past_the_source_warps(self, tmp_path):
+        # Same origin but a smaller source: the window overhangs its edge.
+        href = write(tmp_path / "small.tif", size=SIZE // 2)
+        target = grid_of(write(tmp_path / "target.tif"))
+        with rio.open(href) as src:
+            assert _aligned_window(src, target) is None
+
+
+class TestReadOntoCommonGrid:
+    """The first source sets the grid; the rest are placed onto it."""
+
+    def test_empty_sources_rejected(self):
+        # Unreachable through STACItem.load, which validates its asset list
+        # first, but reachable for any other caller of this module.
+        with pytest.raises(ValidationError, match="at least one source"):
+            read_onto_common_grid([], bbox=None, resampling=Resampling.nearest)
+
+    def test_single_source_keeps_its_own_grid(self, tmp_path):
+        href = write(tmp_path / "b04.tif")
+        array, grid, nodata, names = read_onto_common_grid(
+            [(href, "B04")], bbox=None, resampling=Resampling.nearest
+        )
+        assert array.shape == (1, SIZE, SIZE)
+        assert (grid.width, grid.height) == (SIZE, SIZE)
+        assert nodata == 0
+        assert names == ["B04"]
+
+    def test_stacking_preserves_order_and_names(self, tmp_path):
+        first = write(tmp_path / "b04.tif", fill=7)
+        second = write(tmp_path / "b08.tif", fill=9)
+        array, _, _, names = read_onto_common_grid(
+            [(first, "B04"), (second, "B08")], bbox=None, resampling=Resampling.nearest
+        )
+        assert array.shape == (2, SIZE, SIZE)
+        assert names == ["B04", "B08"]
+        assert array[0].max() == 7 and array[1].max() == 9
+
+    def test_coarser_source_is_warped_onto_the_fine_grid(self, tmp_path):
+        fine = write(tmp_path / "fine.tif", res=RES, fill=1)
+        coarse = write(tmp_path / "coarse.tif", res=RES * 2, size=SIZE // 2, fill=5)
+        array, grid, _, names = read_onto_common_grid(
+            [(fine, "B04"), (coarse, "B11")], bbox=None, resampling=Resampling.nearest
+        )
+        # The 20 m band lands on the 10 m grid rather than keeping its own size.
+        assert array.shape == (2, SIZE, SIZE)
+        assert (grid.width, grid.height) == (SIZE, SIZE)
+        assert names == ["B04", "B11"]
+        assert array[1].max() == 5
+
+    def test_multiband_source_numbers_its_bands(self, tmp_path):
+        href = write(tmp_path / "stack.tif", count=3)
+        _, _, _, names = read_onto_common_grid(
+            [(href, "TCI")], bbox=None, resampling=Resampling.nearest
+        )
+        assert names == ["TCI_1", "TCI_2", "TCI_3"]
+
+    def test_nodata_comes_from_the_first_source(self, tmp_path):
+        first = write(tmp_path / "a.tif")
+        second = write(tmp_path / "b.tif")
+        with rio.open(second, "r+") as dst:
+            dst.nodata = 65535
+        _, _, nodata, _ = read_onto_common_grid(
+            [(first, "A"), (second, "B")], bbox=None, resampling=Resampling.nearest
+        )
+        assert nodata == 0
+
+    def test_mixed_dtypes_promote(self, tmp_path):
+        first = write(tmp_path / "u16.tif")
+        second = str(tmp_path / "f32.tif")
+        with rio.open(first) as src:
+            profile = src.profile
+        profile.update(dtype="float32")
+        with rio.open(second, "w", **profile) as dst:
+            dst.write(np.full((1, SIZE, SIZE), 0.5, dtype="float32"))
+        array, _, _, _ = read_onto_common_grid(
+            [(first, "A"), (second, "B")], bbox=None, resampling=Resampling.nearest
+        )
+        assert array.dtype == np.result_type(np.uint16, np.float32)

--- a/tests/test_stacking.py
+++ b/tests/test_stacking.py
@@ -182,3 +182,37 @@ class TestReadOntoCommonGrid:
             [(first, "A"), (second, "B")], bbox=None, resampling=Resampling.nearest
         )
         assert array.dtype == np.result_type(np.uint16, np.float32)
+
+    def test_per_source_resampling_length_must_match(self, tmp_path):
+        first = write(tmp_path / "a.tif")
+        second = write(tmp_path / "b.tif", res=RES * 2, size=SIZE // 2)
+        with pytest.raises(ValidationError, match="one resampling method per source"):
+            read_onto_common_grid(
+                [(first, "A"), (second, "B")],
+                bbox=None,
+                resampling=[Resampling.nearest],
+            )
+
+    def test_per_source_resampling_is_applied(self, tmp_path):
+        # A categorical source travelling with a continuous one: the second
+        # gets nearest even though the request as a whole says bilinear.
+        fine = write(tmp_path / "fine.tif", res=RES, fill=1)
+        classes = str(tmp_path / "classes.tif")
+        with rio.open(fine) as src:
+            profile = src.profile
+        profile.update(
+            width=SIZE // 2,
+            height=SIZE // 2,
+            transform=from_origin(ORIGIN[0], ORIGIN[1], RES * 2, RES * 2),
+        )
+        data = np.zeros((1, SIZE // 2, SIZE // 2), dtype="uint16")
+        data[0, : SIZE // 4] = 4
+        data[0, SIZE // 4 :] = 9
+        with rio.open(classes, "w", **profile) as dst:
+            dst.write(data)
+        array, _, _, _ = read_onto_common_grid(
+            [(fine, "A"), (classes, "SCL")],
+            bbox=None,
+            resampling=[Resampling.bilinear, Resampling.nearest],
+        )
+        assert set(np.unique(array[1])) <= {4, 9}

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -3,11 +3,11 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from affine import Affine
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
+from rasterio.transform import from_origin
 
 from eeo import load_array
 from eeo.core.adapters import RasterioAdapter
@@ -54,7 +54,7 @@ def rgb_float32_raster():
 
     return load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
 
@@ -240,7 +240,7 @@ def ndvi_like_raster():
 
     return load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
 
@@ -330,7 +330,7 @@ def test_stretch_keeps_nodata_unpainted_when_range_is_empty(monkeypatch):
     array[0, 0] = 1.0  # single valid pixel: p2 == p98, so no limits apply
     ds = load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     calls = _capture_imshow(monkeypatch)
@@ -351,7 +351,7 @@ def test_stretch_limits_are_computed_per_band(monkeypatch):
     band2 = band1 * 10.0 + 100.0
     ds = load_array(
         np.stack([band1, band2]),
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     calls = _capture_imshow(monkeypatch)
@@ -406,7 +406,7 @@ def test_display_out_shape_caps_large_raster():
 def test_read_band_for_display_decimates_and_rescales_transform():
     ds = load_array(
         np.zeros((600, 600), dtype=np.float32),
-        transform=Affine.translation(0, 600) * Affine.scale(1, -1),
+        transform=from_origin(0, 600, 1, 1),
         crs=CRS.from_epsg(32633),
     ).to_rasterio()
 
@@ -423,7 +423,7 @@ def test_read_band_for_display_decimates_and_rescales_transform():
 def test_read_band_for_display_numpy_backend_reads_full():
     ds = load_array(
         np.zeros((600, 600), dtype=np.float32),
-        transform=Affine.translation(0, 600) * Affine.scale(1, -1),
+        transform=from_origin(0, 600, 1, 1),
         crs=CRS.from_epsg(32633),
     )
 
@@ -454,7 +454,7 @@ def large_rgb_raster():
     )
     ds = load_array(
         np.stack([base, 0.5 * base, 0.25 * base]),
-        transform=Affine.translation(0, LARGE_SIDE) * Affine.scale(1, -1),
+        transform=from_origin(0, LARGE_SIDE, 1, 1),
         crs=CRS.from_epsg(32633),
     ).to_rasterio()
     yield ds
@@ -720,7 +720,7 @@ def test_reflow_fill_order_is_dataset_major(multiband_uint16, monkeypatch):
     """Every band of the first dataset, then every band of the next."""
     second = load_array(
         np.zeros((2, 6, 6), dtype=np.float32) + 5.0,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     titles = []
@@ -776,7 +776,7 @@ def test_mask_nodata_for_display_nan_nodata_needs_no_mask():
     array = np.array([[1.0, np.nan], [3.0, 4.0]], dtype=np.float32)
     ds = load_array(
         array,
-        transform=Affine.translation(0, 2) * Affine.scale(1, -1),
+        transform=from_origin(0, 2, 1, 1),
         crs=CRS.from_epsg(4326),
         nodata=np.nan,
     )
@@ -868,7 +868,7 @@ def test_composite_makes_nodata_transparent(monkeypatch):
     array[0, :2, :2] = -9999.0  # nodata in the red channel only
     ds = load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
         nodata=-9999.0,
     )
@@ -890,7 +890,7 @@ def test_composite_stretch_ignores_nodata(monkeypatch):
     array[:, 0, 0] = -9999.0
     ds = load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
         nodata=-9999.0,
     )
@@ -957,7 +957,7 @@ def test_colorbar_labelled_from_band_name(plot_func, monkeypatch):
     """A named band labels its own colorbar; ``colorbar_label`` overrides it."""
     ds = load_array(
         np.linspace(-0.4, 0.9, 36, dtype=np.float32).reshape(6, 6),
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
         band_names=["NDVI"],
     )
@@ -997,7 +997,7 @@ def test_colorbar_extend_one_sided(monkeypatch):
     array = np.linspace(0.0, 1.0, 36, dtype=np.float32).reshape(6, 6)
     ds = load_array(
         array,
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     bars = _capture_colorbars(monkeypatch)
@@ -1013,7 +1013,7 @@ def test_colorbar_per_band_in_a_grid(monkeypatch):
     band2 = band1 * 10.0 + 100.0
     ds = load_array(
         np.stack([band1, band2]),
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     bars = _capture_colorbars(monkeypatch)
@@ -1056,7 +1056,7 @@ def test_colorbar_all_nodata_band(monkeypatch):
     """An all-NaN band has no finite values; the bar falls back to no arrowheads."""
     ds = load_array(
         np.full((6, 6), np.nan, dtype=np.float32),
-        transform=Affine.translation(0, 6) * Affine.scale(1, -1),
+        transform=from_origin(0, 6, 1, 1),
         crs=CRS.from_epsg(4326),
     )
     bars = _capture_colorbars(monkeypatch)


### PR DESCRIPTION
<!--
Thanks for contributing to Easy-EO! Keep PRs focused on a single task where possible.
-->

## Summary

<!-- What does this PR change, and why?  (e.g. "feat: add NDMI index"). -->
Adds local scene loaders for Sentinel-2 L2A and Landsat Collection 2 Level-2 products, supporting unpacked products and supported archives.

- Refactors the shared multi-asset stacking logic from STAC into a common internal module.
- Adds product metadata/level and sensor detection with clear rejection of unsupported Level-1 products.
- Adds common-name band resolution and preserves band_names/provenance metadata.
- Adds bbox cropping and native-resolution selection without silent upsampling.
- Supports Sentinel-2 .SAFE/.zip and Landsat directories/.tar; explicitly rejects .tar.gz.
- Adds synthetic offline fixtures and coverage for detection, band mapping, archives, scaling, nodata, and cropping.
- Documents stored digital numbers and Sentinel-2/Landsat scaling conventions.

## Related issues / tasks

<!-- e.g. Closes #123 -->
**Local Scene Loaders (Sentinel-2 & Landsat)**
## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [ ] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behavior is stated in the docstring and covered by a test
- [x] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

<!-- Anything the maintainer should pay special attention to, verify manually, or be aware of (e.g. dependency bound changes, memory behavior). -->
The local loaders share the existing stacking/alignment path, so STAC and local scene loading use the same crop and resampling behavior.

The suite remains fully offline with synthetic SAFE/Landsat fixtures. Real-product validation also covers loading named-band subsets, bbox cropping, scaling, and NDVI consistency with the STAC path.