### PR TITLE
release: prepare for version 0.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,15 @@ repos:
   # numpydoc section/signature validation (config in [tool.numpydoc_validation]).
   # Scoped to the public operation API; internal helpers use concise docstrings
   # that ruff's D-rules already cover.
+  #
+  # This pattern must match the file list in the CI "numpydoc" step. When it
+  # drifted, eeo/io/ was checked in CI but not here, so a missing Parameters
+  # section passed every local hook and failed the build.
   - repo: https://github.com/numpy/numpydoc
     rev: v1.10.0
     hooks:
       - id: numpydoc-validation
-        files: ^(eeo/(ops|analysis|preprocessing|viz)/|eeo/core/loader\.py|eeo/_show_versions\.py)
+        files: ^(eeo/(ops|analysis|preprocessing|viz|io)/|eeo/core/loader\.py|eeo/_show_versions\.py)
 
   # mypy runs against the whole `eeo` package (per its pyproject config), not
   # just the changed files, so it can resolve intra-package imports. It runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ are called out under a **Breaking** heading.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-29
+
 ### Added
 
 - `eeo.load_sentinel2()` and `eeo.load_landsat()`, for reading a product you
@@ -54,6 +56,21 @@ are called out under a **Breaking** heading.
 - A "Citing Easy-EO" documentation page covering the software DOI, the
   separate sample-data DOI, and the Copernicus attribution that citing the
   deposit does not replace.
+
+### Fixed
+
+- Pointing either loader at the folder a product was *downloaded* into now
+  works. A folder holding an unpacked product was already accepted, but one
+  holding the `.zip` or `.tar` itself was refused as holding nothing — which
+  is the state a download is in before you touch it. Resolving to a single
+  archive in the folder follows the same "exactly one, or refuse by name" rule
+  the multiple-products case uses, and an unpacked product beside its own
+  archive still wins, being the cheaper of the two to read.
+- Composed transforms no longer use affine's `*` operator, which affine 3.0
+  deprecates in favour of `@`. The library builds them directly instead, so it
+  raises no deprecation warning on affine 3 while still working on affine 2.4,
+  which has no `@` at all. Nothing about the values changes: the coefficients
+  are identical, verified against real Sentinel-2 and Landsat scenes.
 
 ## [0.3.1] - 2026-08-16
 
@@ -478,7 +495,8 @@ Initial public beta release.
 - Visualization: `plot_raster`, `plot_composite`,
   `plot_raster_with_histogram`, `plot_band_array`.
 
-[Unreleased]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/Tommy-Burns/easy-eo/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Tommy-Burns/easy-eo/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Tommy-Burns/easy-eo/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Tommy-Burns/easy-eo/compare/v0.1.0b1...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,12 @@ pytest                       # full suite; coverage is measured automatically
 pytest tests/test_ops.py -x  # a single file, stop at first failure
 ```
 
+You can check the lines that changed
+```bash
+pytest --cov-report=xml
+uvx --from diff-cover diff-cover coverage.xml --compare-branch=main --fail-under=100
+```
+
 Coverage is enforced: the run fails if total coverage drops below the
 project threshold. Bug fixes must include a regression test, and new features
 must include tests (see `CODE_STYLE.md`).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "Easy-EO"
 copyright = "2025, Thomas Burns Botchwey"
 author = "Thomas Burns Botchwey"
-release = "0.3.1"
+release = "0.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/eeo/__init__.py
+++ b/eeo/__init__.py
@@ -40,4 +40,4 @@ __all__ = [
     "MissingDependencyError",
 ]
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "easy-eo"
-version = "0.3.1"
+version = "0.4.0"
 description = "A lightweight Earth Observation utilities library for chainable raster operations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_landsat_metadata.py
+++ b/tests/test_landsat_metadata.py
@@ -72,6 +72,47 @@ class TestFindMetadata:
             find_metadata(tmp_path / "empty")
 
 
+class TestMalformedODL:
+    """The text parser survives a file whose GROUP nesting is broken.
+
+    A truncated download can leave either of these behind. Neither should
+    raise from an empty stack — the readable groups are kept and the
+    unattributable lines are dropped, so the caller fails later on a missing
+    field with a message naming it, rather than here on an IndexError.
+    """
+
+    def _read(self, tmp_path, text):
+        directory = tmp_path / "product"
+        directory.mkdir()
+        (directory / "X_MTL.txt").write_text(text)
+        source = open_product(directory, "Landsat")
+        return read_metadata_groups(source, PurePosixPath("X_MTL.txt"))
+
+    def test_an_unmatched_end_group_is_ignored(self, tmp_path):
+        groups = self._read(
+            tmp_path,
+            "END_GROUP = NEVER_OPENED\n"
+            "GROUP = PRODUCT_CONTENTS\n"
+            '  LANDSAT_PRODUCT_ID = "LC09_L2SP_193028_20260822_20260823_02_T1"\n'
+            "END_GROUP = PRODUCT_CONTENTS\n"
+            "END\n",
+        )
+        assert groups["PRODUCT_CONTENTS"]["LANDSAT_PRODUCT_ID"].startswith("LC09")
+
+    def test_a_key_outside_any_group_is_dropped(self, tmp_path):
+        # There is no group to file it under, so it is not guessed at.
+        groups = self._read(
+            tmp_path,
+            'ORPHANED_KEY = "no group to file this under"\n'
+            "GROUP = PRODUCT_CONTENTS\n"
+            '  PROCESSING_LEVEL = "L2SP"\n'
+            "END_GROUP = PRODUCT_CONTENTS\n"
+            "END\n",
+        )
+        assert groups == {"PRODUCT_CONTENTS": {"PROCESSING_LEVEL": "L2SP"}}
+        assert not any("ORPHANED_KEY" in members for members in groups.values())
+
+
 class TestIdentityComesFromTheMetadata:
     """A renamed directory must not change what the product is."""
 

--- a/tests/test_sentinel2_metadata.py
+++ b/tests/test_sentinel2_metadata.py
@@ -225,6 +225,16 @@ class TestMalformedProducts:
         assert "B01" not in product.band_offsets
         assert product.band_offsets["B04"] == -1000.0
 
+    def test_spectral_entries_missing_their_ids_are_skipped(self, tmp_path):
+        # A Spectral_Information entry with no bandId, or no physicalBand, maps
+        # nothing to nothing. Skipping it drops the offsets that referenced it
+        # rather than keying them by None.
+        from product_fixtures import S2_SPECTRAL
+
+        partial = S2_SPECTRAL.replace('bandId="3" ', "", 1).replace('physicalBand="B8A"', "", 1)
+        product = read_product(write_safe(tmp_path, spectral=partial))
+        assert set(product.band_offsets) == {"B01", "B12"}
+
     def test_offsets_for_an_unlisted_band_are_skipped(self, tmp_path):
         # band_id 99 appears in no Spectral_Information entry, so there is no
         # band name to key it by.

--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "easy-eo"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopandas" },


### PR DESCRIPTION
<!--
Thanks for contributing to Easy-EO! Keep PRs focused on a single task where possible.
-->

## Summary
This PR is about the version 0.4.0 release
<!-- What does this PR change, and why?  (e.g. "feat: add NDMI index"). -->

## Related issues / tasks
Version 0.4.0
<!-- e.g. Closes #123 -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented under a "Breaking" heading in CHANGELOG)
- [x] Docs / tooling / CI only

## Checklist (Definition of Done)

- [x] `pytest` passes and coverage stays at or above the threshold
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy` passes
- [x] New/changed public functions have NumPy-style docstrings with a runnable
      example, per `CODE_STYLE.md`
- [x] Nodata and dtype behavior is stated in the docstring and covered by a test
- [x] Bound ops changed? Regenerated `eeo/core/core.pyi`
      (`python scripts/generate_core_stub.py`)
- [x] Docs API reference updated where relevant
- [x] `CHANGELOG.md` updated under "Unreleased"

## Notes for the reviewer

<!-- Anything the maintainer should pay special attention to, verify manually, or be aware of (e.g. dependency bound changes, memory behavior). -->
